### PR TITLE
Fix finding Add method for IList of Nullable ValueTypes. Add option RuntimeTypeModel.DontThrowNullReference.

### DIFF
--- a/Examples/ListAsInterfaceTests.cs
+++ b/Examples/ListAsInterfaceTests.cs
@@ -24,6 +24,12 @@ namespace Examples
     {
         IList<string> Data { get; }
     }
+    [ProtoContract]
+    class DataWithNullableIList
+    {
+        [ProtoMember(1)]
+        public IList<int?> Data { get; set; }
+    }
 
     [TestFixture]
     public class ListAsInterfaceTests
@@ -49,6 +55,87 @@ namespace Examples
             Assert.AreNotSame(data, clone);
             Assert.AreEqual(1, clone.Count);
             Assert.AreEqual("abc", clone[0]);
+        }
+
+        [Test]
+        public void TestNullableIListWithoutData()
+        {
+            var original = new DataWithNullableIList();
+            var clone = Serializer.DeepClone(original);
+            Assert.IsNotNull(clone);
+        }
+
+        [Test]
+        public void TestNullableIListWithData()
+        {
+            var original = new DataWithNullableIList { Data = new List<int?> { 4 } };
+            var clone = Serializer.DeepClone(original);
+            Assert.IsNotNull(clone);
+            Assert.AreNotSame(original, clone);
+            Assert.IsNotNull(clone.Data);
+            Assert.AreEqual(1, clone.Data.Count);
+            Assert.AreEqual(4, clone.Data[0]);
+        }
+
+        [Test]
+        public void TestNullableIListWithNullData()
+        {
+            try
+            {
+                var original = new DataWithNullableIList { Data = new List<int?> { null, 4 } };
+                Serializer.DeepClone(original);
+                Assert.Fail();
+            }
+            catch (NullReferenceException) { /* expected */ }
+        }
+
+        [Test]
+        public void TestNullableIListWithNullDataDontThrow()
+        {
+            var model = ProtoBuf.Meta.RuntimeTypeModel.Create();
+            model.DontThrowNullReference = true;
+
+            var original = new DataWithNullableIList { Data = new List<int?> { null, 4 } };
+            var clone = (DataWithNullableIList)model.DeepClone(original);
+            Assert.IsNotNull(clone);
+            Assert.AreNotSame(original, clone);
+            Assert.IsNotNull(clone.Data);
+            Assert.AreEqual(1, clone.Data.Count);
+            Assert.AreEqual(4, clone.Data[0]);
+        }
+
+        [Test]
+        public void TestNullableIListWithNullDataSupportNull()
+        {
+            var model = ProtoBuf.Meta.RuntimeTypeModel.Create();
+            model.Add(typeof(DataWithNullableIList), true)[1].SupportNull = true;
+
+            var original = new DataWithNullableIList { Data = new List<int?> { null, 4 } };
+            var clone = (DataWithNullableIList)model.DeepClone(original);
+            Assert.IsNotNull(clone);
+            Assert.AreNotSame(original, clone);
+            Assert.IsNotNull(clone.Data);
+            Assert.AreEqual(2, clone.Data.Count);
+            Assert.AreEqual(null, clone.Data[0]);
+            Assert.AreEqual(4, clone.Data[1]);
+        }
+
+
+        [Test]
+        public void TestNullableIListWithNullDataSupportNullDontThrow()
+        {
+            var model = ProtoBuf.Meta.RuntimeTypeModel.Create();
+            model.DontThrowNullReference = true;
+            model.Add(typeof(DataWithNullableIList), true)[1].SupportNull = true;
+
+            var original = new DataWithNullableIList { Data = new List<int?> { null, 4 } };
+            var clone = (DataWithNullableIList)model.DeepClone(original);
+            Assert.IsNotNull(clone);
+            Assert.AreNotSame(original, clone);
+            Assert.IsNotNull(clone.Data);
+            Assert.AreEqual(2, clone.Data.Count);
+            Assert.AreEqual(null, clone.Data[0]);
+            Assert.AreEqual(4, clone.Data[1]);
         }
 
         static void TestList<T>(T original) where T : class, IDataWithList

--- a/Examples/Primatives.cs
+++ b/Examples/Primatives.cs
@@ -404,13 +404,13 @@ namespace Examples
             //Assert.AreEqual(p.TestDecimalTwos, clone.TestDecimalTwos, "Twos 0");
             //Assert.AreEqual(p.TestDecimalZigZag, clone.TestDecimalZigZag, "ZigZag 0");
 
-            p.TestDecimalDefault = decimal.Parse("0.000"); // p.TestDecimalTwos = p.TestDecimalZigZag =
+            p.TestDecimalDefault = decimal.Parse("0.000", System.Globalization.CultureInfo.InvariantCulture); // p.TestDecimalTwos = p.TestDecimalZigZag =
              clone = Serializer.DeepClone(p);
             Assert.AreEqual(p.TestDecimalDefault, clone.TestDecimalDefault, "Default 0.000");
             //Assert.AreEqual(p.TestDecimalTwos, clone.TestDecimalTwos, "Twos 0.000");
             //Assert.AreEqual(p.TestDecimalZigZag, clone.TestDecimalZigZag, "ZigZag 0.000");
 
-            p.TestDecimalDefault = decimal.Parse("1.000"); //p.TestDecimalTwos = p.TestDecimalZigZag = 
+            p.TestDecimalDefault = decimal.Parse("1.000", System.Globalization.CultureInfo.InvariantCulture); //p.TestDecimalTwos = p.TestDecimalZigZag = 
             clone = Serializer.DeepClone(p);
             Assert.AreEqual(p.TestDecimalDefault, clone.TestDecimalDefault, "Default 1.000");
             //Assert.AreEqual(p.TestDecimalTwos, clone.TestDecimalTwos, "Twos 1.000");

