### PR TITLE
Tests: move from Console. to xUnit test output

### DIFF
--- a/src/Examples/Arrays.cs
+++ b/src/Examples/Arrays.cs
@@ -5,6 +5,8 @@ using Xunit;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using System.Linq;
+using Xunit.Abstractions;
+
 namespace Examples
 {
     [ProtoContract]
@@ -76,6 +78,9 @@ namespace Examples
     
     public class ArrayTests
     {
+        private ITestOutputHelper Log { get; }
+        public ArrayTests(ITestOutputHelper _log) => Log = _log;
+
         [ProtoContract]
         class Foo { }
         [Fact]
@@ -366,7 +371,7 @@ namespace Examples
 
             MemoryStream stm = new MemoryStream();
             Serializer.Serialize(stm, t);
-            Console.WriteLine(stm.Length);
+            Log.WriteLine(stm.Length.ToString());
         }
         static void VerifyNodeTree(Node node) {
             Node clone = Serializer.DeepClone(node);

--- a/src/Examples/DictionaryTests.cs
+++ b/src/Examples/DictionaryTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Examples.Dictionary
 {
@@ -45,7 +46,7 @@ namespace Examples.Dictionary
         }
     }
 
-    
+
     public class DictionaryTests
     {
         [Fact]
@@ -181,6 +182,8 @@ namespace Examples.Dictionary
     67-68-69 = "ghi"
 etc
          */
+        private ITestOutputHelper Log { get; }
+        public NestedDictionaryTests(ITestOutputHelper _log) => Log = _log;
 
         [Fact]
         public void TestNestedConcreteConcreteDictionary()
@@ -295,15 +298,15 @@ etc
             int l2 = BulkTest(model, o2, out int s2, out int d2);
             int l3 = BulkTest(model, o3, out int s3, out int d3);
 
-            Console.WriteLine("Bytes (props)\t" + l1);
-            Console.WriteLine("Ser (props)\t" + s1);
-            Console.WriteLine("Deser (props)\t" + d1);
-            Console.WriteLine("Bytes (kv-default)\t" + l2);
-            Console.WriteLine("Ser (kv-default)\t" + s2);
-            Console.WriteLine("Deser (kv-default)\t" + d2);
-            Console.WriteLine("Bytes (kv-grouped)\t" + l3);
-            Console.WriteLine("Ser (kv-grouped)\t" + s3);
-            Console.WriteLine("Deser (kv-grouped)\t" + d3);
+            Log.WriteLine("Bytes (props)\t" + l1);
+            Log.WriteLine("Ser (props)\t" + s1);
+            Log.WriteLine("Deser (props)\t" + d1);
+            Log.WriteLine("Bytes (kv-default)\t" + l2);
+            Log.WriteLine("Ser (kv-default)\t" + s2);
+            Log.WriteLine("Deser (kv-default)\t" + d2);
+            Log.WriteLine("Bytes (kv-grouped)\t" + l3);
+            Log.WriteLine("Ser (kv-grouped)\t" + s3);
+            Log.WriteLine("Deser (kv-grouped)\t" + d3);
 
             using var state = ProtoWriter.State.Create(Stream.Null, null, null);
             Stopwatch watch = Stopwatch.StartNew();
@@ -317,7 +320,7 @@ etc
             }
             watch.Stop();
             state.Close();
-            Console.WriteLine("Encoding: " + watch.ElapsedMilliseconds);
+            Log.WriteLine("Encoding: " + watch.ElapsedMilliseconds);
             
         }
         const int LOOP = 500000;

--- a/src/Examples/Issues/Issue167.cs
+++ b/src/Examples/Issues/Issue167.cs
@@ -4,12 +4,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class Issue167
     {
+        private ITestOutputHelper Log { get; }
+        public Issue167(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void Execute()
         {
@@ -21,9 +24,9 @@ namespace Examples.Issues
                     Serializer.Serialize<Problematic>(memStream, test); //causes stackoverflow exception.
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
-                Console.WriteLine(ex.StackTrace);
+                Log.WriteLine(ex.StackTrace);
             }
         }
 
@@ -44,6 +47,4 @@ namespace Examples.Issues
             }
         }
     }
-
-    
 }

