### PR TITLE
KnownTypeName usage leads to type mismatches

### DIFF
--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Inheritance.cs" />
     <Compile Include="InheritanceMidLevel.cs" />
     <Compile Include="InternerTests.cs" />
+    <Compile Include="Issues\Gh24.cs" />
     <Compile Include="Issues\Issue316.cs" />
     <Compile Include="Issues\Issue329.cs" />
     <Compile Include="Issues\Issue331.cs" />

--- a/Examples/Issues/Gh24.cs
+++ b/Examples/Issues/Gh24.cs
@@ -1,0 +1,154 @@
+﻿using NUnit.Framework;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Examples.Issues
+{
+    [TestFixture]
+    // https://github.com/mgravell/protobuf-net/issues/24
+    // assemblies loaded multiple times cause incorrect behavior of ProtoInclude
+    public class Gh24
+    {
+        DirectoryInfo tempDir;
+        AppDomain domain;
+        FileInfo assemblyPath;
+
+        static readonly byte[] testData = { 0x0a, 0x05, 0x15, 0x46, 0x41, 0x49, 0x4c };
+
+        const string ASSEMBLY_NAME = "Examples.Issues.Gh24";
+
+        [SetUp]
+        public void SetUp()
+        {
+            tempDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "protobuf-net-gh24-" + Convert.ToBase64String(BitConverter.GetBytes(DateTime.UtcNow.Ticks)).Replace('/', '-').Substring(0, 11)));
+            tempDir.Create();
+
+            var subdir = tempDir.CreateSubdirectory("payload");
+            assemblyPath = new FileInfo(Path.Combine(subdir.FullName, ASSEMBLY_NAME + ".dll"));
+            var references = CreateAssembly(assemblyPath);
+
+            var setup = new AppDomainSetup
+            {
+                ApplicationBase = tempDir.FullName
+            };
+            domain = AppDomain.CreateDomain("Gh24", null, setup);
+
+            var initializer = (Initializer)domain.CreateInstanceFromAndUnwrap(typeof(Initializer).Assembly.Location, typeof(Initializer).FullName);
+            var assemblyPaths = references.ToDictionary(r => r, r => Assembly.Load(r).Location);
+            assemblyPaths[new AssemblyName(ASSEMBLY_NAME)] = assemblyPath.FullName;
+            initializer.Initialize(assemblyPaths);
+        }
+
+        static IEnumerable<AssemblyName> CreateAssembly(FileInfo path)
+        {
+            var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(ASSEMBLY_NAME), AssemblyBuilderAccess.Save, path.DirectoryName);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(ASSEMBLY_NAME + ".dll");
+
+            var baseTypeBuilderInfo = BuildBaseType(moduleBuilder);
+            var baseTypeBuilder = baseTypeBuilderInfo.Item1;
+            var childTypeBuilderInfo = BuildChildType(moduleBuilder, baseTypeBuilder, baseTypeBuilderInfo.Item2);
+            var childTypeBuilder = childTypeBuilderInfo.Item1;
+            baseTypeBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(ProtoIncludeAttribute).GetConstructor(new[] { typeof(int), typeof(Type) }), new object[] { 1, childTypeBuilder }));
+            var programBuilder = BuildProgramType(moduleBuilder, childTypeBuilder, childTypeBuilderInfo.Item2);
+
+            baseTypeBuilder.CreateType();
+            childTypeBuilder.CreateType();
+            programBuilder.CreateType();
+
+            assemblyBuilder.Save(path.Name);
+
+            return assemblyBuilder.GetReferencedAssemblies();
+        }
+
+        static Tuple<TypeBuilder, ConstructorBuilder> BuildBaseType(ModuleBuilder moduleBuilder)
+        {
+            var baseTypeBuilder = moduleBuilder.DefineType(ASSEMBLY_NAME + ".BaseType", TypeAttributes.Public | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit, typeof(Object));
+            baseTypeBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(ProtoContractAttribute).GetConstructor(Type.EmptyTypes), new object[0]));
+            var baseConstructorBuilder = baseTypeBuilder.DefineDefaultConstructor(MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName);
+            return Tuple.Create(baseTypeBuilder, baseConstructorBuilder);
+        }
+
+        static Tuple<TypeBuilder, FieldBuilder> BuildChildType(ModuleBuilder moduleBuilder, Type baseType, ConstructorInfo baseConstructor)
+        {
+            var childTypeBuilder = moduleBuilder.DefineType(ASSEMBLY_NAME + ".ChildType", TypeAttributes.Public | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit, baseType);
+            childTypeBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(ProtoContractAttribute).GetConstructor(Type.EmptyTypes), new object[0]));
+            var statusBuilder = childTypeBuilder.DefineField("Status", typeof(string), FieldAttributes.Public);
+            statusBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(ProtoMemberAttribute).GetConstructor(new[] { typeof(int) }), new object[] { 1 }));
+            statusBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(DefaultValueAttribute).GetConstructor(new[] { typeof(string) }), new object[] { "Pass" }));
+            var failBuilder = childTypeBuilder.DefineField("Fail", typeof(int), FieldAttributes.Public);
+            failBuilder.SetCustomAttribute(new CustomAttributeBuilder(typeof(ProtoMemberAttribute).GetConstructor(new[] { typeof(int) }), new object[] { 2 }, new[] { typeof(ProtoMemberAttribute).GetProperty("DataFormat") }, new object[] { DataFormat.FixedSize }));
+            var childConstructorBuilder = childTypeBuilder.DefineConstructor(MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName, CallingConventions.HasThis, Type.EmptyTypes);
+            var generator = childConstructorBuilder.GetILGenerator();
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Call, baseConstructor);
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldstr, "Pass");
+            generator.Emit(OpCodes.Stfld, statusBuilder);
+            return Tuple.Create(childTypeBuilder, statusBuilder);
+        }
+
+        static TypeBuilder BuildProgramType(ModuleBuilder moduleBuilder, Type childType, FieldInfo statusField)
+        {
+            var programBuilder = moduleBuilder.DefineType(ASSEMBLY_NAME + ".Program", TypeAttributes.Public | TypeAttributes.AutoLayout | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Abstract | TypeAttributes.Sealed, typeof(Object));
+            var mainBuilder = programBuilder.DefineMethod("Main", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Static, typeof(String), new[] { typeof(byte[]) });
+            var generator = mainBuilder.GetILGenerator();
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Newobj, typeof(MemoryStream).GetConstructor(new[] { typeof(byte[]) }));
+            generator.EmitCall(OpCodes.Call, typeof(Serializer).GetMethods(BindingFlags.Public | BindingFlags.Static).Single(m => m.Name == "Deserialize" && m.IsGenericMethodDefinition && m.GetGenericArguments().Length == 1).MakeGenericMethod(new[] { childType }), null);
+            generator.Emit(OpCodes.Ldfld, statusField);
+            generator.Emit(OpCodes.Ret);
+            return programBuilder;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AppDomain.Unload(domain);
+            tempDir.Delete(true);
+        }
+
+        [Test]
+        public void TestKnownTypeResolution()
+        {
+            var invoker = (Invoker)domain.CreateInstanceFromAndUnwrap(typeof(Invoker).Assembly.Location, typeof(Invoker).FullName);
+            var result = invoker.Invoke(testData);
+            Assert.AreEqual("Pass", result);
+        }
+
+        public class Initializer : MarshalByRefObject
+        {
+            public void Initialize(Dictionary<AssemblyName, string> assemblies)
+            {
+                var cache = assemblies.ToDictionary(a => a.Key, a => new Lazy<Assembly>(() => Assembly.LoadFile(a.Value)));
+                AppDomain.CurrentDomain.AssemblyResolve += (o, e) =>
+                {
+                    var request = new AssemblyName(e.Name);
+                    return cache.Where(a => AssemblyName.ReferenceMatchesDefinition(request, a.Key)).Select(a => a.Value.Value).FirstOrDefault();
+                };
+
+                var main = Assembly.Load(ASSEMBLY_NAME);
+
+                // make the assembly available in the application base directory after loading from subdirectory to reproduce issue
+                var copyPath = Path.Combine(Path.GetDirectoryName(main.Location), "..", Path.GetFileName(main.Location));
+                File.Copy(main.Location, copyPath);
+                Assembly.Load(AssemblyName.GetAssemblyName(copyPath));
+            }
+        }
+
+        public class Invoker : MarshalByRefObject
+        {
+            public string Invoke(byte[] bytes)
+            {
+                return (string)Type.GetType(Assembly.CreateQualifiedName(ASSEMBLY_NAME, ASSEMBLY_NAME + ".Program"), true, false)
+                    .GetMethod("Main", BindingFlags.Public | BindingFlags.Static)
+                    .Invoke(null, new object[] { bytes });
+            }
+        }
+    }
+}

