### PR TITLE
Fix DateTime Serialization bug where DateTimeKind was not serialized/des...

### DIFF
--- a/protobuf-net.unittest/Serializers/SerializerTests.cs
+++ b/protobuf-net.unittest/Serializers/SerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.Serialization;
 using NUnit.Framework;
 using ProtoBuf;
 
@@ -47,6 +48,62 @@ namespace ProtoBuf.unittest.Serializers
 
             // Assert
             Assert.AreEqual(deserializedTimeSpan, originalTimeSpan);
+        }
+
+        [Test]
+        public void WhenEmptyArrayIsSerializedAndDeserialized_EmptyArrayIsPreserved()
+        {
+            // Arrange
+            var original = new Test
+            {
+                Array = new int[0]
+            };
+
+            // Act
+            Test deserialized;
+
+            using (var stream = new MemoryStream())
+            {
+                Serializer.Serialize(stream, original);
+                stream.Flush();
+                stream.Position = 0;
+                deserialized = Serializer.Deserialize<Test>(stream);
+            }
+
+            // Assert
+            Assert.IsNotNull(deserialized.Array);
+            Assert.AreEqual(deserialized.Array.Length, 0);
+        }
+
+        [Test]
+        public void WhenNullArrayIsSerializedAndDeserialized_ArrayIsNull()
+        {
+            // Arrange
+            var original = new Test
+            {
+                Array = null
+            };
+
+            // Act
+            Test deserialized;
+
+            using (var stream = new MemoryStream())
+            {
+                Serializer.Serialize(stream, original);
+                stream.Flush();
+                stream.Position = 0;
+                deserialized = Serializer.Deserialize<Test>(stream);
+            }
+
+            // Assert
+            Assert.IsNull(deserialized.Array);
+        }
+
+        [DataContract]
+        private class Test
+        {
+            [DataMember(Order = 1)]
+            public int[] Array { get; set; }
         }
     }
 }

--- a/protobuf-net.unittest/Serializers/SerializerTests.cs
+++ b/protobuf-net.unittest/Serializers/SerializerTests.cs
@@ -26,6 +26,7 @@ namespace ProtoBuf.unittest.Serializers
                 deserializedDate = Serializer.Deserialize<DateTime>(stream);
             }
 
+            // Assert
             Assert.AreEqual(deserializedDate.Kind, utcDate.Kind);
         }
 

--- a/protobuf-net.unittest/Serializers/SerializerTests.cs
+++ b/protobuf-net.unittest/Serializers/SerializerTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
 using ProtoBuf;
 
-namespace protobuf_net.Tests
+namespace ProtoBuf.unittest.Serializers
 {
     [TestFixture]
     public class SerializerTests

--- a/protobuf-net.unittest/Serializers/SerializerTests.cs
+++ b/protobuf-net.unittest/Serializers/SerializerTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using NUnit.Framework.SyntaxHelpers;
+using ProtoBuf;
+
+namespace protobuf_net.Tests
+{
+    [TestFixture]
+    public class SerializerTests
+    {
+        [Test]
+        public void WhenDateTimeIsSerializedAndThenDeserialized_DateTimeKindIsPreserved()
+        {
+            // Arrange
+            var utcDate = new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            // Act
+            DateTime deserializedDate;
+
+            using (var stream = new MemoryStream())
+            {
+                Serializer.Serialize(stream, utcDate);
+                stream.Flush();
+                stream.Position = 0;
+                deserializedDate = Serializer.Deserialize<DateTime>(stream);
+            }
+
+            // Assert
+            Assert.That(deserializedDate.Kind, Is.EqualTo(utcDate.Kind));
+        }
+
+        [Test]
+        public void WhenTimespanIsSerializedAndDeserialized_TimeSpanIsPreserved()
+        {
+            // Arrange
+            var originalTimeSpan = new TimeSpan(1, 2, 3, 4);
+
+            // Act
+            TimeSpan deserializedTimeSpan;
+
+            using (var stream = new MemoryStream())
+            {
+                Serializer.Serialize(stream, originalTimeSpan);
+                stream.Flush();
+                stream.Position = 0;
+                deserializedTimeSpan = Serializer.Deserialize<TimeSpan>(stream);
+            }
+
+            // Assert
+            Assert.That(deserializedTimeSpan, Is.EqualTo(originalTimeSpan));
+        }
+    }
+}

--- a/protobuf-net.unittest/Serializers/SerializerTests.cs
+++ b/protobuf-net.unittest/Serializers/SerializerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using NUnit.Framework;
-using NUnit.Framework.SyntaxHelpers;
 using ProtoBuf;
 
 namespace ProtoBuf.unittest.Serializers
@@ -26,8 +25,7 @@ namespace ProtoBuf.unittest.Serializers
                 deserializedDate = Serializer.Deserialize<DateTime>(stream);
             }
 
-            // Assert
-            Assert.That(deserializedDate.Kind, Is.EqualTo(utcDate.Kind));
+            Assert.AreEqual(deserializedDate.Kind, utcDate.Kind);
         }
 
         [Test]
@@ -48,7 +46,7 @@ namespace ProtoBuf.unittest.Serializers
             }
 
             // Assert
