### PR TITLE
Add a seam point to allow custom string serialization/deserialization

### DIFF
--- a/src/protobuf-net/IStringSerializer.cs
+++ b/src/protobuf-net/IStringSerializer.cs
@@ -1,0 +1,50 @@
+﻿namespace ProtoBuf
+{
+    public interface IStringSerializer
+    {
+        string ReadString(byte[] buffer, int offset, int count);
+        
+        int GetLength(string value);
+
+        void WriteString(string value, byte[] buffer, int offset);
+    }
+
+    public static class StringSerializer 
+    {
+        public static IStringSerializer Instance { get; private set; }
+
+        static StringSerializer()
+        {
+            Instance = new DefaultSerializer();
+        }
+
+
+        public static void SetSerializer(IStringSerializer instance)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentException();
+            }
+
+            Instance = instance;
+        }
+
+        private class DefaultSerializer : IStringSerializer
+        {
+            public String ReadString(Byte[] buffer, Int32 offset, Int32 count)
+            {
+                return Encoding.UTF8.GetString(buffer, offset, count);
+            }
+
+            public Int32 GetLength(String value)
+            {
+                return Encoding.UTF8.GetByteCount(value);
+            }
+
+            public Int32 WriteString(String value, Byte[] buffer, Int32 offset)
+            {
+                return Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, offset);
+            }
+        }
+    }
+}

--- a/src/protobuf-net/ProtoReader.cs
+++ b/src/protobuf-net/ProtoReader.cs
@@ -463,28 +463,6 @@ namespace ProtoBuf
             throw EoF(this);
         }
 
-        private Dictionary<string, string> stringInterner;
-        private string Intern(string value)
-        {
-            if (value == null) return null;
-            if (value.Length == 0) return "";
-            if (stringInterner == null)
-            {
-                stringInterner = new Dictionary<string, string>
-                {
-                    { value, value }
-                };
-            }
-            else if (stringInterner.TryGetValue(value, out string found))
-            {
-                value = found;
-            }
-            else
-            {
-                stringInterner.Add(value, value);
-            }
-            return value;
-        }
 
 #if COREFX
         static readonly Encoding encoding = Encoding.UTF8;
@@ -501,10 +479,8 @@ namespace ProtoBuf
                 int bytes = (int)ReadUInt32Variant(false);
                 if (bytes == 0) return "";
                 if (available < bytes) Ensure(bytes, true);
+                string s = StringSerializer.Instance.ReadString(ioBuffer, ioIndex, bytes);
 
-                string s = encoding.GetString(ioBuffer, ioIndex, bytes);
-
-                if (internStrings) { s = Intern(s); }
                 available -= bytes;
                 position64 += bytes;
                 ioIndex += bytes;

--- a/src/protobuf-net/ProtoWriter.cs
+++ b/src/protobuf-net/ProtoWriter.cs
@@ -587,7 +587,8 @@ namespace ProtoBuf
             writer.ioBuffer[writer.ioIndex - 1] &= 0x7F;
             writer.position64 += count;
         }
-
+        //Provide it someho
+        IStringSerializer stringSerializer;
         /// <summary>
         /// Writes a string to the stream; supported wire-types: String
         /// </summary>
@@ -603,10 +604,12 @@ namespace ProtoBuf
                 writer.wireType = WireType.None;
                 return; // just a header
             }
-            int predicted = encoding.GetByteCount(value);
+            int predicted = StringSerializer.Instance.GetLength(value);
             WriteUInt32Variant((uint)predicted, writer);
             DemandSpace(predicted, writer);
-            int actual = encoding.GetBytes(value, 0, value.Length, writer.ioBuffer, writer.ioIndex);
+            int actual = StringSerializer.Instance.WriteString(value, 0, value.Length, writer.ioBuffer, writer.ioIndex);
+
+
             Helpers.DebugAssert(predicted == actual);
             IncrementedAndReset(actual, writer);
         }

