### PR TITLE
MapDecorator throws when using custom structs as values.

### DIFF
--- a/src/Examples/Issues/Issue318.cs
+++ b/src/Examples/Issues/Issue318.cs
@@ -1,0 +1,51 @@
+﻿#if !COREFX
+using Xunit;
+using ProtoBuf;
+using System.Collections.Generic;
+
+namespace Examples.Issues
+{
+    
+    public class Issue318
+    {
+        [Fact]
+        public void Execute()
+        {
+            Serializer.PrepareSerializer<DictWithImmutableStructValueType>(); // this used to throw.
+        }
+
+        [ProtoContract]
+        class DictWithImmutableStructValueType
+        {
+            [ProtoMember(1)]
+            public Dictionary<string, ImmutableValueType> Dict { get; set; } = new Dictionary<string, ImmutableValueType>();
+        }
+
+        [ProtoContract]
+        struct ImmutableValueType
+        {
+            [ProtoMember(1)]
+            private readonly int _value;
+
+            public ImmutableValueType(int value)
+            {
+                _value = value;
+            }
+
+            public int Value => _value;
+
+            public override int GetHashCode()
+            {
+                return _value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is ImmutableValueType x)
+                    return x._value == _value;
+                return false;
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #318 (and maybe #379)

I was unsure how to do this nicely (in terms of what type check to perform) as there was numerous ways of doing it.

There is one failing test but it looks to be just some very minor formatting change within .proto definitions vs C++ - we already have some exceptions in this area so maybe could add to it?  I'll await advice here.