### PR TITLE
IOptionalMemberCallbacks

### DIFF
--- a/protobuf-net/IOptionalMemberCallbacks.cs
+++ b/protobuf-net/IOptionalMemberCallbacks.cs
@@ -1,0 +1,21 @@
+﻿namespace ProtoBuf
+{
+    /// <summary>
+    /// Interface which allows more control over when optional members get serialized
+    /// and provides notification when an optional member is deserialized.
+    /// </summary>
+    public interface IOptionalMemberCallbacks
+    {
+        /// <summary>
+        /// Called prior to serialization of an optional member (of the type implementing this interface).
+        /// The member will be serialized only if true is returned.
+        /// </summary>        
+        bool ShouldSerialize(int flag);
+
+        /// <summary>
+        /// Called after an optional member (of the type implementing this interface) is assigned a value
+        /// from deserialization.
+        /// </summary>
+        void WasDeserialized(int flag);
+    }
+}

--- a/protobuf-net/Serializers/OptionalMemberDecorator.cs
+++ b/protobuf-net/Serializers/OptionalMemberDecorator.cs
@@ -1,0 +1,115 @@
+﻿#if !NO_RUNTIME
+using System;
+using ProtoBuf.Meta;
+
+#if FEAT_IKVM
+using Type = IKVM.Reflection.Type;
+using IKVM.Reflection;
+#else
+using System.Reflection;
+#endif
+
+
+
+namespace ProtoBuf.Serializers
+{
+    /// <summary>
+    /// Decorator for optional members of a type implementing IOptionalMemberCallbacks.
+    /// Handles calling the ShouldSerialize and WasDeserialized callbacks.
+    /// </summary>
+    sealed class OptionalMemberDecorator : ProtoDecoratorBase
+    {
+        private readonly MethodInfo _shouldSerialize;
+        private readonly MethodInfo _wasDeserialized;
+
+        private readonly int _memberId;
+        private readonly object[] _args;
+
+        public override Type ExpectedType
+        {
+            get
+            {
+                return Tail.ExpectedType;
+            }
+        }
+
+        public override bool RequiresOldValue
+        {
+            get
+            {
+                return Tail.RequiresOldValue;
+            }
+        }
+
+        public override bool ReturnsValue
+        {
+            get
+            {
+                return Tail.ReturnsValue;
+            }
+        }
+
+        public OptionalMemberDecorator(int memberId, MethodInfo shouldSerialize, MethodInfo wasDeserialized, IProtoSerializer tail)
+            : base(tail)
+        {
+            if (shouldSerialize == null || wasDeserialized == null) 
+                throw new InvalidOperationException();
+
+            _shouldSerialize = shouldSerialize;
+            _wasDeserialized = wasDeserialized;
+            
+            _memberId = memberId;
+            _args = new object[] {memberId};
+        }
+#if !FEAT_IKVM
+
+        public override void Write(object value, ProtoWriter dest)
+        {
+            // JCF: Gross, allocating an array every call to this method.
+            //      But maybe this method is just here for debug builds and release builds should really be using
+            //      EmitWrite... correct?
+            if ((bool)_shouldSerialize.Invoke(value, _args) == false)
+                return;
+
+            Tail.Write(value, dest);
+        }
+
+        public override object Read(object value, ProtoReader source)
+        {            
+            object result = Tail.Read(value, source);
+            
+            _wasDeserialized.Invoke(value, _args);
+
+            return result;
+        }
+#endif
+
+#if FEAT_COMPILER
+        protected override void EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            using (Compiler.Local loc = ctx.GetLocalWithValue(ExpectedType, valueFrom))
+            {
+                ctx.LoadAddress(loc, ExpectedType);
+                ctx.LoadValue(_memberId);
+                ctx.EmitCall(_shouldSerialize);
+                Compiler.CodeLabel done = ctx.DefineLabel();
+                ctx.BranchIfFalse(done, false);
+                Tail.EmitWrite(ctx, loc);
+                ctx.MarkLabel(done);
+            }
+
+        }
+        protected override void EmitRead(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {            
+            using (Compiler.Local loc = ctx.GetLocalWithValue(ExpectedType, valueFrom))
+            {
+                Tail.EmitRead(ctx, loc);
+                ctx.LoadAddress(loc, ExpectedType);
+                ctx.LoadValue(_memberId);
+                ctx.EmitCall(_wasDeserialized);
+            }
+        }
+#endif
+    }
+}
+#endif

--- a/protobuf-net/protobuf-net.csproj
+++ b/protobuf-net/protobuf-net.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Compiler\CompilerDelegates.cs" />
     <Compile Include="Compiler\CompilerContext.cs" />
     <Compile Include="Compiler\Local.cs" />
+    <Compile Include="IOptionalMemberCallbacks.cs" />
     <Compile Include="ProtoConverterAttribute.cs" />
     <Compile Include="DataFormat.cs">
       <SubType>Code</SubType>
@@ -229,6 +230,7 @@
     <Compile Include="Serializers\ByteSerializer.cs" />
     <Compile Include="Serializers\ImmutableCollectionDecorator.cs" />
     <Compile Include="Serializers\NullDecorator.cs" />
+    <Compile Include="Serializers\OptionalMemberDecorator.cs" />
     <Compile Include="Serializers\ParseableSerializer.cs" />
     <Compile Include="Serializers\KeyValuePairDecorator.cs" />
     <Compile Include="Serializers\ListDecorator.cs" />


### PR DESCRIPTION
An alternative to the ShouldSerialize Get/Set pattern. Instead of one method/property per member, call a single method and pass the FieldNumber as an argument (to identify the member).