-            Assert.That(deserializedTimeSpan, Is.EqualTo(originalTimeSpan));
+            Assert.AreEqual(deserializedTimeSpan, originalTimeSpan);
         }
     }
 }

--- a/protobuf-net.unittest/protobuf-net.unittest.csproj
+++ b/protobuf-net.unittest/protobuf-net.unittest.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Serializers\DateTimeTests.cs" />
     <Compile Include="Serializers\KeyValuePairTests.cs" />
     <Compile Include="Serializers\NilSerializer.cs" />
+    <Compile Include="Serializers\SerializerTests.cs" />
     <Compile Include="Serializers\SubItems.cs" />
     <Compile Include="Serializers\Tag.cs" />
     <Compile Include="Serializers\Util.cs" />

--- a/protobuf-net/BclHelpers.cs
+++ b/protobuf-net/BclHelpers.cs
@@ -47,6 +47,14 @@ namespace ProtoBuf
         
         internal static readonly DateTime EpochOrigin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
 
+        /// <summary>
+        /// Writes a TimeSpan to a protobuf stream
+        /// </summary>
+        public static void WriteTimeSpan(TimeSpan timeSpan, ProtoWriter dest)
+        {
+            WriteTimeSpan(timeSpan, dest, null);
+        }
+
         private static void WriteTimeSpan(TimeSpan timeSpan, ProtoWriter dest, DateTimeKind? dateTimeKind)
         {
             if (dest == null) throw new ArgumentNullException("dest");
@@ -125,13 +133,6 @@ namespace ProtoBuf
             }
         }
 
-        /// <summary>
-        /// Writes a TimeSpan to a protobuf stream
-        /// </summary>
-        public static void WriteTimeSpan(TimeSpan timeSpan, ProtoWriter dest)
-        {
-            WriteTimeSpan(timeSpan, dest, null);
-        }
         /// <summary>
         /// Parses a TimeSpan from a protobuf stream
         /// </summary>        

--- a/protobuf-net/BclHelpers.cs
+++ b/protobuf-net/BclHelpers.cs
@@ -109,7 +109,7 @@ namespace ProtoBuf
                         if (dateTimeKind.HasValue)
                         {
                             ProtoWriter.WriteFieldHeader(FieldDateTimeKind, WireType.Variant, dest);
-                            ProtoWriter.WriteInt64((int)dateTimeKind.Value, dest);
+                            ProtoWriter.WriteByte((byte)dateTimeKind.Value, dest);
                         }
                     }
                     if (scale != TimeSpanScale.Days)
@@ -210,7 +210,7 @@ namespace ProtoBuf
                                 value = source.ReadInt64();
                                 break;
                             case FieldDateTimeKind:
-                                dateTimeKind = (DateTimeKind)source.ReadInt32();
+                                dateTimeKind = (DateTimeKind)source.ReadByte();
                                 break;
                             default:
                                 source.SkipField();

--- a/protobuf-net/BclHelpers.cs
+++ b/protobuf-net/BclHelpers.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Reflection;
-using System.Security.Cryptography;
 
 namespace ProtoBuf
 {

--- a/protobuf-net/Serializers/ArrayDecorator.cs
+++ b/protobuf-net/Serializers/ArrayDecorator.cs
@@ -138,18 +138,16 @@ namespace ProtoBuf.Serializers
         {
             IList arr = (IList)value;
             int len = arr.Count;
-            SubItemToken token;
+
+            ProtoWriter.WriteFieldHeader(fieldNumber, WireType.String, dest);
+            SubItemToken token = ProtoWriter.StartSubItem(value, dest);
+
             bool writePacked = (options & OPTIONS_WritePacked) != 0;
             if (writePacked)
             {
-                ProtoWriter.WriteFieldHeader(fieldNumber, WireType.String, dest);
-                token = ProtoWriter.StartSubItem(value, dest);
                 ProtoWriter.SetPackedField(fieldNumber, dest);
             }
-            else
-            {
-                token = new SubItemToken(); // default
-            }
+
             bool checkForNull = !SupportNull;
             for (int i = 0; i < len; i++)
             {
@@ -157,10 +155,8 @@ namespace ProtoBuf.Serializers
                 if (checkForNull && obj == null) { throw new NullReferenceException(); }
                 Tail.Write(obj, dest);
             }
-            if (writePacked)
-            {
-                ProtoWriter.EndSubItem(token, dest);
-            }            
+            
+            ProtoWriter.EndSubItem(token, dest);           
         }
         public override object Read(object value, ProtoReader source)
         {


### PR DESCRIPTION
I've supplied 2 bug fixes.

1) Behavior before: When DateTime was serialized and then deserialized the DateTimeKind was lost. I noticed this recently when my Utc DateTimes were being lost and my deserialized dates were an hour out due to BST time.

Behavior now: DateTimeKind is preserved in serialization/deserialization round trip.

2) Behavior before: Empty arrays would be serialized and then deserialized as null.

Behavior now: Empty arrays are preserved on serialization/deserialization round trip.

The tests in SerializerTests.cs should convey my intention in more detail and they all now pass.

Please let me know if these changes can be merged into master or if there is any feedback for improvements.

Rob