--- a/src/protobuf-net/StringCache.cs
+++ b/src/protobuf-net/StringCache.cs
@@ -1,0 +1,180 @@
+namespace ProtoBuf
+{
+    public class StringCache : IStringSerializer
+    {
+        public static int CacheStringLength = 32;
+
+
+        private static readonly ConcurrentDictionary<ArraySlice, string> _cache = new ConcurrentDictionary<ArraySlice, string>();
+        private static readonly ConcurrentDictionary<string, byte[]> _utf8Cache = new ConcurrentDictionary<string, byte[]>();
+
+        public string ReadString(byte[] buffer, int index, int count)
+        {
+            var slice = new ArraySlice(buffer, index, count);
+            string result;
+            if (!_cache.TryGetValue(slice, out result))
+            {
+                result = Encoding.UTF8.GetString(slice.Buffer, slice.Index, slice.Count);
+                if (string.IsInterned(result) != null)
+                {
+                    var copy = slice.DeepCopy();
+                    if (_cache.TryAdd(copy, result))
+                    {
+                        _utf8Cache.TryAdd(result, copy.Buffer);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public int GetLength(string value)
+        {
+            return _utf8Cache.TryGetValue(value, out byte[] cached)
+                ? cached.Length
+                : Encoding.UTF8.GetByteCount(value);
+        }
+
+        public int WriteString(string value, byte[] buffer, int offset)
+        {
+            if(_utf8Cache.TryGetValue(value, out byte[] cached))
+            {
+                Array.Copy(cached, 0, buffer, offset, cached.Length);
+                return cached.Length;
+            }
+
+            return Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, offset);
+        }
+    }
+
+    internal struct ArraySlice : IEquatable<ArraySlice>
+    {
+        private readonly byte[] _buffer;
+        private readonly int _index;
+        private readonly int _count;
+        private readonly int _hashCode;
+
+        public ArraySlice(byte[] buffer, int index, int count)
+        {
+            _buffer = buffer;
+            _index = index;
+            _count = count;
+            _hashCode = CalculateHashCode(buffer, index, count);
+        }
+
+        public byte[] Buffer => _buffer;
+
+        public int Index => _index;
+
+        public int Count => _count;
+
+        public unsafe bool Equals(ArraySlice other)
+        {
+            if (_count != other._count)
+            {
+                return false;
+            }
+
+            fixed (byte* p1 = &_buffer[_index], p2 = &other._buffer[other._index])
+            {
+                byte* thisP = p1, otherP = p2;
+                int l = _count;
+                for (int i = 0; i < l / 8; i++, thisP += 8, otherP += 8)
+                {
+                    if (*((long*)thisP) != *((long*)otherP))
+                    {
+                        return false;
+                    }
+                }
+
+                if ((l & 4) != 0)
+                {
+                    if (*((int*)thisP) != *((int*)otherP))
+                    {
+                        return false;
+                    }
+
+                    thisP += 4;
+                    otherP += 4;
+                }
+
+                if ((l & 2) != 0)
+                {
+                    if (*((short*)thisP) != *((short*)otherP))
+                    {
+                        return false;
+                    }
+
+                    thisP += 2;
+                    otherP += 2;
+                }
+
+                if ((l & 1) != 0)
+                {
+                    if (*thisP != *otherP)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            return obj is ArraySlice slice && Equals(slice);
+        }
+
+        public override int GetHashCode()
+        {
+            return _hashCode;
+        }
+
+        private static unsafe int CalculateHashCode(byte[] buffer, int index, int count)
+        {
+            unchecked
+            {
+                fixed (byte* p = &buffer[index])
+                {
+                    byte* current = p;
+                    uint hash = 5381;
+                    var left = count;
+
+                    while (left > 3)
+                    {
+                        hash = (hash << 5) + hash + (*(uint*)current);
+                        left -= sizeof(uint);
+                        current += sizeof(uint);
+                    }
+
+                    if (left >= 2)
+                    {
+                        hash = (hash << 5) + hash + (*(ushort*)current);
+                        left -= sizeof(ushort);
+                        current += sizeof(ushort);
+                    }
+
+                    if (left != 0)
+                    {
+                        hash = (hash << 5) + hash + *current;
+                    }
+
+                    return (int)hash;
+                }
+            }
+        }
+
+        internal ArraySlice DeepCopy()
+        {
+            var buffer = new byte[Count];
+            Array.Copy(_buffer, _index, buffer, 0, _count);
+            return new ArraySlice(buffer, 0, _count);
+        }
+    }
+}


### PR DESCRIPTION
It's not a ready to merge PR, but an idea to discuss. 
I'm working on a trading application which uses huge amount of small repetitive strings. All of them are interned using `string.Intern()`. I had to build a modified version of protobuf-net which is capable of writing such strings from cached byte arrays and reading them from `Dictionary<ArraySegment,string>`.
I saw a few percents improvement in performance, and greatly reduced GC pressure. (I can share figures later). I'm sure it won't work well for "general purpose" string serialization/deserialization, but it works well for me. 
To sum up, I would rather have an extension point in the original code than maintaining my own copy, and I need some feedback whether I'm on the right way to implement it. 
Upcoming version 3 looks like an opportunity for some breaking changes.  


