### PR TITLE
fix: if the same message type name is in the hierarchy under the same namespace, then get type name error.

### DIFF
--- a/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
@@ -890,6 +890,17 @@ namespace ProtoBuf.Reflection
 
         private string FindNameFromCommonAncestor(IType declaring, IType target, NameNormalizer normalizer)
         {
+            // check if the same message type name is in the hierarchy under the same namespace, and if so, use a fully qualified name
+            var declaringParts = declaring.FullyQualifiedName.Split('.').Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var targetParts = target.FullyQualifiedName.Split('.').Where(x => !string.IsNullOrEmpty(x)).ToList();
+            if (declaringParts.FirstOrDefault() == targetParts.FirstOrDefault())
+            {
+                if (declaringParts.Intersect(targetParts).Count() > 1)
+                {
+                    return $"global::{target.FullyQualifiedName.Substring(1)}";
+                }
+            }
+
             // trivial case; asking for self, or asking for immediate child
             if (ReferenceEquals(declaring, target) || ReferenceEquals(declaring, target.Parent))
             {


### PR DESCRIPTION
I ran into some problems when I used `protogen.exe` to generate my c# code from the `proto` file. My ·proto· file is like this.
proto1.proto
````proto
syntax = "proto2";
package Proto;

message Test {
    message Child1 {

    }
}
proto
````
proto2.proto
````proto
syntax = "proto2";
package Proto;
import "proto1.proto";

message Proto2 {
    message Test {
        message Child2 {
            optional Proto.Test.Child1 child = 1;
        }
    }
}
````
and generated part of the c# code is as follows
````csharp
[global::ProtoBuf.ProtoContract()]
public partial class Child2 : global::ProtoBuf.IExtensible
{
       private global::ProtoBuf.IExtension __pbn__extensionData;
       global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
                    => global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);

       [global::ProtoBuf.ProtoMember(1, Name = @"child")]
       public Test.Child1 Child { get; set; }

}
````
I think it shoud be like this
````csharp
[global::ProtoBuf.ProtoContract()]
public partial class Child2 : global::ProtoBuf.IExtensible
{
       private global::ProtoBuf.IExtension __pbn__extensionData;
       global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
                    => global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);

       [global::ProtoBuf.ProtoMember(1, Name = @"child")]
       public global::Proto.Test.Child1 Child { get; set; }

}
````