--- a/src/Examples/Issues/Issue176.cs
+++ b/src/Examples/Issues/Issue176.cs
@@ -5,18 +5,17 @@ using System.IO;
 using System.Linq;
 
 using DAL;
-
-using Xunit;
-
 using ProtoBuf.Meta;
-using System.Data.Linq;
-using System.Collections;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class Issue176
     {
+        private ITestOutputHelper Log { get; }
+        public Issue176(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void TestOrderLineGetDeserializedAndAttachedToOrder()
         {
@@ -40,7 +39,7 @@ namespace Examples.Issues
                 roundTrippedOrders.SelectMany(o => o.Lines).Count()); //, "total count");
         }
 
-        static void DbMetrics(string caption, IEnumerable<Order> orders)
+        private void DbMetrics(string caption, IEnumerable<Order> orders)
         {
             int count = orders.Count();
             int lines = orders.SelectMany(ord => ord.Lines).Count();
@@ -49,7 +48,7 @@ namespace Examples.Issues
             decimal totalValue = orders.SelectMany(ord => ord.Lines)
                     .Sum(line => line.Quantity * line.UnitPrice);
 
-            Console.WriteLine("{0}\torders {1}; lines {2}; units {3}; value {4:C}",
+            Log.WriteLine("{0}\torders {1}; lines {2}; units {3}; value {4:C}",
                               caption, count, lines, totalQty, totalValue);
         }
 

--- a/src/Examples/Issues/Issue356.cs
+++ b/src/Examples/Issues/Issue356.cs
@@ -9,6 +9,8 @@ namespace test
     using Xunit;
     using ProtoBuf;
     using Examples;
+    using Xunit.Abstractions;
+
     [XmlType]
     public class SimpleObject : IEquatable<SimpleObject>
     {
@@ -49,6 +51,9 @@ namespace test
     
     public class TestIncorrectStream
     {
+        private ITestOutputHelper Log { get; }
+        public TestIncorrectStream(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void TestDeserializationFromXml()
         {
@@ -65,7 +70,7 @@ namespace test
                 XmlWriter writer = XmlWriter.Create(sb);
                 XmlSerializer xmlSerializer = new XmlSerializer(typeof(SimpleObject));
                 xmlSerializer.Serialize(writer, original);
-                Console.WriteLine(sb.ToString());
+                Log.WriteLine(sb.ToString());
 
                 // use XML text as input stream for XML deserialization
                 byte[] bytes = Encoding.Unicode.GetBytes(sb.ToString());

--- a/src/Examples/Issues/Issue45.cs
+++ b/src/Examples/Issues/Issue45.cs
@@ -4,19 +4,22 @@ using Xunit;
 using System;
 using ProtoBuf;
 using System.IO;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class LateLoadedTests
     {
+        private ITestOutputHelper Log { get; }
+        public LateLoadedTests(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void TestLateLoad()
         {
             const string dllPath = "LateLoaded.dll";
             if(!File.Exists(dllPath))
             {
-                Console.WriteLine("Late-load dll not found {0}; test inconclusive", dllPath);
+                Log.WriteLine("Late-load dll not found {0}; test inconclusive", dllPath);
                 return;
             }
             Assembly assembly = Assembly.LoadFrom(dllPath);

--- a/src/Examples/Issues/MB.cs
+++ b/src/Examples/Issues/MB.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using Examples;
+using Xunit.Abstractions;
 
 namespace TestMediaBrowser
 {
@@ -124,9 +125,10 @@ namespace TestMediaBrowser
 
 #endregion
 
-    
     public class TestSerialization
     {
+        private ITestOutputHelper Log { get; }
+        public TestSerialization(ITestOutputHelper _log) => Log = _log;
 
         [Fact]
         public void TestSerializerShouldSupportNulls()
@@ -401,15 +403,13 @@ namespace TestMediaBrowser
 
         }
 
-
-        static void TimeAction(string description, Action func)
+        private void TimeAction(string description, Action func)
         {
             var watch = new Stopwatch();
             watch.Start();
             func();
             watch.Stop();
-            Console.Write(description);
-            Console.WriteLine(" Time Elapsed {0} ms", watch.ElapsedMilliseconds);
+            Log.WriteLine("{0} Time Elapsed {1} ms", description, watch.ElapsedMilliseconds);
         }
     }
 }

--- a/src/Examples/Issues/SO10841807.cs
+++ b/src/Examples/Issues/SO10841807.cs
@@ -1,20 +1,21 @@
 ﻿#if !NO_WCF
-using System;
-using System.Text.RegularExpressions;
 using Xunit;
 using ProtoBuf.ServiceModel;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class SO10841807
     {
+        private ITestOutputHelper Log { get; }
+        public SO10841807(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void Execute()
         {
             string aqn = typeof (ProtoBehaviorExtension).AssemblyQualifiedName;
-            Assert.True(Regex.IsMatch(aqn, @"ProtoBuf\.ServiceModel\.ProtoBehaviorExtension, protobuf\-net, Version=[0-9.]+, Culture=neutral, PublicKeyToken=257b51d87d2e4d67"));
-            Console.WriteLine("WCF AQN: " + aqn);
+            Assert.Matches(@"ProtoBuf\.ServiceModel\.ProtoBehaviorExtension, protobuf\-net, Version=[0-9.]+, Culture=neutral, PublicKeyToken=257b51d87d2e4d67", aqn);
+            Log.WriteLine("WCF AQN: " + aqn);
         }
     }
 }

--- a/src/Examples/Issues/SO13162642.cs
+++ b/src/Examples/Issues/SO13162642.cs
@@ -1,15 +1,17 @@
 ﻿using Xunit;
 using ProtoBuf;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
-{
-    
+{   
     public class SO13162642
     {
+        private ITestOutputHelper Log { get; }
+        public SO13162642(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void Execute()
         {
@@ -21,7 +23,7 @@ namespace Examples.Issues
             using (var f = File.OpenRead("Data.protobuf"))
             {
                 var dtos = Serializer.DeserializeItems<DTO>(f, ProtoBuf.PrefixStyle.Base128, 1);
-                Console.WriteLine(dtos.Count());
+                Log.WriteLine(dtos.Count().ToString());
             }
         }
 
@@ -40,7 +42,7 @@ namespace Examples.Issues
             using (var f = File.OpenRead("Data.protobuf"))
             {
                 var dtos = Serializer.DeserializeItems<DTO>(f, ProtoBuf.PrefixStyle.Base128, 1);
-                Console.WriteLine(dtos.Count());
+                Log.WriteLine(dtos.Count().ToString());
             }
         }
 

--- a/src/Examples/Issues/SO1930209.cs
+++ b/src/Examples/Issues/SO1930209.cs
@@ -8,12 +8,15 @@ using System.Threading;
 using Xunit;
 using ProtoBuf;
 using ProtoBuf.Meta;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class SO1930209
     {
+        private ITestOutputHelper Log { get; }
+        public SO1930209(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void ExecuteSimpleNestedShouldNotBuffer()
         {
@@ -42,7 +45,7 @@ namespace Examples.Issues
 #if DEBUG
             model.ForwardsOnly = true;
 #endif
-            Console.WriteLine("Inventing data...");
+            Log.WriteLine("Inventing data...");
             var watch = Stopwatch.StartNew();
             var arr = new B[5];
             for (int i = 0; i < arr.Length; i++)
@@ -56,18 +59,18 @@ namespace Examples.Issues
             }
             var orig = new A {Array1 = arr};
             watch.Stop();
-            Console.WriteLine("{0}ms", watch.ElapsedMilliseconds);
-            Console.WriteLine("Serializing...");
+            Log.WriteLine("{0}ms", watch.ElapsedMilliseconds);
+            Log.WriteLine("Serializing...");
             watch = Stopwatch.StartNew();
             using (var file = File.Create(@"big.file"))
             {
                 model.Serialize(file, orig);
             }
             watch.Stop();
-            Console.WriteLine("{0}ms", watch.ElapsedMilliseconds);
+            Log.WriteLine("{0}ms", watch.ElapsedMilliseconds);
             var len = new FileInfo(@"big.file").Length;
-            Console.WriteLine("{0} bytes", len);
-            Console.WriteLine("Deserializing...");
+            Log.WriteLine("{0} bytes", len);
+            Log.WriteLine("Deserializing...");
             watch = Stopwatch.StartNew();
             A clone;
             using (var file = File.OpenRead(@"big.file"))
@@ -77,11 +80,11 @@ namespace Examples.Issues
 #pragma warning restore CS0618
             }
             watch.Stop();
-            Console.WriteLine("{0}ms", watch.ElapsedMilliseconds);
+            Log.WriteLine("{0}ms", watch.ElapsedMilliseconds);
             int chk1 = GetCheckSum(orig), chk2 = GetCheckSum(clone);
-            Console.WriteLine("Checksum: {0} vs {1}", chk1, chk2);
+            Log.WriteLine("Checksum: {0} vs {1}", chk1, chk2);
             Assert.Equal(chk1, chk2);
-            Console.WriteLine("All done...");
+            Log.WriteLine("All done...");
         }
 
         private static int GetCheckSum(A a)

--- a/src/Examples/Issues/SO7078615.cs
+++ b/src/Examples/Issues/SO7078615.cs
@@ -3,11 +3,10 @@ using System.IO;
 using Xunit;
 using ProtoBuf;
 using ProtoBuf.Meta;
-using System;
+using Xunit.Abstractions;
 
 namespace Examples.Issues
 {
-    
     public class SO7078615
     {
         [ProtoContract] // treat the interface as a contract
@@ -68,6 +67,9 @@ namespace Examples.Issues
     
     public class SO7078615_NoAttribs
     {
+        private ITestOutputHelper Log { get; }
+        public SO7078615_NoAttribs(ITestOutputHelper _log) => Log = _log;
+
         public interface IMessage { }
         public interface IEvent : IMessage { }
         public class DogBarkedEvent : IEvent
@@ -128,7 +130,7 @@ namespace Examples.Issues
             }
             watch.Stop();
             var hoisted = watch.ElapsedMilliseconds;
-            Console.WriteLine(hoisted);
+            Log.WriteLine(hoisted.ToString());
             watch = Stopwatch.StartNew();
             {
                 for (int i = 0; i < values.Length; i++)
@@ -136,12 +138,9 @@ namespace Examples.Issues
             }
             watch.Stop();
             var direct = watch.ElapsedMilliseconds;
-            Console.WriteLine(direct);
+            Log.WriteLine(direct.ToString());
             Assert.True(2 < 3);
             Assert.True(hoisted < direct);
         }
-
-        
     }
-
 }

--- a/src/Examples/StupidlyComplexModel.cs
+++ b/src/Examples/StupidlyComplexModel.cs
@@ -4,13 +4,15 @@ using ProtoBuf.Meta;
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
+using Xunit.Abstractions;
 
 namespace Examples
-{
-    
+{   
     public class StupidlyComplexModel
     {
+        private ITestOutputHelper Log { get; }
+        public StupidlyComplexModel(ITestOutputHelper _log) => Log = _log;
+
         [Fact]
         public void TimeStupidlyComplexModel()
         {
@@ -47,7 +49,7 @@ namespace Examples
             [ProtoMember(20)] public int T {get;set;}
         }
 
-        private static void TimeModel<T>(int count, Action<TypeModel, string> test = null)
+        private void TimeModel<T>(int count, Action<TypeModel, string> test = null)
         {
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
@@ -62,9 +64,8 @@ namespace Examples
                 model.Compile();
             }
             watch.Stop();
-            Console.WriteLine(string.Format("{0}: {1}ms/Compile, {2} types, {3}ms total, {4} iteratons",
+            Log.WriteLine(string.Format("{0}: {1}ms/Compile, {2} types, {3}ms total, {4} iteratons",
                 typeof(T).Name, watch.ElapsedMilliseconds / count, typeCount, watch.ElapsedMilliseconds, count));
-            
         }
 
 

--- a/src/protobuf-net.Test/Meta/PocoStruct.cs
+++ b/src/protobuf-net.Test/Meta/PocoStruct.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using ProtoBuf.Meta;
+using Xunit.Abstractions;
 
 namespace ProtoBuf.unittest.Meta
-{
-    
+{   
     public class PocoClass
     {
+        private ITestOutputHelper Log { get; }
+        public PocoClass(ITestOutputHelper _log) => Log = _log;
+
         public class Company
         {
             private readonly List<Employee> employees = new List<Employee>();
@@ -37,7 +40,7 @@ namespace ProtoBuf.unittest.Meta
             using var ms = new MemoryStream();
             model.Serialize(ms, comp);
             ms.Position = 0;
-            Console.WriteLine("Bytes: " + ms.Length);
+            Log.WriteLine("Bytes: " + ms.Length);
 #pragma warning disable CS0618
             clone = (Company) model.Deserialize(ms, null, typeof(Company));
 #pragma warning restore CS0618
@@ -50,6 +53,9 @@ namespace ProtoBuf.unittest.Meta
     
     public class PocoStruct
     {
+        private ITestOutputHelper Log { get; }
+        public PocoStruct(ITestOutputHelper _log) => Log = _log;
+
         public struct Company
         {
             private List<Employee> employees;
@@ -80,7 +86,7 @@ namespace ProtoBuf.unittest.Meta
             {
                 model.Serialize(ms, comp);
                 ms.Position = 0;
-                Console.WriteLine("Bytes: " + ms.Length);
+                Log.WriteLine("Bytes: " + ms.Length);
 #pragma warning disable CS0618
                 clone = (Company)model.Deserialize(ms, null, typeof(Company));
 #pragma warning restore CS0618

--- a/src/protobuf-net.Test/Perf/Issue103.cs
+++ b/src/protobuf-net.Test/Perf/Issue103.cs
@@ -15,11 +15,15 @@ namespace ProtoBuf.unittest.Perf
     using Issue103Types;
     using Xunit;
     using System.Diagnostics;
-using ProtoBuf.Meta;
+    using ProtoBuf.Meta;
     using System.IO;
-    
+    using Xunit.Abstractions;
+
     public class Issue103
     {
+        private ITestOutputHelper Log { get; }
+        public Issue103(ITestOutputHelper _log) => Log = _log;
+
         static RuntimeTypeModel CreateModel()
         {
             var model = RuntimeTypeModel.Create();
@@ -56,11 +60,9 @@ using ProtoBuf.Meta;
             model.CompileInPlace();
             RunTestIssue103(50000, typeA, typeB, model, "CompileInPlace");
             RunTestIssue103(50000, typeA, typeB, model.Compile(), "Compile");
-            
-
         }
 
-        private static void RunTestIssue103(int loop, TypeA typeA, TypeB typeB, TypeModel model, string caption)
+        private void RunTestIssue103(int loop, TypeA typeA, TypeB typeB, TypeModel model, string caption)
         {
             // for JIT and preallocation
             MemoryStream ms = new MemoryStream();
@@ -113,10 +115,10 @@ using ProtoBuf.Meta;
             }
             typeBDeser.Stop();
 
-            Console.WriteLine(caption + " A/ser\t" + (typeASer.ElapsedMilliseconds * 1000 / loop) + " μs/item");
-            Console.WriteLine(caption + " A/deser\t" + (typeADeser.ElapsedMilliseconds * 1000 / loop) + " μs/item");
-            Console.WriteLine(caption + " B/ser\t" + (typeBSer.ElapsedMilliseconds * 1000 / loop) + " μs/item");
-            Console.WriteLine(caption + " B/deser\t" + (typeBDeser.ElapsedMilliseconds * 1000 / loop) + " μs/item");
+            Log.WriteLine(caption + " A/ser\t" + (typeASer.ElapsedMilliseconds * 1000 / loop) + " μs/item");
+            Log.WriteLine(caption + " A/deser\t" + (typeADeser.ElapsedMilliseconds * 1000 / loop) + " μs/item");
+            Log.WriteLine(caption + " B/ser\t" + (typeBSer.ElapsedMilliseconds * 1000 / loop) + " μs/item");
+            Log.WriteLine(caption + " B/deser\t" + (typeBDeser.ElapsedMilliseconds * 1000 / loop) + " μs/item");
         }
     }
 }


### PR DESCRIPTION
Follow-up to #574 - this eliminates most of the build/test output noise and tucks it into the xUnit output (which we could emit to console if wanted) and always appears in VS.