--- a/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -38,7 +38,8 @@ namespace ProtoBuf.Meta
            OPTIONS_UseImplicitZeroDefaults = 32,
            OPTIONS_AllowParseableTypes = 64,
            OPTIONS_AutoAddProtoContractTypesOnly = 128,
-           OPTIONS_IncludeDateTimeKind = 256;
+           OPTIONS_IncludeDateTimeKind = 256,
+           OPTIONS_DontThrowNullReference = 512;
         private bool GetOption(ushort option)
         {
             return (options & option) == option;
@@ -111,7 +112,14 @@ namespace ProtoBuf.Meta
             get { return GetOption(OPTIONS_IncludeDateTimeKind); }
             set { SetOption(OPTIONS_IncludeDateTimeKind, value); }
         }
-
+        /// <summary>
+        /// Global switch that determines whether to throw <c>NullRefeneceException</c> on null items in collections when SupportNull is false.
+        /// </summary>
+        public bool DontThrowNullReference
+        {
+            get { return GetOption(OPTIONS_DontThrowNullReference); }
+            set { SetOption(OPTIONS_DontThrowNullReference, value); }
+        }
         /// <summary>
         /// Should the <c>Kind</c> be included on date/time values?
         /// </summary>

--- a/protobuf-net/Meta/TypeModel.cs
+++ b/protobuf-net/Meta/TypeModel.cs
@@ -771,6 +771,11 @@ namespace ProtoBuf.Meta
                         add = Helpers.GetInstanceMethod(interfaceType, "TryAdd", types);
                         if (add != null) break;
                     }
+                    if (interfaceType.Name == "ICollection`1" && interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition().FullName == "System.Collections.Generic.ICollection`1")
+                    {
+                        add = Helpers.GetInstanceMethod(interfaceType, "Add", types);
+                        if (add != null) break;
+                    }
                 }
             }
 #endif

--- a/protobuf-net/Meta/ValueMember.cs
+++ b/protobuf-net/Meta/ValueMember.cs
@@ -353,11 +353,11 @@ namespace ProtoBuf.Meta
                         , "Wrong type in the tail; expected {0}, received {1}", ser.ExpectedType, underlyingItemType);
                     if (memberType.IsArray)
                     {
-                        ser = new ArrayDecorator(model, ser, fieldNumber, IsPacked, wireType, memberType, OverwriteList, SupportNull);
+                        ser = new ArrayDecorator(model, ser, fieldNumber, IsPacked, wireType, memberType, OverwriteList, SupportNull, model.DontThrowNullReference);
                     }
                     else
                     {
-                        ser = ListDecorator.Create(model, memberType, defaultType, ser, fieldNumber, IsPacked, wireType, member != null && PropertyDecorator.CanWrite(model, member), OverwriteList, SupportNull);
+                        ser = ListDecorator.Create(model, memberType, defaultType, ser, fieldNumber, IsPacked, wireType, member != null && PropertyDecorator.CanWrite(model, member), OverwriteList, SupportNull, model.DontThrowNullReference);
                     }
                 }
                 else if (defaultValue != null && !IsRequired && getSpecified == null)

--- a/protobuf-net/Serializers/ImmutableCollectionDecorator.cs
+++ b/protobuf-net/Serializers/ImmutableCollectionDecorator.cs
@@ -136,9 +136,9 @@ namespace ProtoBuf.Serializers
         }
 #endif
         private readonly MethodInfo builderFactory, add, addRange, finish;
-        internal ImmutableCollectionDecorator(TypeModel model, Type declaredType, Type concreteType, IProtoSerializer tail, int fieldNumber, bool writePacked, WireType packedWireType, bool returnList, bool overwriteList, bool supportNull,
+        internal ImmutableCollectionDecorator(TypeModel model, Type declaredType, Type concreteType, IProtoSerializer tail, int fieldNumber, bool writePacked, WireType packedWireType, bool returnList, bool overwriteList, bool supportNull, bool dontThrowNullReference,
             MethodInfo builderFactory, MethodInfo add, MethodInfo addRange, MethodInfo finish)
-            : base(model, declaredType, concreteType, tail, fieldNumber, writePacked, packedWireType, returnList, overwriteList, supportNull)
+            : base(model, declaredType, concreteType, tail, fieldNumber, writePacked, packedWireType, returnList, overwriteList, supportNull, dontThrowNullReference)
         {
             this.builderFactory = builderFactory;
             this.add = add;

--- a/protobuf-net/Serializers/TupleSerializer.cs
+++ b/protobuf-net/Serializers/TupleSerializer.cs
@@ -56,11 +56,11 @@ namespace ProtoBuf.Serializers
                 {
                     if (finalType.IsArray)
                     {
-                        serializer = new ArrayDecorator(model, tail, i + 1, false, wireType, finalType, false, false);
+                        serializer = new ArrayDecorator(model, tail, i + 1, false, wireType, finalType, false, false, false);
                     }
                     else
                     {
-                        serializer = ListDecorator.Create(model, finalType, defaultType, tail, i + 1, false, wireType, true, false, false);
+                        serializer = ListDecorator.Create(model, finalType, defaultType, tail, i + 1, false, wireType, true, false, false, false);
                     }
                 }
                 tails[i] = serializer;


### PR DESCRIPTION
There was an issue serializing types like IList of int? because 'Add' method was not found.
Also introduced an option to be able to silently ignore null values in collections.