### PR TITLE
Add Exception.Data["protoMessageFragment"] for Invalid wire-type exception

### DIFF
--- a/Examples/TraceError.cs
+++ b/Examples/TraceError.cs
@@ -25,7 +25,9 @@ namespace Examples
         [Test]
         public void TestTrace()
         {
-            TraceErrorData ed = new TraceErrorData {Foo = 12, Bar = "abcdefghijklmnopqrstuvwxyz"};
+            var fooValue = 12;
+            var barValue = "abcdefghijklmnopqrstuvwxyz";
+            TraceErrorData ed = new TraceErrorData { Foo = fooValue, Bar = barValue };
             MemoryStream ms = new MemoryStream();
             Serializer.Serialize(ms, ed);
             byte[] buffer = ms.GetBuffer();
@@ -41,6 +43,9 @@ namespace Examples
             {
                 Assert.IsTrue(ex.Data.Contains("protoSource"), "Missing protoSource");
                 Assert.AreEqual("tag=2; wire-type=String; offset=4; depth=0", ex.Data["protoSource"]);
+                var fragment = (byte[])ex.Data["protoMessageFragment"];
+                var fragmentAsString = System.Text.Encoding.UTF8.GetString(fragment).Trim('\0');
+                Assert.AreEqual("\b" + Char.ConvertFromUtf32(fooValue) + Char.ConvertFromUtf32(18) + Char.ConvertFromUtf32(barValue.Length) + barValue, fragmentAsString);
             } catch(Exception ex)
             {
                 Assert.Fail("Unexpected exception: " + ex);

--- a/protobuf-net/ProtoReader.cs
+++ b/protobuf-net/ProtoReader.cs
@@ -523,7 +523,7 @@ namespace ProtoBuf
         }
         private Exception CreateWireTypeException()
         {
-            return CreateException("Invalid wire-type; this usually means you have over-written a file without truncating or setting the length; see http://stackoverflow.com/q/2152978/23354");
+            return CreateException("Invalid wire-type; this usually means you have over-written a file without truncating or setting the length; see Exception.Data[\"protoSource\"] and Exception.Data[\"protoMessageFragment\"]; for more info see http://stackoverflow.com/q/2152978/23354");
         }
         private Exception CreateException(string message)
         {
@@ -1183,6 +1183,12 @@ namespace ProtoBuf
             {
                 exception.Data.Add("protoSource", string.Format("tag={0}; wire-type={1}; offset={2}; depth={3}",
                     source.fieldNumber, source.wireType, source.position, source.depth));
+            }
+            if (exception != null && source != null && !exception.Data.Contains("protoMessageFragment"))
+            {
+                byte[] messageFragment = new byte[source.ioBuffer.Length];
+                source.ioBuffer.CopyTo(messageFragment, 0);
+                exception.Data.Add("protoMessageFragment", messageFragment);
             }
 #endif
             return exception;


### PR DESCRIPTION
Add Exception.Data["protoMessageFragment"] to ease debugging of the error "Invalid wire-type" when deserializing a proto message
