### PR TITLE
Support open generic types as surrogates

### DIFF
--- a/src/protobuf-net.Test/Attribs/ProtoContractSurrogate.cs
+++ b/src/protobuf-net.Test/Attribs/ProtoContractSurrogate.cs
@@ -49,5 +49,79 @@ namespace ProtoBuf.unittest.Attribs
 
             Assert.Equal(tableColumn.Key, clone.Key);
         }
+
+        [ProtoContract(Surrogate = typeof(ImmutableGenericType1Surrogate<>))]
+        public class ImmutableGenericType1<T>
+        {
+            public ImmutableGenericType1(T value)
+            {
+                Value = value;
+            }
+
+            public T Value { get; }
+        }
+
+        [ProtoContract]
+        public class ImmutableGenericType1Surrogate<T>
+        {
+            [ProtoMember(1, IsRequired = true)]
+            public T Value { get; set; }
+
+            public static implicit operator ImmutableGenericType1<T>(ImmutableGenericType1Surrogate<T> surrogate)
+            {
+                return surrogate == null ? null : new ImmutableGenericType1<T>(surrogate.Value);
+            }
+
+            public static implicit operator ImmutableGenericType1Surrogate<T>(ImmutableGenericType1<T> source)
+            {
+                return source == null ? null : new ImmutableGenericType1Surrogate<T> { Value = source.Value };
+            }
+        }
+
+        [Fact]
+        public void ImmutableGenericSerialization()
+        {
+            var instance = new ImmutableGenericType1<string>("XYZ!");
+            var clone = RuntimeTypeModel.Default.DeepClone(instance);
+
+            Assert.Equal(instance.Value, clone.Value);
+        }
+
+        [ProtoContract(Surrogate = typeof(ImmutableGenericType2<>.Surrogate))]
+        public class ImmutableGenericType2<T>
+        {
+            public ImmutableGenericType2(T value)
+            {
+                Value = value;
+            }
+
+            public T Value { get; }
+
+            [ProtoContract]
+            public class Surrogate
+            {
+                [ProtoMember(1, IsRequired = true)]
+                public T Value { get; set; }
+
+                public static implicit operator ImmutableGenericType2<T>(Surrogate surrogate)
+                {
+                    return surrogate == null ? null : new ImmutableGenericType2<T>(surrogate.Value);
+                }
+
+                public static implicit operator Surrogate(ImmutableGenericType2<T> source)
+                {
+                    return source == null ? null : new Surrogate { Value = source.Value };
+                }
+            }
+        }
+
+        [Fact]
+        public void ImmutableGenericNestedSerialization()
+        {
+            var instance = new ImmutableGenericType2<string>("XYZ!");
+            var clone = RuntimeTypeModel.Default.DeepClone(instance);
+
+            Assert.Equal(instance.Value, clone.Value);
+        }
     }
 }

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1370,6 +1370,20 @@ namespace ProtoBuf.Meta
 
                 if ((BaseType != null && BaseType != this) || (_subTypes?.Count ?? 0) > 0)
                     ThrowSubTypeWithSurrogate(Type);
+
+                if (surrogateType.IsGenericTypeDefinition)
+                {
+                    if (!Type.IsGenericType)
+                    {
+                        ThrowHelper.ThrowArgumentException("Cannot use an open generic type as a surrogate for a non generic type");
+                    }
+                    var genericArguments = Type.GetGenericArguments();
+                    if (genericArguments.Length != surrogateType.GetGenericArguments().Length)
+                    {
+                        ThrowHelper.ThrowArgumentException("The generic type parameters of the surrogate must match the generic arguments of the target type");
+                    }
+                    surrogateType = surrogateType.MakeGenericType(genericArguments);
+                }
             }
             ThrowIfFrozen();
 


### PR DESCRIPTION
The `Surrogate` attribute is quite handy but it cannot be used on generic types.
This PR enables open generic types to be specified as surrogates:
```cs
    [ProtoContract(Surrogate = typeof(ImmutableGenericTypeSurrogate<>))]
    public class ImmutableGenericType<T>
    {
        public ImmutableGenericType(T value)
        {
            Value = value;
        }
        public T Value { get; }
    }
```