### PR TITLE
Initial AppVeyor setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ filedata.bin
 *.binlog
 src/VBTest/*
 src/Benchmark/DalSerializer.dll
+.nupkgs/*

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.Build.Traversal/2.0.19">
+  <ItemGroup>
+    <!-- After moving files around, this can be src\**\*.csroj -->
+    <ProjectReference Include="src\protobuf-net\*.csproj" />
+    <ProjectReference Include="src\protobuf-net.Core\*.csproj" />
+    <ProjectReference Include="src\protobuf-net.MSBuild\*.csproj" />
+    <ProjectReference Include="src\protobuf-net.Protogen\*.csproj" />
+    <ProjectReference Include="src\protobuf-net.Reflection\*.csproj" />
+    <ProjectReference Include="src\protogen\*.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(Packing) != 'true'">
+    <ProjectReference Include="src\*\*.csproj" Exclude="src\protogen.Site\*.csproj" />
+    <!-- <ProjectReference Include="samples\**\*.csproj" Exclude="samples\**\*Mvc5*.csproj" />
+    <ProjectReference Include="tests\**\*.csproj" /> -->
+  </ItemGroup>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,12 @@ build_script:
 test: off
 artifacts:
 - path: .\.nupkgs\*.nupkg
+
+deploy:
+- provider: NuGet
+  server: https://www.myget.org/F/stackoverflow/api/v2
+  on:
+    branch: master
+  api_key:
+    secure: P/UHxq2DEs0GI1SoDXDesHjRVsSVgdywz5vmsnhFQQY5aJgO3kP+QfhwfhXz19Rw
+  symbol_server: https://www.myget.org/F/stackoverflow/symbols/api/v2/package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+image: Visual Studio 2019
+
+install:
+  - choco install dotnetcore-sdk --version 3.0.100
+
+skip_branch_with_pr: true
+skip_tags: true
+skip_commits:
+  files:
+    - '**/*.md'
+    - docs/*
+
+environment:
+  Appveyor: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+nuget:
+  disable_publish_on_pr: true
+
+build_script:
+  - cmd: dotnet build Build.csproj -c Release /p:CI=true /p:GeneratePackageOnBuild=false
+  - cmd: dotnet test Build.csproj -c Release
+  - cmd: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
+
+test: off
+artifacts:
+- path: .\.nupkgs\*.nupkg

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,13 +31,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="All" /> 
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19351-01" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="All" IncludeAssets="runtime;build;native;contentfiles;analyzers" />
     <!-- oh gawd, I'm just not emotionally prepared for this...
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Examples/Issues/Issue228.cs
+++ b/src/Examples/Issues/Issue228.cs
@@ -46,7 +46,7 @@ message IdName {
    optional int32 Id = 1 [default = 0];
    optional string Name = 2;
 }
-", protoFile);
+", protoFile, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/src/protobuf-net.Test/CustomScalarAllocator.cs
+++ b/src/protobuf-net.Test/CustomScalarAllocator.cs
@@ -53,7 +53,7 @@ message HazMemoryBlobish {
 message HazRegularString {
    string Value = 1;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/src/protobuf-net.Test/Issues/TypeSerializedHow.cs
+++ b/src/protobuf-net.Test/Issues/TypeSerializedHow.cs
@@ -47,7 +47,7 @@ message ModelWithTypeMember {
    optional int32 Id = 1 [default = 0];
    optional string SomeType = 2;
 }
-", proto);
+", proto, ignoreLineEndingDifferences: true);
         }
         [ProtoContract]
         public class ModelWithTypeMember

--- a/src/protobuf-net.Test/Serializers/Proto3Tests.cs
+++ b/src/protobuf-net.Test/Serializers/Proto3Tests.cs
@@ -29,7 +29,7 @@ enum RegularEnum {
    B = 1;
    C = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [Fact]
         public void HazBasicEnum_WorksForKnownAndUnknownValues()
@@ -78,7 +78,7 @@ enum StrictEnum {
    B = 1;
    C = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [Fact]
         public void HazStrictEnum_WorksForKnownAndUnknownValues()
@@ -121,7 +121,7 @@ enum AliasedEnum {
 message HazAliasedEnum {
    optional AliasedEnum Value = 1 [default = A];
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [Fact]
         public void HazAliasedEnum_WorksForKnownAndUnknownValues()
@@ -339,7 +339,7 @@ package ProtoBuf.Serializers;
 message HazMap {
    map<int32,string> Lookup = 3;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -352,7 +352,7 @@ package ProtoBuf.Serializers;
 message HazMapWithDataFormat {
    map<sint32,sint64> Lookup = 3;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
 #if FEAT_DYNAMIC_REF
@@ -368,7 +368,7 @@ import ""protobuf-net/protogen.proto""; // custom protobuf-net options
 message HasRefDynamic {
    optional .bcl.NetObjectProxy Obj = 1 [(.protobuf_net.fieldopt).asRef = true, (.protobuf_net.fieldopt).dynamicType = true];
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [ProtoContract]
         public class HasRefDynamic
@@ -394,7 +394,7 @@ message HazTime {
    optional .bcl.TimeSpan c = 3;
    optional .google.protobuf.Duration d = 4;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [ProtoContract]
@@ -421,7 +421,7 @@ message TestPackNonPackedSchemas {
    repeated float NonPacked = 2;
    optional bool Boolean = 3 [default = false];
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -436,7 +436,7 @@ message TestPackNonPackedSchemas {
    repeated float NonPacked = 2 [packed = false];
    bool Boolean = 3;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -454,7 +454,7 @@ enum SomeEnum {
    A = 1;
    C = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         public Proto3Tests(ITestOutputHelper log)
@@ -489,7 +489,7 @@ enum SomeEnum {
    A = 1;
    C = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -507,7 +507,7 @@ enum SomeEnum {
    A = 1;
    C = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [ProtoContract]
@@ -595,7 +595,7 @@ package ProtoBuf.Serializers;
 message HazImplicitMap {
    map<int32,string> Lookup = 3;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
 
         [ProtoContract]
@@ -619,7 +619,7 @@ message KeyValuePair_Int32_String {
    optional int32 Key = 1;
    optional string Value = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [ProtoContract]
         public class HazDisabledMap
@@ -641,7 +641,7 @@ message KeyValuePair_Double_String {
    optional double Key = 1;
    optional string Value = 2;
 }
-", schema);
+", schema, ignoreLineEndingDifferences: true);
         }
         [ProtoContract]
         public class HazInvalidKeyTypeMap


### PR DESCRIPTION
Sets up some AppVeyor build goodness. Trying vanilla version which will work cross-platform first (e.g. no complicated build script).

Build's working - sorted some tests with line-ending-agnostic checks (due the checkouts being undefined in `.gitattributes` and SourceLink normalizing endings before packaging to get the proper hashes.

Note `Directory.build.props` was renamed to `Directory.Build.props` to allow Linux builds later, but not really in play here.

Overall, we're doing:
```cmd
dotnet build Build.csproj -c Release /p:CI=true /p:GeneratePackageOnBuild=false
dotnet test Build.csproj -c Release
dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true
```

For @mgravell:
- This should be ready, though it doesn't go green it's 2 specific tests failing consistently (see [this build](https://ci.appveyor.com/project/StackExchange/protobuf-net/builds/28062972/tests) for examples). I've confirmed these are failing for me locally as well so they seem to be legit fails:
  - `ProtoBuf.Schemas.SchemaTests.CompareProtoToParser(path: "google/protobuf/unittest.proto")`
  - `ProtoBuf.unittest.Attribs.PointStructTests.RoundTripPointWithSurrogate`
  - Details to save time: 
	```
	Assert.Equal() Failure
	                                 ↓ (pos 64824)
	Expected: ···  "DefaultValue": "2e+08",\r\n              "JsonName": "largeF···
	Actual:   ···  "DefaultValue": "200000000",\r\n              "JsonName": "la···
	                                 ↑ (pos 64824)
	   at ProtoBuf.Schemas.SchemaTests.CompareProtoToParser(String path) in C:\projects\protobuf-net\src\protobuf-net.Reflection.Test\Sch
	```
	```
	Assert.Equal() Failure
	Expected: 1
	Actual:   0
	   at ProtoBuf.unittest.Attribs.PointStructTests.ClonePointCountingConversions(TypeModel model, Point original, String message, Int32 toPoint, Int32 fromPoint) in C:\projects\protobuf-net\src\protobuf-net.Test\Attribs\PointStruct.cs:line 108
	   at ProtoBuf.unittest.Attribs.PointStructTests.RoundTripPointWithSurrogate() in C:\projects\protobuf-net\src\protobuf-net.Test\Attribs\PointStruct.cs:line 142
	```
- I can cleanup the output using xUnit logging and remove the `Console.Write*` bits from the few tests that use it, but not sure if you prefer to see them in output all the time. Thoughts? Here's the slowest of the lot in a quick test locally:
- I haven't looked in depth yet, but judging by pauses there are some long running tests occupying most of the build time (makes the build take about 10 minutes give or take), think it's worth excluding a few tests from the CI run? If so I can take a stab at doing that cleanly. ![slow tests](https://user-images.githubusercontent.com/454813/66701386-ecfb8900-ecc9-11e9-8ea3-a095126ae228.png)