### PR TITLE
Enforce "required" fields

### DIFF
--- a/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
@@ -177,7 +177,18 @@ namespace ProtoBuf.Reflection
         {
             var name = ctx.NameNormalizer.GetName(@enum);
             var tw = ctx.Write("[global::ProtoBuf.ProtoContract(");
-            if (name != @enum.Name) tw.Write($@"Name = @""{@enum.Name}""");
+            bool comma = false;
+            if(name != @enum.Name)
+            {
+                tw.Write($@"Name = @""{@enum.Name}""");
+                comma = true;
+            }
+            if(ctx.EnforceRequired)
+            {
+                if(comma)
+                    ctx.Write(", ");
+                ctx.Write("EnforceRequired = true");
+            }
             tw.WriteLine(")]");
             WriteOptions(ctx, @enum.Options);
             ctx.WriteLine($"{GetAccess(GetAccess(@enum))} enum {Escape(name)}").WriteLine("{").Indent();

--- a/src/protobuf-net.Reflection/CodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CodeGenerator.cs
@@ -497,9 +497,11 @@ namespace ProtoBuf.Reflection
                 OneOfEnums = (File.Options?.GetOptions()?.EmitOneOfEnum ?? false) || (_options != null && _options.TryGetValue("oneof", out var oneof) && string.Equals(oneof, "enum", StringComparison.OrdinalIgnoreCase));
 
                 EmitListSetters = IsEnabled("listset");
+                EnforceRequired = IsEnabled("required");
             }
 
             internal bool EmitListSetters { get; }
+            internal bool EnforceRequired { get; }
             internal bool IsEnabled(string key)
             {
                 var option = GetCustomOption(key);

--- a/src/protobuf-net.Test/Serializers/RequiredEnforced.cs
+++ b/src/protobuf-net.Test/Serializers/RequiredEnforced.cs
@@ -1,0 +1,72 @@
+﻿using ProtoBuf.Meta;
+using ProtoBuf.unittest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace ProtoBuf.Serializers
+{
+	public class RequiredEnforced
+	{
+		[ProtoContract]
+		public class HazEnforcedRequired
+		{
+			[ProtoMember(1, IsRequired = true)]
+			public int Value
+			{
+				get
+				{
+					if(__pbn__Value == null) throw new InvalidOperationException("Field 'Value' not specified.");
+					return __pbn__Value.Value;
+				}
+				set { __pbn__Value = value; }
+			}
+			public bool ShouldSerializeValue() => __pbn__Value != null;
+			public void ResetValue() => __pbn__Value = null;
+			private int? __pbn__Value;
+
+			[ProtoMember(2, IsRequired = true, OverwriteList = true)]
+			public byte[] BytesValue
+			{
+				get
+				{
+					if(__pbn__BytesValue == null) throw new InvalidOperationException("Field 'BytesValue' not specified.");
+					return __pbn__BytesValue;
+				}
+				set { __pbn__BytesValue = value; }
+			}
+			public bool ShouldSerializeBytesValue() => __pbn__BytesValue != null;
+			public void ResetBytesValue() => __pbn__BytesValue = null;
+			private byte[] __pbn__BytesValue;
+		}
+
+		[Fact]
+		public void HazEnforcedRequired_EnforceGet()
+		{
+			var source = new HazEnforcedRequired();
+			Assert.Throws<InvalidOperationException>(() => source.Value);
+			Assert.Throws<InvalidOperationException>(() => source.BytesValue);
+			source.Value = 42;
+			source.BytesValue = new byte[4];
+			var x = source.Value;
+			var y = source.BytesValue;
+		}
+
+		[Fact]
+		public void HazEnforcedRequired_Serialize()
+		{
+			var ms = new MemoryStream();
+			var source = new HazEnforcedRequired { Value = 42, BytesValue = new byte[4], };
+			Assert.True(source.ShouldSerializeValue());
+			Assert.True(source.ShouldSerializeBytesValue());
+			Serializer.Serialize(ms, source);
+			ms.Position = 0;
+			var obj = Serializer.Deserialize<HazEnforcedRequired>(ms);
+			Assert.Equal(42, obj.Value);
+			Assert.True(obj.ShouldSerializeValue());
+			Assert.True(obj.ShouldSerializeBytesValue());
+		}
+	}
+}

--- a/src/protobuf-net/Helpers.cs
+++ b/src/protobuf-net/Helpers.cs
@@ -93,7 +93,7 @@ namespace ProtoBuf
 #endif
         }
 #if !NO_RUNTIME
-        public static void Sort(int[] keys, object[] values)
+        public static void Sort<TElement>(int[] keys, TElement[] values)
         {
             // bubble-sort; it'll work on MF, has small code,
             // and works well-enough for our sizes. This approach
@@ -110,7 +110,7 @@ namespace ProtoBuf
                         int tmpKey = keys[i];
                         keys[i] = keys[i - 1];
                         keys[i - 1] = tmpKey;
-                        object tmpValue = values[i];
+                        TElement tmpValue = values[i];
                         values[i] = values[i - 1];
                         values[i - 1] = tmpValue;
                         swapped = true;

--- a/src/protobuf-net/ProtoContractAttribute.cs
+++ b/src/protobuf-net/ProtoContractAttribute.cs
@@ -125,6 +125,19 @@ namespace ProtoBuf
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating that the required specifier should be enforced when writing
+        /// messages.
+        /// </summary>
+        public bool EnforceRequired
+        {
+            get { return HasFlag(OPTIONS_EnforceRequired); }
+            set
+            {
+                SetFlag(OPTIONS_EnforceRequired, value);
+            }
+        }
+
         private bool HasFlag(ushort flag) { return (flags & flag) == flag; }
         private void SetFlag(ushort flag, bool value)
         {
@@ -143,7 +156,8 @@ namespace ProtoBuf
             OPTIONS_AsReferenceDefault = 32,
             OPTIONS_EnumPassthru = 64,
             OPTIONS_EnumPassthruHasValue = 128,
-            OPTIONS_IsGroup = 256;
+            OPTIONS_IsGroup = 256,
+            OPTIONS_EnforceRequired = 512;
 
         /// <summary>
         /// Applies only to enums (not to DTO classes themselves); gets or sets a value indicating that an enum should be treated directly as an int/short/etc, rather

--- a/src/protogen/Program.cs
+++ b/src/protogen/Program.cs
@@ -310,6 +310,7 @@ Parse PROTO_FILES and generate output based on the options given:
   +names={auto|original}      Specify naming convention rules.
   +oneof={default|enum}       Specify whether 'oneof' should generate enums.
   +listset={yes|no}           Specify whether lists should emit setters
+  +required={yes|no}          Specify whether required fields are enforced
   +OPTION=VALUE               Specify a custom OPTION/VALUE pair for the
                               selected code generator.
   --package=PACKAGE           Add a default package (when no package is


### PR DESCRIPTION
This pull request adds a code generation option and a `ProtoContractAttribute.EnforceRequired` flag to both detect and enforce required field presence when:

* getting fields (the getter throws `InvalidOperationException` if the field is unset)
* serializing (serialization throws `ProtoException` if a required field was not serialized)
* deserializing (ditto)

Does the general approach seem ok?

What's missing from this pull request:
* emit support (`FEAT_COMPILER`)
* Visual Basic codegen support

If the approach looks good I can work on implementing those as well.
