### PR TITLE
Scalar value passthru

### DIFF
--- a/src/protobuf-net.Test/Serializers/ScalarValuePassthruTests.cs
+++ b/src/protobuf-net.Test/Serializers/ScalarValuePassthruTests.cs
@@ -1,0 +1,1254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.Serialization;
+using ProtoBuf.Meta;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProtoBuf.unittest.Serializers
+{
+    public sealed class ScalarValuePassthruTests
+    {
+        private readonly ITestOutputHelper _tw;
+
+        public ScalarValuePassthruTests(ITestOutputHelper tw)
+        {
+            _tw = tw;
+        }
+
+        private byte[] SerializeToArray(object obj, RuntimeTypeModel model)
+        {
+            var ms = new MemoryStream();
+            model.Serialize(ms, obj);
+            Assert.NotEqual(0, ms.Length);
+            return ms.ToArray();
+        }
+
+        private static RuntimeTypeModel CreateModelWithIDTypeConfigured()
+        {
+            var model = TypeModel.Create();
+            model.Add(typeof(CustomerID), false).ScalarValuePassthru = true;
+            return model;
+        }
+
+        private static RuntimeTypeModel CreateModelWithScalarValuePassthruInference()
+        {
+            var model = TypeModel.Create();
+            Assert.False(model.InferScalarValuePassthru);
+            model.InferScalarValuePassthru = true;
+            return model;
+        }
+
+        private static RuntimeTypeModel CreatePristineModel()
+        {
+            return TypeModel.Create();
+        }
+
+        private static T DeepClone<T>(T original, RuntimeTypeModel model)
+        {
+            var clone = model.DeepClone(original);
+            return (T)clone;
+        }
+
+
+        [ProtoContract]
+        public sealed class I64_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public CustomerID CustomerID;
+        }
+
+        [ProtoContract]
+        public sealed class I64Raw_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public long StudentID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Roundtrip(bool autoCompile)
+        {
+            var orig = new I64_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            };
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var clone = DeepClone(orig, model);
+            Assert.Equal(10, clone.ID);
+            Assert.Equal(444, clone.CustomerID.ValueNoThrow);
+        }
+
+        // This type has a shape that is recognizable to AutoTuple detection:
+        // Readonly props that are matched by a ctor.
+        public struct DetectScalarValuePassthru_ID
+        {
+            public long Value { get; private set; }
+
+            public DetectScalarValuePassthru_ID(long value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class DetectScalarValuePassthru_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public DetectScalarValuePassthru_ID OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DetectScalarValuePassthru(bool autoCompile)
+        {
+            // Scalar value passthru inference makes some kinds of structs serialize
+            // with scalar value passthru that would otherwise be serialized
+            // by TupleSerializer as a nested structure.
+            // To avoid that kind of breakage, this test ensures tries to make sure
+            // that you only get it when you ask for it.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+
+            {
+                // with passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                model.InferScalarValuePassthru = true;
+                bytesWithPassthruInference = SerializeToArray(new DetectScalarValuePassthru_Message
+                {
+                    ID = 10,
+                    OtherID = new DetectScalarValuePassthru_ID(444),
+                }, model);
+                Assert.True(model[typeof(CustomerID)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new DetectScalarValuePassthru_Message
+                {
+                    ID = 10,
+                    OtherID = new DetectScalarValuePassthru_ID(444),
+                }, model);
+                Assert.False(model[typeof(CustomerID)].ScalarValuePassthru);
+            }
+            Assert.NotEqual(bytesWithPassthruInference, bytesWithoutPassthruInference);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Bytes(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var bytesFromTyped = SerializeToArray(new I64_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            }, model);
+            var bytesFromRaw = SerializeToArray(new I64Raw_Message
+            {
+                ID = 10,
+                StudentID = 444,
+            }, CreatePristineModel());
+            Assert.Equal(bytesFromRaw, bytesFromTyped);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_DefaultBytes_DefaultIsNotOmitted(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            // The default value (when specified or derived) is not written.
+            // Ideally it would behave the same with passthru, but to keep these changes
+            // minimally intrusive to protobuf-net, default values are not derived or handled.
+            // That difference in behavior is probably not so bad, since nullable value types
+            // are thing, and are a usually a better expression of missing values than
+            // default/zero values are.
+            var bytesFromTyped = SerializeToArray(new I64_Message
+            {
+                ID = 10,
+                CustomerID = default(CustomerID),
+            }, model);
+            var bytesFromRaw = SerializeToArray(new I64Raw_Message
+            {
+                ID = 10,
+                StudentID = 0,
+            }, CreatePristineModel());
+            Assert.NotEqual(bytesFromRaw, bytesFromTyped);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_RoundtripDefaultNot0(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model[typeof(I64Raw_Message)][1].DefaultValue = 444L;
+            model.AutoCompile = autoCompile;
+
+            //			model[typeof(I64_Message)][1].DefaultValue = 444;
+            var bytesFromTyped = SerializeToArray(new I64_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            }, model);
+
+            var bytesFromRaw = SerializeToArray(new I64Raw_Message
+            {
+                ID = 10,
+                StudentID = 444,
+            }, model);
+            Assert.Equal(bytesFromRaw, bytesFromTyped);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_RoundtripDefault(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var clone = DeepClone(new I64_Message
+            {
+                ID = 10,
+                CustomerID = default(CustomerID),
+            }, model);
+            Assert.Equal(default(CustomerID), clone.CustomerID);
+        }
+
+        [Fact]
+        public void I64_Schema()
+        {
+            var orig = new I64_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            };
+            var model = CreateModelWithIDTypeConfigured();
+            var schema = model.GetSchema(orig.GetType());
+
+            _tw.WriteLine("schema:");
+            _tw.WriteLine(schema);
+            // Note the absense of a message named CustomerID, and the use of int64 instead of CustomerID for the CustomerID field.
+            // Also, no default value is specified, in contrast to the plain in64 ID field.
+            // That is not by design, rather it is to keep the required changes to protobuf-net minimal.
+            Assert.Equal(@"syntax = ""proto2"";
+package ProtoBuf.unittest.Serializers;
+
+message I64_Message {
+   optional int64 ID = 1 [default = 0];
+   optional int64 CustomerID = 10;
+}
+", schema);
+            Assert.Equal(@"syntax = ""proto3"";
+package ProtoBuf.unittest.Serializers;
+
+message I64_Message {
+   int64 ID = 1;
+   int64 CustomerID = 10;
+}
+", model.GetSchema(orig.GetType(), ProtoSyntax.Proto3));
+        }
+
+        [ProtoContract]
+        public sealed class I64Prop_Message
+        {
+            [ProtoMember(1)] public long ID { get; set; }
+
+            [ProtoMember(10)] public CustomerID CustomerID { get; set; }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64Prop_Roundtrip(bool autoCompile)
+        {
+            // most of the other tests are using fields. Using properties should behave the same.
+            // We do not replicate all of the test with variations with properties, though;
+            // instead we trust that the system handles them the same.
+            // So we'll just have this small test.
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var clone = DeepClone(new I64Prop_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            }, model);
+            Assert.Equal(10, clone.ID);
+            Assert.Equal(444, clone.CustomerID.ValueNoThrow);
+        }
+
+
+        [ProtoContract]
+        public sealed class I64_Nullable_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public CustomerID? CustomerID;
+        }
+
+        [ProtoContract]
+        public sealed class I64Raw_Nullable_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public long? StudentID;
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Roundtrip_Nullable(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            // Using non-null value.
+
+            var clone = DeepClone(new I64_Nullable_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            }, model);
+            Assert.Equal(10, clone.ID);
+            Assert.Equal((CustomerID)444, clone.CustomerID);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_RoundtripDefault_Nullable(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            {
+                // Roundtrip null zero/default value.
+                var i64clone = DeepClone(new I64_Nullable_Message
+                {
+                    ID = 10,
+                    CustomerID = null,
+                }, model);
+                var i64rawclone = DeepClone(new I64Raw_Nullable_Message
+                {
+                    ID = 10,
+                    StudentID = null,
+                }, CreatePristineModel());
+                Assert.Null(i64clone.CustomerID);
+                Assert.Null(i64rawclone.StudentID);
+            }
+            {
+                // Roundtrip non-null zero/default value.
+                var i64clone = DeepClone(new I64_Nullable_Message
+                {
+                    ID = 10,
+                    CustomerID = default(CustomerID),
+                }, model);
+                var i64rawclone = DeepClone(new I64Raw_Nullable_Message
+                {
+                    ID = 10,
+                    StudentID = default(long),
+                }, CreatePristineModel());
+                Assert.Equal(default(CustomerID), i64clone.CustomerID);
+                Assert.Equal(default(long), i64rawclone.StudentID);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Bytes_Nullable(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            {
+                // Using non-null value.
+                var bytesFromTyped = SerializeToArray(new I64_Nullable_Message
+                {
+                    ID = 10,
+                    CustomerID = (CustomerID)444,
+                }, model);
+                var bytesFromRaw = SerializeToArray(new I64Raw_Nullable_Message
+                {
+                    ID = 10,
+                    StudentID = 444,
+                }, CreatePristineModel());
+                Assert.Equal(bytesFromRaw, bytesFromTyped);
+            }
+            {
+                // Using null value.
+                var bytesFromTyped = SerializeToArray(new I64_Nullable_Message
+                {
+                    ID = 10,
+                    CustomerID = null,
+                }, model);
+                var bytesFromRaw = SerializeToArray(new I64Raw_Nullable_Message
+                {
+                    ID = 10,
+                    StudentID = null,
+                }, CreatePristineModel());
+                Assert.Equal(bytesFromRaw, bytesFromTyped);
+            }
+        }
+
+        [Fact]
+        public void I64_Schema_Nullable()
+        {
+            var orig = new I64_Nullable_Message
+            {
+                ID = 10,
+                CustomerID = (CustomerID)444,
+            };
+            var model = CreateModelWithIDTypeConfigured();
+
+            var schema = model.GetSchema(orig.GetType());
+            _tw.WriteLine("schema:");
+            _tw.WriteLine(schema);
+            Assert.Equal(@"syntax = ""proto2"";
+package ProtoBuf.unittest.Serializers;
+
+message I64_Nullable_Message {
+   optional int64 ID = 1 [default = 0];
+   optional int64 CustomerID = 10;
+}
+", schema);
+        }
+
+
+        [ProtoContract]
+        public sealed class I64_List_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public CustomerID[] CustomerIDs;
+        }
+
+        [ProtoContract]
+        public sealed class I64Raw_List_Message
+        {
+            [ProtoMember(1)] public long ID;
+
+            [ProtoMember(10)] public long[] StudentIDs;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Roundtrip_List(bool autoCompile)
+        {
+            var orig = new I64_List_Message
+            {
+                ID = 10,
+                CustomerIDs = new[] { (CustomerID)444, (CustomerID)555 },
+            };
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var clone = DeepClone(orig, model);
+            Assert.Equal(10, clone.ID);
+            Assert.Equal(2, clone.CustomerIDs.Length);
+            Assert.Equal((CustomerID)444, clone.CustomerIDs[0]);
+            Assert.Equal((CustomerID)555, clone.CustomerIDs[1]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_RoundtripDefault_List(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            // Clone raw longs first, to establish it's behavior.
+            var rawclone = DeepClone(new I64Raw_List_Message
+            {
+                ID = 10,
+                StudentIDs = new[] { 444L, default(long) },
+            }, CreatePristineModel());
+            Assert.Equal(2, rawclone.StudentIDs.Length);
+            Assert.Equal(444, rawclone.StudentIDs[0]);
+            Assert.Equal(default(long), rawclone.StudentIDs[1]);
+
+
+            // Now check that we get the same results.
+
+            var clone = DeepClone(new I64_List_Message
+            {
+                ID = 10,
+                CustomerIDs = new[] { (CustomerID)444, default(CustomerID) },
+            }, model);
+            Assert.Equal(10, clone.ID);
+            Assert.Equal(2, clone.CustomerIDs.Length);
+            Assert.Equal((CustomerID)444, clone.CustomerIDs[0]);
+            Assert.Equal(default(CustomerID), clone.CustomerIDs[1]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_Bytes_List(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var bytesFromTyped = SerializeToArray(new I64_List_Message
+            {
+                ID = 10,
+                CustomerIDs = new[] { (CustomerID)444, (CustomerID)555 },
+            }, model);
+            var bytesFromRaw = SerializeToArray(new I64Raw_List_Message
+            {
+                ID = 10,
+                StudentIDs = new[] { 444L, 555L },
+            }, CreatePristineModel());
+            Assert.Equal(bytesFromRaw, bytesFromTyped);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I64_BytesDefault_List(bool autoCompile)
+        {
+            var model = CreateModelWithIDTypeConfigured();
+            model.AutoCompile = autoCompile;
+
+            var bytesFromTyped = SerializeToArray(new I64_List_Message
+            {
+                ID = 10,
+                CustomerIDs = new[] { (CustomerID)444, default(CustomerID) },
+            }, model);
+            var bytesFromRaw = SerializeToArray(new I64Raw_List_Message
+            {
+                ID = 10,
+                StudentIDs = new[] { 444L, default(long) },
+            }, CreatePristineModel());
+            Assert.Equal(bytesFromRaw, bytesFromTyped);
+        }
+
+        [Fact]
+        public void I64_Schema_List()
+        {
+            var orig = new I64_List_Message
+            {
+                ID = 10,
+                CustomerIDs = new[] { (CustomerID)444, (CustomerID)555 },
+            };
+            var model = CreateModelWithIDTypeConfigured();
+            var schema = model.GetSchema(orig.GetType());
+
+            _tw.WriteLine("schema:");
+            _tw.WriteLine(schema);
+            Assert.Equal(@"syntax = ""proto2"";
+package ProtoBuf.unittest.Serializers;
+
+message I64_List_Message {
+   optional int64 ID = 1 [default = 0];
+   repeated int64 CustomerIDs = 10;
+}
+", schema);
+        }
+
+        [Fact]
+        public void I64Raw_Schema_List()
+        {
+            // This test is mainly here to know/document the schema that is generated for plain int64s.
+            var orig = new I64Raw_List_Message
+            {
+                ID = 10,
+                StudentIDs = new[] { 444L, 555L },
+            };
+            var model = CreateModelWithIDTypeConfigured();
+            var schema = model.GetSchema(orig.GetType());
+
+            _tw.WriteLine("schema:");
+            _tw.WriteLine(schema);
+        }
+
+        public struct I32_ID
+        {
+            public int Value { get; private set; }
+
+            public I32_ID(int value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class I32_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public I32_ID OtherID;
+        }
+
+        [ProtoContract]
+        public sealed class I32Raw_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public int OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I32_AllInOne(bool autoCompile)
+        {
+            // most of the other tests are using int64. Since the impl doesn't make a distinction betweeen
+            // different raw types, other raw types should behave the same.
+            // So we'll just have this small test of int32 to show that it probably also works for all
+            // the other raw types. Exept for string, for which we also have a test, since it is
+            // a reference type.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesForRawI32;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                bytesWithPassthruInference = SerializeToArray(new I32_Message
+                {
+                    ID = 10,
+                    OtherID = new I32_ID(444),
+                }, model);
+                Assert.True(model[typeof(I32_ID)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new I32_Message
+                {
+                    ID = 10,
+                    OtherID = new I32_ID(444),
+                }, model);
+                Assert.False(model[typeof(I32_ID)].ScalarValuePassthru);
+            }
+            {
+                // raw i32.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI32 = SerializeToArray(new I32Raw_Message
+                {
+                    ID = 10,
+                    OtherID = 444,
+                }, model);
+            }
+
+            var clone = DeepClone(new I32_Message
+            {
+                ID = 10,
+                OtherID = new I32_ID(444),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal(444, clone.OtherID.Value);
+
+            Assert.Equal(bytesForRawI32, bytesWithPassthruInference);
+            Assert.NotEqual(bytesWithPassthruInference, bytesWithoutPassthruInference);
+        }
+
+        public struct I32N_ID
+        {
+            public int? Value { get; private set; }
+
+            public I32N_ID(int value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class I32N_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public I32N_ID OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void I32N_NotSupported(bool autoCompile)
+        {
+            // The purpose of scalar value passthru is to wrap "primitive" types.
+            // It is not obvious that it makes sense to wrap a nullable primitive type.
+            // So for now at least, this test ensures that we do not commit to supporting that.
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                var ex = Assert.Throws<InvalidOperationException>(() => SerializeToArray(new I32N_Message
+                {
+                    ID = 10,
+                    OtherID = new I32N_ID(444),
+                }, model));
+                Assert.Contains("No serializer defined for type:", ex.Message);
+            }
+        }
+
+        public struct String_ID
+        {
+            public string Value { get; private set; }
+
+            public String_ID(string value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class String_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public String_ID OtherID;
+        }
+
+        [ProtoContract]
+        public sealed class StringRaw_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public string OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void String_AllInOne(bool autoCompile)
+        {
+            // See I32_AllInOne.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesForRawString;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                bytesWithPassthruInference = SerializeToArray(new String_Message
+                {
+                    ID = 10,
+                    OtherID = new String_ID("x1"),
+                }, model);
+                Assert.True(model[typeof(String_ID)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new String_Message
+                {
+                    ID = 10,
+                    OtherID = new String_ID("x1"),
+                }, model);
+                Assert.False(model[typeof(String_ID)].ScalarValuePassthru);
+            }
+            {
+                // raw i32.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawString = SerializeToArray(new StringRaw_Message
+                {
+                    ID = 10,
+                    OtherID = "x1",
+                }, model);
+            }
+
+            var clone = DeepClone(new String_Message
+            {
+                ID = 10,
+                OtherID = new String_ID("x1"),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal("x1", clone.OtherID.Value);
+            _tw.WriteLine("Serialized base64: " + Convert.ToBase64String(bytesWithPassthruInference));
+            Assert.Equal(bytesForRawString, bytesWithPassthruInference);
+            Assert.NotEqual(bytesWithPassthruInference, bytesWithoutPassthruInference);
+        }
+
+        [ProtoContract]
+        public struct ProtoContract_ID
+        {
+            [ProtoMember(1)]
+            public int Value { get; private set; }
+
+            public ProtoContract_ID(int value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class ProtoContract_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public ProtoContract_ID OtherID;
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProtoContract_AllInOne(bool autoCompile)
+        {
+            // We want to check the effect of applying ProtoContract and ProtoMember to
+            // a type that could otherwise look like a wrapper type:
+            // In that case we should just do what we have  "always" done with such a type: Treat it as a classic contract.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesWithExplicitPassthru;
+            byte[] bytesForRawI32;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                bytesWithPassthruInference = SerializeToArray(new ProtoContract_Message
+                {
+                    ID = 10,
+                    OtherID = new ProtoContract_ID(444),
+                }, model);
+                Assert.False(model[typeof(ProtoContract_ID)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new ProtoContract_Message
+                {
+                    ID = 10,
+                    OtherID = new ProtoContract_ID(444),
+                }, model);
+                Assert.False(model[typeof(ProtoContract_ID)].ScalarValuePassthru);
+            }
+            {
+                // with passthru for the type explicitly enabled: What ought to take precedence?
+                // At least this piece of code documents the current behavior.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                model[typeof(ProtoContract_ID)].ScalarValuePassthru = true;
+                bytesWithExplicitPassthru = SerializeToArray(new ProtoContract_Message
+                {
+                    ID = 10,
+                    OtherID = new ProtoContract_ID(444),
+                }, model);
+            }
+            {
+                // raw i32.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI32 = SerializeToArray(new I32Raw_Message
+                {
+                    ID = 10,
+                    OtherID = 444,
+                }, model);
+            }
+
+            var clone = DeepClone(new I32_Message
+            {
+                ID = 10,
+                OtherID = new I32_ID(444),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal(444, clone.OtherID.Value);
+
+            Assert.NotEqual(bytesForRawI32, bytesWithPassthruInference);
+            Assert.Equal(bytesWithPassthruInference, bytesWithoutPassthruInference);
+            Assert.Equal(bytesForRawI32, bytesWithExplicitPassthru);
+        }
+
+        [ProtoContract]
+        public struct DataContract_ID
+        {
+            [DataMember]
+            public int Value { get; private set; }
+
+            public DataContract_ID(int value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class DataContract_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public DataContract_ID OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataContract_AllInOne(bool autoCompile)
+        {
+            // We want to check the effect of applying ProtoContract and ProtoMember to
+            // a type that could otherwise look like a wrapper type:
+            // In that case we should just do what we have  "always" done with such a type: Treat it as a classic contract.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesWithExplicitPassthru;
+            byte[] bytesForRawI32;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                bytesWithPassthruInference = SerializeToArray(new DataContract_Message
+                {
+                    ID = 10,
+                    OtherID = new DataContract_ID(444),
+                }, model);
+                Assert.False(model[typeof(DataContract_ID)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new DataContract_Message
+                {
+                    ID = 10,
+                    OtherID = new DataContract_ID(444),
+                }, model);
+                Assert.False(model[typeof(DataContract_ID)].ScalarValuePassthru);
+            }
+            {
+                // with passthru for the type explicitly enabled: What ought to take precedence?
+                // At least this piece of code documents the current behavior.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                model[typeof(DataContract_ID)].ScalarValuePassthru = true;
+                bytesWithExplicitPassthru = SerializeToArray(new DataContract_Message
+                {
+                    ID = 10,
+                    OtherID = new DataContract_ID(444),
+                }, model);
+            }
+            {
+                // raw i32.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI32 = SerializeToArray(new I32Raw_Message
+                {
+                    ID = 10,
+                    OtherID = 444,
+                }, model);
+            }
+
+            var clone = DeepClone(new I32_Message
+            {
+                ID = 10,
+                OtherID = new I32_ID(444),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal(444, clone.OtherID.Value);
+
+            Assert.NotEqual(bytesForRawI32, bytesWithPassthruInference);
+            Assert.Equal(bytesWithPassthruInference, bytesWithoutPassthruInference);
+            Assert.Equal(bytesForRawI32, bytesWithExplicitPassthru);
+        }
+
+        public struct Surrogate_ID_TheSurrogate
+        {
+            public int Value { get; private set; }
+
+            public Surrogate_ID_TheSurrogate(int value) => Value = value;
+
+            public static explicit operator Surrogate_ID_TheSurrogate(Surrogate_Using value)
+            {
+                return new Surrogate_ID_TheSurrogate(value.Field1 * 100 + value.Field2);
+            }
+
+            public static explicit operator Surrogate_Using(Surrogate_ID_TheSurrogate value)
+            {
+                return new Surrogate_Using(value.Value / 100, value.Value % 100);
+            }
+        }
+
+        [ProtoContract(Surrogate = typeof(Surrogate_ID_TheSurrogate))]
+        public struct Surrogate_Using
+        {
+            public int Field1 { get; private set; }
+            public int Field2 { get; private set; }
+
+            public Surrogate_Using(int field1, int field2)
+            {
+                Field1 = field1;
+                Field2 = field2;
+            }
+        }
+
+        [ProtoContract]
+        public sealed class Surrogate_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public Surrogate_Using OtherUsing;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Surrogate_AllInOne(bool autoCompile)
+        {
+            // We would like for surrogate types to also be passthru serializable.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesForRawI32;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                bytesWithPassthruInference = SerializeToArray(new Surrogate_Message
+                {
+                    ID = 10,
+                    OtherUsing = new Surrogate_Using(5, 7),
+                }, model);
+                Assert.False(model[typeof(Surrogate_Using)].ScalarValuePassthru);
+                Assert.True(model[typeof(Surrogate_ID_TheSurrogate)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithoutPassthruInference = SerializeToArray(new Surrogate_Message
+                {
+                    ID = 10,
+                    OtherUsing = new Surrogate_Using(5, 7),
+                }, model);
+                Assert.False(model[typeof(Surrogate_Using)].ScalarValuePassthru);
+                Assert.False(model[typeof(Surrogate_ID_TheSurrogate)].ScalarValuePassthru);
+            }
+            {
+                // raw i32, which is what we want the surrogate to serialize as.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI32 = SerializeToArray(new I32Raw_Message
+                {
+                    ID = 10,
+                    OtherID = 5 * 100 + 7,
+                }, model);
+            }
+
+            var clone = DeepClone(new Surrogate_Message
+            {
+                ID = 10,
+                OtherUsing = new Surrogate_Using(5, 7),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal(5, clone.OtherUsing.Field1);
+            Assert.Equal(7, clone.OtherUsing.Field2);
+
+            _tw.WriteLine("Serialized base64, surr: " + Convert.ToBase64String(bytesWithPassthruInference));
+            _tw.WriteLine("Serialized base64, i32raw: " + Convert.ToBase64String(bytesForRawI32));
+
+            Assert.Equal(bytesForRawI32, bytesWithPassthruInference);
+            Assert.NotEqual(bytesWithPassthruInference, bytesWithoutPassthruInference);
+
+            _tw.WriteLine("schema:");
+            var schema = CreateModelWithScalarValuePassthruInference().GetSchema(typeof(Surrogate_Message));
+            _tw.WriteLine(schema);
+            Assert.Equal(@"syntax = ""proto2"";
+package ProtoBuf.unittest.Serializers;
+
+message Surrogate_Message {
+   optional int64 ID = 1 [default = 0];
+   optional int32 OtherUsing = 2;
+}
+", schema);
+
+        }
+
+        [ProtoContract]
+        public sealed class MapKeyRaw_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public Dictionary<long, string> TheMap;
+        }
+        [ProtoContract]
+        public sealed class MapKey_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public Dictionary<CustomerID, string> TheMap;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MapKey_NotImplemented(bool autoCompile)
+        {
+            // This test just makes sure that some kind of exception happen when using scalar value passthru
+            // for map keys, until such use might be supported.
+            // It seems that supporting it is mainly a question of accepting such types as keys,
+            // maybe checking that they implement iequatable, and finally making sure that
+            // ScalarValuePassthruDecorator is being used.
+
+            byte[] bytesWithPassthruInference;
+            byte[] bytesWithoutPassthruInference;
+            byte[] bytesForRawI64;
+
+            {
+                // with passthru inference.
+                var model = CreateModelWithScalarValuePassthruInference();
+                model.AutoCompile = autoCompile;
+
+                Action testCode = () =>
+                {
+                    bytesWithPassthruInference = SerializeToArray(new MapKey_Message
+                    {
+                        ID = 10,
+                        TheMap = new Dictionary<CustomerID, string> { { (CustomerID)42, "hey" } }
+                    }, model);
+                };
+                if (autoCompile)
+                {
+                    var ex = Assert.Throws<InvalidOperationException>(testCode);
+                    Assert.Contains(" was not possible to prepare a serializer for:", ex.Message);
+                }
+                else
+                {
+                    var ex = Assert.Throws<NotSupportedException>(testCode);
+                }
+                // Assert.False(model[typeof(Surrogate_Using)].ScalarValuePassthru);
+                // Assert.True(model[typeof(Surrogate_ID_TheSurrogate)].ScalarValuePassthru);
+            }
+            {
+                // without passthru inference.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    bytesWithoutPassthruInference = SerializeToArray(new MapKey_Message
+                    {
+                        ID = 10,
+                        TheMap = new Dictionary<CustomerID, string> { { (CustomerID)42, "hey" } }
+                    }, model);
+                });
+                Assert.Contains("No serializer defined for type:", ex.Message);
+                // Assert.False(model[typeof(Surrogate_Using)].ScalarValuePassthru);
+                // Assert.False(model[typeof(Surrogate_ID_TheSurrogate)].ScalarValuePassthru);
+            }
+            {
+                // raw i64, which is what we want the surrogate to serialize as.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI64 = SerializeToArray(new MapKeyRaw_Message
+                {
+                    ID = 10,
+                    TheMap = new Dictionary<long, string> { { 42, "hey" } }
+                }, model);
+            }
+
+            //var clone = DeepClone(new Surrogate_Message
+            //{
+            //    ID = 10,
+            //    OtherUsing = new Surrogate_Using(5, 7),
+            //}, CreateModelWithScalarValuePassthruInference());
+            //Assert.Equal(5, clone.OtherUsing.Field1);
+            //Assert.Equal(7, clone.OtherUsing.Field2);
+
+            //_tw.WriteLine("Serialized base64, surr: " + Convert.ToBase64String(bytesWithPassthruInference));
+            //_tw.WriteLine("Serialized base64, i32raw: " + Convert.ToBase64String(bytesForRawI64));
+
+            //Assert.Equal(bytesForRawI64, bytesWithPassthruInference);
+            //Assert.NotEqual(bytesWithPassthruInference, bytesWithoutPassthruInference);
+
+            //_tw.WriteLine("schema:");
+            //var schema = CreateModelWithScalarValuePassthruInference().GetSchema(typeof(Surrogate_Message));
+            //_tw.WriteLine(schema);
+            //Assert.Equal(@"syntax = ""proto2"";
+            //package ProtoBuf.unittest.Serializers;
+            
+            //message Surrogate_Message {
+            //   optional int64 ID = 1 [default = 0];
+            //   optional int32 OtherUsing = 2;
+            //}
+            //", schema);
+
+        }
+
+
+        public struct UnsupportedPassthruType_ID
+        {
+            public I64_Message Value { get; private set; }
+
+            public UnsupportedPassthruType_ID(I64_Message value) => Value = value;
+        }
+
+        [ProtoContract]
+        public sealed class UnsupportedPassthruType_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2)] public UnsupportedPassthruType_ID OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void UnsupportedPassthruType_AllInOne(bool autoCompile)
+        {
+            // Scalar value passthru was made for types that wrap primitive types.
+            // This test is here to poke into what happens when we encounter a type
+            // that wraps something else.
+            // In this test it wraps a "real" message type, and the wrapper type 
+            // will get ValueTuple handling, but that is kind of besides the point.
+
+            var model = CreateModelWithScalarValuePassthruInference();
+            model.AutoCompile = autoCompile;
+
+            SerializeToArray(new UnsupportedPassthruType_Message
+            {
+                ID = 10,
+                OtherID = new UnsupportedPassthruType_ID(new I64_Message { ID = 10 }),
+            }, model);
+            Assert.False(model[typeof(UnsupportedPassthruType_ID)].ScalarValuePassthru);
+        }
+
+
+        [DebuggerDisplay("{Value,nq}")]
+        public struct CustomerID : IEquatable<CustomerID>
+        {
+            private long _value;
+
+            public CustomerID(long value) => _value = value;
+
+            public long Value => _value != default ? _value : throw new InvalidOperationException("ID has no value. Does this value come from an unitialized field?");
+            public long ValueNoThrow => _value;
+
+            public override string ToString() => Value.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
+
+            public override int GetHashCode() => _value.GetHashCode();
+
+            public bool Equals(CustomerID other) => other._value == this._value;
+            public override bool Equals(object obj) => obj is CustomerID v && Equals(v);
+
+            public static bool operator ==(CustomerID x, CustomerID y) => x.Equals(y);
+            public static bool operator !=(CustomerID x, CustomerID y) => !x.Equals(y);
+
+            public static explicit operator CustomerID(long value) => new CustomerID(value);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Serializers/ScalarValuePassthruTests.cs
+++ b/src/protobuf-net.Test/Serializers/ScalarValuePassthruTests.cs
@@ -862,13 +862,6 @@ message I64_List_Message {
                 }, model);
             }
 
-            var clone = DeepClone(new I32_Message
-            {
-                ID = 10,
-                OtherID = new I32_ID(444),
-            }, CreateModelWithScalarValuePassthruInference());
-            Assert.Equal(444, clone.OtherID.Value);
-
             Assert.NotEqual(bytesForRawI32, bytesWithPassthruInference);
             Assert.Equal(bytesWithPassthruInference, bytesWithoutPassthruInference);
             Assert.Equal(bytesForRawI32, bytesWithExplicitPassthru);
@@ -932,6 +925,54 @@ message I64_List_Message {
             Assert.Equal(444, clone.OtherID.Value);
 
             Assert.Equal(bytesForRawI32, bytesWithProtoScalar);
+        }
+
+        [ProtoContract]
+        public sealed class DataFormat_FromProtoMember_Message
+        {
+            [ProtoMember(1)] public long ID;
+            [ProtoMember(2, DataFormat = DataFormat.ZigZag)] public ProtoScalar_ID OtherID;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataFormat_FromProtoMember(bool autoCompile)
+        {
+            byte[] bytesWithMemberZigZag;
+            byte[] bytesForRawI32;
+
+            {
+                // with ProtoScalar.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesWithMemberZigZag = SerializeToArray(new DataFormat_FromProtoMember_Message
+                {
+                    ID = 10,
+                    OtherID = new ProtoScalar_ID(444),
+                }, model);
+            }
+            {
+                // raw i32.
+                var model = CreatePristineModel();
+                model.AutoCompile = autoCompile;
+
+                bytesForRawI32 = SerializeToArray(new I32Raw_Message
+                {
+                    ID = 10,
+                    OtherID = 444,
+                }, model);
+            }
+
+            var clone = DeepClone(new DataFormat_FromProtoMember_Message
+            {
+                ID = 10,
+                OtherID = new ProtoScalar_ID(444),
+            }, CreateModelWithScalarValuePassthruInference());
+            Assert.Equal(444, clone.OtherID.Value);
+
+            Assert.NotEqual(bytesForRawI32, bytesWithMemberZigZag);
         }
 
         [ProtoScalar]

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -631,7 +631,11 @@ namespace ProtoBuf.Meta
 
                 if (fullAttributeTypeName == "ProtoBuf.ProtoScalarAttribute")
                 {
+                    var dataFormat = DataFormat.Default;
+                    GetDataFormat(ref dataFormat, item, nameof(ProtoScalarAttribute.DataFormat));
+
                     ScalarValuePassthru = true;
+                    ScalarValuePassthruDataFormat = dataFormat;
                 }
                 if (fullAttributeTypeName == "System.Runtime.Serialization.DataContractAttribute")
                 {
@@ -1740,6 +1744,20 @@ namespace ProtoBuf.Meta
         {
             get { return HasFlag(OPTIONS_ScalarValuePassThru); }
             set { SetFlag(OPTIONS_ScalarValuePassThru, value, true); }
+        }
+
+        DataFormat _scalarValuePassthruDataFormat = DataFormat.Default;
+
+        /// <summary>
+        /// </summary>
+        public DataFormat ScalarValuePassthruDataFormat
+        {
+            get { return _scalarValuePassthruDataFormat; }
+            set
+            {
+                ThrowIfFrozen();
+                _scalarValuePassthruDataFormat = value;
+            }
         }
 
         /// <summary>

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -5,6 +5,7 @@ using System.Text;
 using ProtoBuf.Serializers;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 #if PROFILE259
 using System.Linq;
@@ -628,6 +629,10 @@ namespace ProtoBuf.Meta
                     }
                 }
 
+                if (fullAttributeTypeName == "ProtoBuf.ProtoScalarAttribute")
+                {
+                    ScalarValuePassthru = true;
+                }
                 if (fullAttributeTypeName == "System.Runtime.Serialization.DataContractAttribute")
                 {
                     if (name == null && item.TryGet("Name", out tmp)) name = (string)tmp;
@@ -2189,6 +2194,13 @@ namespace ProtoBuf.Meta
             }
 
             if (model.TryGetBasicTypeSerializer(fieldType) == null)
+            {
+                // This limitation os probably not necessary. It is mainly here to limit scope that
+                // we are committing ourselves to.
+                error = nameof(MetaType.ScalarValuePassthru) + " only works for types that wrap simple types.";
+                return null;
+            }
+            if (Helpers.IsValueType(fieldType) && Helpers.GetUnderlyingType(fieldType) != null)
             {
                 // This limitation os probably not necessary. It is mainly here to limit scope that
                 // we are committing ourselves to.

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -33,7 +33,8 @@ namespace ProtoBuf.Meta
            OPTIONS_AllowParseableTypes = 64,
            OPTIONS_AutoAddProtoContractTypesOnly = 128,
            OPTIONS_IncludeDateTimeKind = 256,
-           OPTIONS_InternStrings = 512;
+           OPTIONS_InternStrings = 512,
+           OPTIONS_InferScalarValuePassthru = 1024;
 
         private bool GetOption(ushort option)
         {
@@ -58,6 +59,19 @@ namespace ProtoBuf.Meta
         {
             get { return GetOption(OPTIONS_InferTagFromNameDefault); }
             set { SetOption(OPTIONS_InferTagFromNameDefault, value); }
+        }
+
+        /// <summary>
+        /// Global default that enables/disables detection of strongly typed wrapper types
+        /// of primitive types, such as a custom "CustomerID" struct that might simply contain an
+        /// int64, instead of using int64 values directly.
+        /// When a field with such a type is detected, the field is serialized as if it
+        /// was just that in64 value, rather than as a nested structure.
+        /// </summary>
+        public bool InferScalarValuePassthru
+        {
+            get { return GetOption(OPTIONS_InferScalarValuePassthru); }
+            set { SetOption(OPTIONS_InferScalarValuePassthru, value); }
         }
 
         /// <summary>
@@ -265,6 +279,7 @@ namespace ProtoBuf.Meta
                 {
                     MetaType tmp = metaTypesArr[i];
                     if (tmp.IsList && tmp != primaryType) continue;
+                    if (tmp.ScalarValuePassthru) continue;
                     tmp.WriteSchema(bodyBuilder, 0, ref imports, syntax);
                 }
             }
@@ -1879,7 +1894,14 @@ namespace ProtoBuf.Meta
                     imports |= CommonImports.Bcl;
                     return ".bcl.NetObjectProxy";
                 }
-                return this[effectiveType].GetSurrogateOrBaseOrSelf(true).GetSchemaTypeName();
+
+                var surrogateOrBaseOrSelf = this[effectiveType].GetSurrogateOrBaseOrSelf(true);
+                if (surrogateOrBaseOrSelf.ScalarValuePassthru)
+                {
+                    var singleField = surrogateOrBaseOrSelf.GetScalarPassthruSingleField();
+                    return GetSchemaTypeName(Helpers.GetMemberType(singleField), dataFormat, false, false, ref imports);
+                }
+                return surrogateOrBaseOrSelf.GetSchemaTypeName();
             }
             else
             {

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -779,7 +779,8 @@ namespace ProtoBuf.Meta
                             var fromSurrogate = SurrogateSerializer.GetConversion(meta.Type, sos.Type, false);
 
                             var singleField = sos.GetScalarPassthruSingleField();
-                            var primitiveTail = TryGetCoreSerializer(model, dataFormat,
+                            var primitiveTail = TryGetCoreSerializer(model,
+                                dataFormat != DataFormat.Default ? dataFormat : sos.ScalarValuePassthruDataFormat,
                                 Helpers.GetMemberType(singleField), out defaultWireType, false, false, false, false);
 
                             return new ScalarValuePassthruFakeDecorator(toSurrogate, fromSurrogate, type, singleField, primitiveTail);
@@ -788,7 +789,8 @@ namespace ProtoBuf.Meta
                         if (meta.ScalarValuePassthru)
                         {
                             var singleField = meta.GetScalarPassthruSingleField();
-                            var primitiveTail = TryGetCoreSerializer(model, dataFormat,
+                            var primitiveTail = TryGetCoreSerializer(model,
+                                dataFormat != DataFormat.Default ? dataFormat : meta.ScalarValuePassthruDataFormat,
                                 Helpers.GetMemberType(singleField), out defaultWireType, false, false, false, false);
 
                             return new ScalarValuePassthruFakeDecorator(null, null, type, singleField, primitiveTail);

--- a/src/protobuf-net/ProtoScalarAttribute.cs
+++ b/src/protobuf-net/ProtoScalarAttribute.cs
@@ -14,6 +14,7 @@ namespace ProtoBuf
         AllowMultiple = false, Inherited = true)]
     public sealed class ProtoScalarAttribute : Attribute
     {
+        public DataFormat DataFormat { get; set; }
     }
 }
 

--- a/src/protobuf-net/ProtoScalarAttribute.cs
+++ b/src/protobuf-net/ProtoScalarAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace ProtoBuf
+{
+    /// <summary>
+    /// Declares that the value type to which it is applied is a strongly typed wrapper
+    /// for a single, primitive type: For example a "CustomerID" struct that simply contains an
+    /// int64. 
+    /// Fields having that strong type are serialized as if it had just been just that in64
+    /// value, rather than as a nested structure.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct,
+        AllowMultiple = false, Inherited = true)]
+    public sealed class ProtoScalarAttribute : Attribute
+    {
+    }
+}
+

--- a/src/protobuf-net/Serializers/ScalarValuePassthruDecorator.cs
+++ b/src/protobuf-net/Serializers/ScalarValuePassthruDecorator.cs
@@ -1,0 +1,163 @@
+﻿
+using System.Reflection;
+using ProtoBuf.Meta;
+#if !NO_RUNTIME
+using System;
+
+namespace ProtoBuf.Serializers
+{
+    /// <summary>
+    /// This is not really a serializer; rather, it is a tuple of two serialisers: 1. A <see cref="ScalarValuePassthruDecorator"/>,
+    /// 2. A primitive serializer.
+    /// They are wrapped up in this type because it is what <see cref="ValueMember.TryGetCoreSerializer"/> returns.
+    /// </summary>
+    sealed class ScalarValuePassthruFakeDecorator : ProtoDecoratorBase
+    {
+        private readonly MethodInfo _toSurrogate;
+        private readonly MethodInfo _fromSurrogate;
+        private readonly Type _strongType;
+        private readonly FieldInfo _singleField;
+
+        public ScalarValuePassthruFakeDecorator(MethodInfo toSurrogate, MethodInfo fromSurrogate, Type strongType, FieldInfo singleField, IProtoSerializer primitiveTypeTail) :
+            base(primitiveTypeTail)
+        {
+            _toSurrogate = toSurrogate;
+            _fromSurrogate = fromSurrogate;
+            _strongType = strongType;
+            _singleField = singleField;
+        }
+
+        public ProtoDecoratorBase GetStronglyTypedDecorator(IProtoSerializer stronglyTypedTail)
+        {
+            return new ScalarValuePassthruDecorator(_toSurrogate, _fromSurrogate, _strongType, _singleField, stronglyTypedTail);
+        }
+
+        public IProtoSerializer PrimitiveTypeSerializer => Tail;
+
+        public override Type ExpectedType => throw new NotSupportedException();
+        public override void Write(ProtoWriter dest, ref ProtoWriter.State state, object value) => throw new NotSupportedException();
+
+        public override object Read(ProtoReader source, ref ProtoReader.State state, object value) => throw new NotSupportedException();
+
+#if FEAT_COMPILER
+        protected override void EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom) => throw new NotSupportedException();
+
+        protected override void EmitRead(Compiler.CompilerContext ctx, Compiler.Local valueFrom) => throw new NotSupportedException();
+#endif
+
+        public override bool ReturnsValue => throw new NotSupportedException();
+        public override bool RequiresOldValue => throw new NotSupportedException();
+    }
+
+    /// <remarks>
+    /// Converts back and forth between a strong type and the primitive type that it contains.
+    /// On the way the value might be represented as a surrogate type.
+    /// </remarks>
+    /// <seealso cref="ProtoBuf.Meta.MetaType.ScalarValuePassthru"/>.
+    sealed class ScalarValuePassthruDecorator : ProtoDecoratorBase
+    {
+        public override Type ExpectedType { get; }
+
+        private readonly FieldInfo _singleField;
+        private readonly MethodInfo _toSurrogate;
+        private readonly MethodInfo _fromSurrogate;
+        public override bool RequiresOldValue => false;
+        public override bool ReturnsValue => true;
+
+        public ScalarValuePassthruDecorator(MethodInfo toSurrogate, MethodInfo fromSurrogate, Type forType,
+            FieldInfo singleField,
+            IProtoSerializer tail) : base(tail)
+        {
+            Helpers.DebugAssert(forType != null);
+            Helpers.DebugAssert(singleField != null);
+            Helpers.DebugAssert(tail.ReturnsValue);
+            Helpers.DebugAssert(!tail.RequiresOldValue);
+            Helpers.DebugAssert(Helpers.IsValueType(forType));
+            Helpers.DebugAssert(toSurrogate == null || Helpers.IsValueType(toSurrogate.ReturnType));
+            Helpers.DebugAssert(fromSurrogate == null || fromSurrogate.ReturnType == forType);
+            _toSurrogate = toSurrogate;
+            _fromSurrogate = fromSurrogate;
+            ExpectedType = forType;
+            _singleField = singleField;
+        }
+
+        public override void Write(ProtoWriter dest, ref ProtoWriter.State state, object value)
+        {
+            Helpers.DebugAssert(value != null);
+            if (_toSurrogate != null)
+            {
+                value = _toSurrogate.Invoke(null, new object[] { value });
+            }
+
+            var innerValue = _singleField.GetValue(value);
+            Tail.Write(dest, ref state, innerValue);
+        }
+
+        public override object Read(ProtoReader source, ref ProtoReader.State state, object value)
+        {
+            Helpers.DebugAssert(value == null);
+            object newValue = Tail.Read(source, ref state, null);
+            if (newValue != null)
+            {
+                if (_toSurrogate != null)
+                {
+                    var newInstance = Activator.CreateInstance(_toSurrogate.ReturnType);
+                    _singleField.SetValue(newInstance, newValue);
+
+                    return _fromSurrogate.Invoke(null, new object[] { newInstance });
+                }
+                else
+                {
+                    var newInstance = Activator.CreateInstance(ExpectedType);
+                    _singleField.SetValue(newInstance, newValue);
+                    return newInstance;
+                }
+            }
+
+            return null;
+        }
+
+
+#if FEAT_COMPILER
+        protected override void EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            ctx.LoadValue(valueFrom);
+            if (_toSurrogate != null)
+            {
+                ctx.EmitCall(_toSurrogate);
+            }
+            ctx.LoadValue(_singleField);
+            ctx.WriteNullCheckedTail(_singleField.FieldType, Tail, null);
+        }
+
+        protected override void EmitRead(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            Helpers.DebugAssert(valueFrom == null);
+
+            if (_toSurrogate != null)
+            {
+                using (Compiler.Local loc = new Compiler.Local(ctx, _toSurrogate.ReturnType))
+                {
+                    ctx.LoadAddress(loc, _toSurrogate.ReturnType);
+                    Tail.EmitRead(ctx, null);
+                    ctx.StoreValue(_singleField);
+                    ctx.LoadValue(loc);
+
+                    ctx.EmitCall(_fromSurrogate);
+                }
+            }
+            else
+            {
+                using (Compiler.Local loc = new Compiler.Local(ctx, ExpectedType))
+                {
+                    ctx.LoadAddress(loc, ExpectedType);
+                    Tail.EmitRead(ctx, null);
+                    ctx.StoreValue(_singleField);
+                    ctx.LoadValue(loc);
+                }
+            }
+        }
+#endif
+    }
+}
+#endif

--- a/src/protobuf-net/Serializers/SurrogateSerializer.cs
+++ b/src/protobuf-net/Serializers/SurrogateSerializer.cs
@@ -98,16 +98,21 @@ namespace ProtoBuf.Serializers
             return false;
         }
 
-        public MethodInfo GetConversion(bool toTail)
+        public static MethodInfo GetConversion(Type expectedType, Type declaredType, bool toTail)
         {
-            Type to = toTail ? declaredType : ExpectedType;
-            Type from = toTail ? ExpectedType : declaredType;
-            if (HasCast(declaredType, from, to, out MethodInfo op) || HasCast(ExpectedType, from, to, out op))
+            Type to = toTail ? declaredType : expectedType;
+            Type from = toTail ? expectedType : declaredType;
+            if (HasCast(declaredType, from, to, out MethodInfo op) || HasCast(expectedType, from, to, out op))
             {
                 return op;
             }
             throw new InvalidOperationException("No suitable conversion operator found for surrogate: " +
-                ExpectedType.FullName + " / " + declaredType.FullName);
+                expectedType.FullName + " / " + declaredType.FullName);
+        }
+
+        public MethodInfo GetConversion(bool toTail)
+        {
+            return GetConversion(ExpectedType, declaredType, toTail);
         }
 
         public void Write(ProtoWriter writer, ref ProtoWriter.State state, object value)


### PR DESCRIPTION
Hi,

This PR enables using strong .net types for scalar values with protobuf-net, while what is serialized remains the same scalar values serialized in the same way.

With this change it is possible to write the following:

```csharp
        [ProtoContract]
        public sealed class I64_Message
        {
            [ProtoMember(1)] public long ID;

            [ProtoMember(10)] public CustomerID CustomerID;
        }
```

Here the `CustomerID` type is simply a struct that contains a single field with a simple type (int, long, string, ...). It will be serialized the same as had it been declared as the type of its single, inner field.

As for the motivation for such a feature, see for example (https://andrewlock.net/using-strongly-typed-entity-ids-to-avoid-primitive-obsession-part-1/). 
At my job we use such strong ID types extensively, and they have helped us avoid a lot of bugs since we introduced them many years ago.

## Implementation

The implementation roughly has the following parts to to it:

 1. A serializer decorator that picks out (serialize) and puts in (deserialize) the value of the single primitive value of a wrapper type (`CustomerID` in the example above).
 2. A new property `ScalarValuePassthru` on `Metatype`, that needs to be set on the wrapper type for this behavior to kick in.
 3. A new property `InferScalarValuePassthru` on `RuntimeTypeModel`, that enable automatically setting  `Metatype.ScalarValuePassthru` on types that appear to be wrapper types. More about that below.

## Current options

I have not found any way to do this without this change. The closest thing that I am aware of is relying on `TupleSerializer`, but that has some significant drawbacks:

 1. It will serialize the value as a nested structure, with the performance and size overhead that that entails.
 2. During deserialization it reads the single property that it assumes represents the value, which at that point has not been assigned to. Reading that property when the value field is zero will typically be caused by not having properly initialized the field that the wrapper type instance is stored in (the `CustomerID` field in the example above). To catch that kind of bugs early, the `.Value` property getters of our wrapper types throw exceptions if they appear to be uninitialized (i.e. if their value is zero). Which obviously makes deserialization stop.

## Status

 - It works and has tests for non-nullable types (`CustomerID`), nullable types (`CustomerID?`) and list/arrays. The serialization is identical to using primitive types directly.
 - The wrapper types do not appear in generated schemas. Rather, they use the primitive types.
 - It does not work for map types. I don't see why it couldn't be made to work though.
 - It works with surrogate types: A surrogate type that has its `Metatype.ScalarValuePassthru` set, will also behave as the type of its single field would.
 - Default values do not work. It could be made to work with little effort, though, it just takes a bit of messing around in `ValueMember.ApplyDefaultBehaviour`. I haven't done that to keep this PR minimally intrusive, and because the importance might not be so high, given the existance of nullable types. A `CustomerID?` will not be serialized, just like a `long?` will not, regardless of default values.

## Compatibility

When passthru is not enabled for any types, nothing changes.

When passthru is enabled for a type for which it makes sense, the serialization format obviously changes. Wrapper types with certain shape is today handled by `TupleSerializer`, which serializes them as a nested structure instead of just a primitive type field. That is the only compatibility concert that I am aware of.
Again, this concern is only relevant for types for which `Metatype.ScalarValuePassthru` is enabled.

There is  some overlap between the shape of types that this PR can autodetect `ScalarValuePassthru` for, and the one that is currently handled by `TupleSerializer`: Whereas `TupleSerializer` seems to rougly speaking be handling types for which there appears to be a one-to-one correspondance between its fields and the argument list of one of its constructors.

I would imagine that in reality this overlap is quite small, since I don't think that tuples with one element and without ProtoContract are terribly common. There it might even make sense to make `RuntimeTypeModel.InferScalarValuePassthru` to true by default in v3.

One can ponder which type shapes the autodetection should react to. Currently it looks for types with all of the following traits:

 - Value type.
 - Has a single field.
 - The single field is not a Nullable<>.
 - Has a constructor (public or not) whose single parameter has the same type as the field.
 - The type of the single field is "primitive", as determined by `RuntimeTypeModel.TryGetBasicTypeSerializer` returning non-null.

## Version

This PR is based on 2.4.0. Is that fine, or would you prefer for it to be based on master?