--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -562,7 +562,7 @@ namespace ProtoBuf.Meta
                     try
                     {
                         if (item.TryGet("knownType", out tmp)) knownType = (Type)tmp;
-                        else if (item.TryGet("knownTypeName", out tmp)) knownType = model.GetType((string)tmp, type
+                        if (knownType == null && item.TryGet("knownTypeName", out tmp)) knownType = model.GetType((string)tmp, type
 #if WINRT
                             .GetTypeInfo()
 #endif       

--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -561,12 +561,12 @@ namespace ProtoBuf.Meta
                     Type knownType = null;
                     try
                     {
-                        if (item.TryGet("knownTypeName", out tmp)) knownType = model.GetType((string)tmp, type
+                        if (item.TryGet("knownType", out tmp)) knownType = (Type)tmp;
+                        else if (item.TryGet("knownTypeName", out tmp)) knownType = model.GetType((string)tmp, type
 #if WINRT
                             .GetTypeInfo()
 #endif       
                             .Assembly);
-                        else if (item.TryGet("knownType", out tmp)) knownType = (Type)tmp;
                     }
                     catch (Exception ex)
                     {

--- a/protobuf-net/Meta/MetaType.cs
+++ b/protobuf-net/Meta/MetaType.cs
@@ -94,34 +94,6 @@ namespace ProtoBuf.Meta
             return type.IsAssignableFrom(subType);
 #endif
         }
-
-        private Type FindValidSubType(Type subType)
-        {
-            if (IsValidSubType(subType))
-            {
-                return subType;
-            }
-            // if subType is invalid, it could be because:
-            // 1. invalid ProtoIncludeAttribute
-            // 2. subType is contained in an assembly that has been loaded multiple times
-#if !FEAT_IKVM && !PORTABLE
-            // Check to see if any other assemblies with the same name contain the desired type.
-            AssemblyName assemblyName = subType.Assembly.GetName();
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (AssemblyName.ReferenceMatchesDefinition(assemblyName, assembly.GetName()))
-                {
-                    Type otherType = assembly.GetType(subType.FullName, false, false);
-                    if (IsValidSubType(otherType))
-                    {
-                        return otherType;
-                    }
-                }
-            }
-#endif
-            return null;
-        }
-
         /// <summary>
         /// Adds a known sub-type to the inheritance model
         /// </summary>
@@ -604,8 +576,7 @@ namespace ProtoBuf.Meta
                     {
                         throw new InvalidOperationException("Unable to resolve sub-type of: " + type.FullName);
                     }
-                    knownType = FindValidSubType(knownType);
-                    if (knownType != null) AddSubType(tag, knownType, dataFormat);
+                    if(IsValidSubType(knownType)) AddSubType(tag, knownType, dataFormat);
                 }
 
                 if (fullAttributeTypeName == "ProtoBuf.ProtoPartialIgnoreAttribute")

--- a/protobuf-net/ProtoIncludeAttribute.cs
+++ b/protobuf-net/ProtoIncludeAttribute.cs
@@ -25,7 +25,10 @@ namespace ProtoBuf
         /// <param name="tag">The unique index (within the type) that will identify this data.</param>
         /// <param name="knownType">The additional type to serialize/deserialize.</param>
         public ProtoIncludeAttribute(int tag, System.Type knownType)
-            : this(tag, knownType == null ? "" : knownType.AssemblyQualifiedName) { }
+            : this(tag, knownType == null ? "" : knownType.AssemblyQualifiedName)
+        {
+            this.knownType = knownType;
+        }
 
         /// <summary>
         /// Creates a new instance of the ProtoIncludeAttribute.
@@ -52,6 +55,7 @@ namespace ProtoBuf
         public string KnownTypeName { get { return knownTypeName; } }
         private readonly string knownTypeName;
 
+        readonly Type knownType;
         /// <summary>
         /// Gets the additional type to serialize/deserialize.
         /// </summary>
@@ -59,7 +63,7 @@ namespace ProtoBuf
         {
             get
             {
-                return TypeModel.ResolveKnownType(KnownTypeName, null, null);
+                return knownType;
             }
         }
 


### PR DESCRIPTION
I was looking at this again now that [dotnet/coreclr](https://github.com/dotnet/coreclr) is out, thinking I could log an issue there and possibly fix it. I was getting some more strange behavior and while I still think this [Gh24.cs](https://github.com/mdonoughe/protobuf-net/blob/0c04562dc144cf0bcec01c976538faeec5695c07/Examples/Issues/Gh24.cs) test I created is encountering a .Net bug, it does not appear to be the .Net bug I thought it was.

I tried to make a version of [mdonoughe/protobuf-net-issue24](https://github.com/mdonoughe/protobuf-net-issue24) that I could run under coreclr, and I wasn't seeing any issues. I knew I could reproduce the issue with Gh24.cs, so I went back to mdonoughe/protobuf-net@0c04562 and started messing with it.
1. I modified protobuf-net to throw an exception when A is not assignable from A's ProtoIncludeAttribute.KnownType, or rather I used CustomAttributeData to check that A is assignable from the type passed to the ProtoIncludeAttribute constructor, and then checked again using the value of the KnownType property. This distinction is important because if CustomAttributeData is using the wrong type then it's a .Net problem and the best protobuf-net could do would be to put in some hack workaround.
2. After verifying that I could detect the problem, I copied and pasted the test code all over, moving it closer to the beginning of Serializer.Deserialize`1, the entry point into protobuf-net code from my test. This ensures the problem isn't being introduced somewhere between, which was something I had suspected because originally I was testing against the child type instead of the base type in the first few places and the child type doesn't have any ProtoInclude attributes so obviously I wouldn't see a problem.
3. Once I could see the problem in Serializer.Deserialize`1, I removed all other protobuf-net code, leaving only Serializer.Deserialize`1 and replacing ProtoInclude with KnownType. Since protobuf-net wasn't actually protobuf-net anymore, it couldn't be a protobuf-net bug I was seeing.
4. However, Gh24.cs uses AssemblyBuilder.Save and that isn't present in coreclr so I needed to create an assembly ahead of time. Rather than use Reflection.Emit to create an assembly and then save that assembly so I can embed it in my test program, I created an assembly the normal way with Visual Studio and then turned it into an embedded resource so I could just write the resource to disk when I needed it. _Doing this caused both tests to pass._
5. I confirmed there was something strange going on with the Reflection.Emit version by switching back and forth between the two versions of the test and running the assemblies through ildasm. It seems when csc builds the assembly the attribute says effectively "ChildType in this assembly," but when Reflection.Emit builds the assembly the attribute says "ChildType in <full name of assembly>" instead.
6. I reverted all my changes back to mdonoughe/protobuf-net@0c04562 and then again replaced the Reflection.Emit code with an embedded resource. The test fails (as expected), but I can make a simple change to protobuf-net which causes both tests to pass.

So I'm thinking now that this is something protobuf-net can and should fix, and there's a separate .Net issue either in Reflection.Emit and/or in the CLR itself related to type literals for types contained in the same assembly.

Does this fix look good? I'm unsure about having ProtoInclude.KnownType return null when a string is used to specify the known type, but if it returns `knownType ?? TypeModel.ResolveKnownType(KnownTypeName, null, null)` the last two parameters to ResolveKnownType cannot be provided by MetaType.cs.

When I try to run the Examples tests that already existed I get the same results before and after my changes: a couple fail in Extensibility, and then NUnit crashes before executing all the tests. The protobuf-net.unittest tests pass.
