### PR TITLE
Tweak CSharpCodeGenerator so that it can be more flexibly subclassed

### DIFF
--- a/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
@@ -787,6 +787,21 @@ namespace ProtoBuf.Reflection
             }
         }
 
+        protected string MakeRelativeName(GeneratorContext ctx, string typeName)
+        {
+            var target = ctx.TryFind<DescriptorProto>(typeName);
+            if (target != null && target.Parent is IType type)
+            {
+                var name = FindNameFromCommonAncestor(type, target, ctx.NameNormalizer);
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    return name;
+                }
+            }
+
+            return Escape(typeName);
+        }
+
         private string GetTypeName(GeneratorContext ctx, FieldDescriptorProto field, out string dataFormat, out bool isMap,
             bool nonNullable = false)
         {

--- a/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CSharpCodeGenerator.cs
@@ -764,7 +764,7 @@ namespace ProtoBuf.Reflection
             }
         }
 
-        private static bool UseArray(FieldDescriptorProto field)
+        protected virtual bool UseArray(FieldDescriptorProto field)
         {
             switch (field.type)
             {

--- a/src/protobuf-net.Reflection/CodeGenerator.cs
+++ b/src/protobuf-net.Reflection/CodeGenerator.cs
@@ -113,6 +113,11 @@ namespace ProtoBuf.Reflection
             => NullIfInherit(obj?.Options?.GetOptions()?.Access)
                 ?? NullIfInherit(GetAccess(obj?.Parent)) ?? Access.Public;
         /// <summary>
+        /// Obtain the access of an item, accounting for the model's hierarchy
+        /// </summary>
+        protected Access GetAccess(ServiceDescriptorProto obj)
+            => NullIfInherit(obj?.Options?.GetOptions()?.Access) ?? Access.Public;
+        /// <summary>
         /// Get the textual name of a given access level
         /// </summary>
         public virtual string GetAccess(Access access)


### PR DESCRIPTION
This PR is along similar lines of #492.

I'm taking a different approach here of leaving the functionality in `protobuf-net.Reflection` untouched, whilst enabling SteamKit to subclass this and tweak the behaviour to our own desires.

In theory this should mean that we have no impact on the potential future gRPC code generation, as you mentioned in the other PR.

See https://github.com/SteamRE/SteamKit/pull/686 for the SteamKit side of this.

Essentially, what we want is to:
- Disable extension generation (already possible)
- Use `List<T>` instead of `T[]` for all repeated fields.
- Emit our own C# interfaces for service generation

I've added our version of `MakeRelativeName` to the class even though it is unused within `protobuf-net.Reflection` itself. This is because implementing it ourselves would require exposing the internal interface `Google.Protobuf.Reflection.IType`, which doesn't seem to me like a very good idea given it's separate namespacing.

For disabling extension generation and list vs array, in theory those could be part of the options dictionary instead of subclassed behaviour, but I have no clue how that plumbing works internally, so this was much easier for me to implement.