### PR TITLE
Move from SerializationContext => UserState as the primary extension API

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -13,7 +13,8 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## v3.0.0-alpha
 
-- **breaking change** (hence 3.0) if you are using `new ProtoReader(...)` - you must now use `ProtoReader.Create(...)`
+- **breaking change** if you are using `new ProtoReader(...)` - you must now use `ProtoReader.Create(...)`
+- **breaking change** by necessity, `ProtoBuf.Serializer+TypeResolver` has moved to `ProtoBuf.Serializer`; this is a rarely used API, but comsumers will need to be recompiled against the new type
 - **breaking change** - mapped enum values are no longer supported; all enums are treated as pass-thru, in line with "proto3" semantics
 - **breaking change** - dynamic typing (i.e. storing the `Type` metadata) and reference-tracking (`AsReference`, `AsReferenceDefault`, `DynamicType`) are not implemented/supported; this is partly due to doubts over whether the features are adviseable, and partly over confidence in testing all the scenarios (it takes time; that time hasn't get happened); feedback is invited
 - **breaking change** - non-generic list-like APIs like `IList` or `ICollection` are no longer supported; there is a new API for processing custom collection types

--- a/src/Examples/Callbacks.cs
+++ b/src/Examples/Callbacks.cs
@@ -380,7 +380,7 @@ namespace Examples
 #endif
             using var ms = new MemoryStream();
             SerializationContext ctx = new SerializationContext { Context = new object()};
-            model.Serialize(ms, orig, ctx);
+            model.Serialize(ms, orig, context: ctx);
             Assert.Null(orig.B.ReadState);
             Assert.Same(ctx.Context, orig.B.WriteState);
 #if REMOTING

--- a/src/Examples/ImmutableCollections.cs
+++ b/src/Examples/ImmutableCollections.cs
@@ -234,7 +234,7 @@ namespace Examples
             try
             {
 #pragma warning disable CS0618
-                model.Deserialize(ms, clone, null); // this is append!
+                model.Deserialize(ms, clone, type: null); // this is append!
 #pragma warning restore CS0618
             }
             catch (Exception ex)

--- a/src/Examples/Issues/SO7793527.cs
+++ b/src/Examples/Issues/SO7793527.cs
@@ -119,7 +119,7 @@ namespace Examples.Issues
             var obj = new FooEnumerable { Bars = Array.Empty<Bar>() };
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                var clone = (FooEnumerable)ser.Deserialize(ms, obj, typeof(FooEnumerable));
+                var clone = (FooEnumerable)ser.Deserialize(ms, obj, type: typeof(FooEnumerable));
             });
             Assert.Equal("For repeated data declared as System.Collections.Generic.IEnumerable`1[Examples.Issues.SO7793527+Bar], the *underlying* collection (Examples.Issues.SO7793527+Bar[]) must implement ICollection<T> and must not declare itself read-only; alternative (more exotic) collections can be used, but must be declared using their well-known form (for example, a member could be declared as ImmutableHashSet<T>)", ex.Message);
         }

--- a/src/Examples/TypeFactory.cs
+++ b/src/Examples/TypeFactory.cs
@@ -45,7 +45,7 @@ namespace Examples
                 CanHazFactory orig = new CanHazFactory {Foo = 123, Bar = 456}, clone;
                 using(var ms = new MemoryStream())
                 {
-                    model.Serialize(ms, orig, ctx);
+                    model.Serialize(ms, orig, context: ctx);
                     ms.Position = 0;
 #pragma warning disable CS0618
                     clone = (CanHazFactory) model.Deserialize(ms, null, typeof(CanHazFactory), ctx);

--- a/src/protobuf-net.Core/ISerializationContext.cs
+++ b/src/protobuf-net.Core/ISerializationContext.cs
@@ -1,4 +1,5 @@
 ﻿using ProtoBuf.Meta;
+using System;
 
 namespace ProtoBuf
 {
@@ -11,9 +12,10 @@ namespace ProtoBuf
         /// The type-model that represents the operation
         /// </summary>
         TypeModel Model { get; }
+
         /// <summary>
-        /// The serialization-context specified for the operation
+        /// Addition information about this serialization operation.
         /// </summary>
-        SerializationContext Context { get; }
+        object UserState { get; }
     }
 }

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -232,10 +232,10 @@ namespace ProtoBuf.Meta
         /// </summary>
         /// <param name="value">The existing instance to be serialized (cannot be null).</param>
         /// <param name="dest">The destination stream to write to.</param>
-        /// <param name="context">Additional information about this serialization operation.</param>
-        public long Serialize<T>(Stream dest, T value, SerializationContext context = null)
+        /// <param name="userState">Additional information about this serialization operation.</param>
+        public long Serialize<T>(Stream dest, T value, object userState = null)
         {
-            var state = ProtoWriter.State.Create(dest, this, context);
+            var state = ProtoWriter.State.Create(dest, this, userState);
             try
             {
                 return SerializeImpl<T>(ref state, value);
@@ -251,10 +251,10 @@ namespace ProtoBuf.Meta
         /// </summary>
         /// <param name="value">The existing instance to be serialized (cannot be null).</param>
         /// <param name="dest">The destination stream to write to.</param>
-        /// <param name="context">Additional information about this serialization operation.</param>
-        public long Serialize<T>(IBufferWriter<byte> dest, T value, SerializationContext context = null)
+        /// <param name="userState">Additional information about this serialization operation.</param>
+        public long Serialize<T>(IBufferWriter<byte> dest, T value, object userState = null)
         {
-            var state = ProtoWriter.State.Create(dest, this, context);
+            var state = ProtoWriter.State.Create(dest, this, userState);
             try
             {
                 return SerializeImpl<T>(ref state, value);
@@ -268,9 +268,9 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public long Measure<T>(T value, SerializationContext context = null)
+        public long Measure<T>(T value, object userState = null)
         {
-            var state = ProtoWriter.NullProtoWriter.CreateNullProtoWriter(this, context);
+            var state = ProtoWriter.NullProtoWriter.CreateNullProtoWriter(this, userState);
             try
             {
                 return SerializeImpl<T>(ref state, value);
@@ -674,15 +674,15 @@ namespace ProtoBuf.Meta
         /// Applies a protocol-buffer stream to an existing instance (which may be null).
         /// </summary>
         /// <typeparam name="T">The type (including inheritance) to consider.</typeparam>
-        /// <param name="context">Additional information about this serialization operation.</param>
+        /// <param name="userState">Additional information about this serialization operation.</param>
         /// <param name="source">The binary stream to apply to the instance (cannot be null).</param>
         /// <param name="value">The existing instance to be modified (can be null).</param>
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(Stream source, T value = default, SerializationContext context = null)
+        public T Deserialize<T>(Stream source, T value = default, object userState = null)
         {
-            using var state = ProtoReader.State.Create(source, this, context);
+            using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
         }
 
@@ -690,15 +690,15 @@ namespace ProtoBuf.Meta
         /// Applies a protocol-buffer stream to an existing instance (which may be null).
         /// </summary>
         /// <typeparam name="T">The type (including inheritance) to consider.</typeparam>
-        /// <param name="context">Additional information about this serialization operation.</param>
+        /// <param name="userState">Additional information about this serialization operation.</param>
         /// <param name="source">The binary stream to apply to the instance (cannot be null).</param>
         /// <param name="value">The existing instance to be modified (can be null).</param>
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, SerializationContext context = null)
+        public T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
         {
-            using var state = ProtoReader.State.Create(source, this, context);
+            using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
         }
 
@@ -706,15 +706,15 @@ namespace ProtoBuf.Meta
         /// Applies a protocol-buffer stream to an existing instance (which may be null).
         /// </summary>
         /// <typeparam name="T">The type (including inheritance) to consider.</typeparam>
-        /// <param name="context">Additional information about this serialization operation.</param>
+        /// <param name="userState">Additional information about this serialization operation.</param>
         /// <param name="source">The binary stream to apply to the instance (cannot be null).</param>
         /// <param name="value">The existing instance to be modified (can be null).</param>
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, SerializationContext context = null)
+        public T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
         {
-            using var state = ProtoReader.State.Create(source, this, context);
+            using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
         }
 
@@ -1231,7 +1231,7 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Create a deep clone of the supplied instance; any sub-items are also cloned.
         /// </summary>
-        public T DeepClone<T>(T value, SerializationContext context = null)
+        public T DeepClone<T>(T value, object userState = null)
         {
 #if PLAT_ISREF
             if (!System.Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences<T>())
@@ -1252,9 +1252,9 @@ namespace ProtoBuf.Meta
             else
             {
                 using var ms = new MemoryStream();
-                Serialize<T>(ms, value, context);
+                Serialize<T>(ms, value, userState);
                 ms.Position = 0;
-                return Deserialize<T>(ms, default, context);
+                return Deserialize<T>(ms, default, userState);
             }
         }
 

--- a/src/protobuf-net.Core/ProtoReader.ReadOnlySequence.cs
+++ b/src/protobuf-net.Core/ProtoReader.ReadOnlySequence.cs
@@ -17,11 +17,11 @@ namespace ProtoBuf
             /// </summary>
             /// <param name="source">The source buffer</param>
             /// <param name="model">The model to use for serialization; this can be null, but this will impair the ability to deserialize sub-objects</param>
-            /// <param name="context">Additional context about this serialization operation</param>
-            public static State Create(ReadOnlySequence<byte> source, TypeModel model, SerializationContext context = null)
+            /// <param name="userState">Additional context about this serialization operation</param>
+            public static State Create(ReadOnlySequence<byte> source, TypeModel model, object userState = null)
             {
                 var reader = Pool<ReadOnlySequenceProtoReader>.TryGet() ?? new ReadOnlySequenceProtoReader();
-                reader.Init(source, model, context);
+                reader.Init(source, model, userState);
                 return new State(reader);
             }
 
@@ -30,9 +30,9 @@ namespace ProtoBuf
             /// </summary>
             /// <param name="source">The source buffer</param>
             /// <param name="model">The model to use for serialization; this can be null, but this will impair the ability to deserialize sub-objects</param>
-            /// <param name="context">Additional context about this serialization operation</param>
-            public static State Create(ReadOnlyMemory<byte> source, TypeModel model, SerializationContext context = null)
-                => Create(new ReadOnlySequence<byte>(source), model, context);
+            /// <param name="userState">Additional context about this serialization operation</param>
+            public static State Create(ReadOnlyMemory<byte> source, TypeModel model, object userState = null)
+                => Create(new ReadOnlySequence<byte>(source), model, userState);
 
 #if FEAT_DYNAMIC_REF
             internal void SetRootObject(object value) => _reader.SetRootObject(value);
@@ -151,9 +151,9 @@ namespace ProtoBuf
                 Pool<ReadOnlySequenceProtoReader>.Put(this);
             }
 
-            internal void Init(ReadOnlySequence<byte> source, TypeModel model, SerializationContext context)
+            internal void Init(ReadOnlySequence<byte> source, TypeModel model, object userState)
             {
-                base.Init(model, context);
+                base.Init(model, userState);
                 _source = source.GetEnumerator();
             }
 

--- a/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
@@ -16,25 +16,25 @@ namespace ProtoBuf
             /// <summary>
             /// Create a new ProtoWriter that tagets a buffer writer
             /// </summary>
-            public static State Create(IBufferWriter<byte> writer, TypeModel model, SerializationContext context = null)
-                => BufferWriterProtoWriter.CreateBufferWriterProtoWriter(writer, model, context);
+            public static State Create(IBufferWriter<byte> writer, TypeModel model, object userState = null)
+                => BufferWriterProtoWriter.CreateBufferWriterProtoWriter(writer, model, userState);
         }
 
         private sealed class BufferWriterProtoWriter : ProtoWriter
         {
-            internal static State CreateBufferWriterProtoWriter(IBufferWriter<byte> writer, TypeModel model, SerializationContext context)
+            internal static State CreateBufferWriterProtoWriter(IBufferWriter<byte> writer, TypeModel model, object userState)
             {
                 if (writer == null) ThrowHelper.ThrowArgumentNullException(nameof(writer));
                 var obj = Pool<BufferWriterProtoWriter>.TryGet() ?? new BufferWriterProtoWriter();
-                obj.Init(model, context, true);
+                obj.Init(model, userState, true);
                 obj._writer = writer;
                 return new State(obj);
             }
 
-            internal override void Init(TypeModel model, SerializationContext context, bool impactCount)
+            internal override void Init(TypeModel model, object userState, bool impactCount)
             {
-                base.Init(model, context, impactCount);
-                _nullWriter.Init(model, context, impactCount: false);
+                base.Init(model, userState, impactCount);
+                _nullWriter.Init(model, userState, impactCount: false);
             }
 
             private IBufferWriter<byte> _writer;

--- a/src/protobuf-net.Core/ProtoWriter.Null.cs
+++ b/src/protobuf-net.Core/ProtoWriter.Null.cs
@@ -10,17 +10,17 @@ namespace ProtoBuf
 {
     public partial class ProtoWriter
     {
-        internal static State CreateNull(TypeModel model, SerializationContext context = null)
-            => NullProtoWriter.CreateNullProtoWriter(model, context);
+        internal static State CreateNull(TypeModel model, object userState = null)
+            => NullProtoWriter.CreateNullProtoWriter(model, userState);
 
         internal sealed class NullProtoWriter : ProtoWriter
         {
             protected internal override State DefaultState() => new State(this);
 
-            internal static State CreateNullProtoWriter(TypeModel model, SerializationContext context)
+            internal static State CreateNullProtoWriter(TypeModel model, object userState)
             {
                 var obj = Pool<NullProtoWriter>.TryGet() ?? new NullProtoWriter();
-                obj.Init(model, context, true);
+                obj.Init(model, userState, true);
                 return new State(obj);
             }
 

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -147,9 +147,9 @@ namespace ProtoBuf
         /// Creates a new writer against a stream
         /// </summary>
         /// <param name="model">The model to use for serialization; this can be null, but this will impair the ability to serialize sub-objects</param>
-        /// <param name="context">Additional context about this serialization operation</param>
+        /// <param name="userState">Additional context about this serialization operation</param>
         /// <param name="impactCount">Whether this initialization should impact usage counters (to check for double-usage)</param>
-        internal virtual void Init(TypeModel model, SerializationContext context, bool impactCount)
+        internal virtual void Init(TypeModel model, object userState, bool impactCount)
         {
             OnInit(impactCount);
             _position64 = 0;
@@ -159,9 +159,8 @@ namespace ProtoBuf
             fieldNumber = 0;
             this.model = model;
             WireType = WireType.None;
-            if (context == null) { context = SerializationContext.Default; }
-            else { context.Freeze(); }
-            Context = context;
+            if (userState is SerializationContext context) context.Freeze();
+            UserState = userState;
         }
 
         [StructLayout(LayoutKind.Auto)]
@@ -195,7 +194,13 @@ namespace ProtoBuf
         /// <summary>
         /// Addition information about this serialization operation.
         /// </summary>
-        public SerializationContext Context { get; private set; }
+        [Obsolete("Prefer " + nameof(UserState))]
+        public SerializationContext Context => SerializationContext.AsSerializationContext(this);
+
+        /// <summary>
+        /// Addition information about this serialization operation.
+        /// </summary>
+        public object UserState { get; private set; }
 
 #if DEBUG || TRACK_USAGE
         int _usageCount;
@@ -236,7 +241,7 @@ namespace ProtoBuf
             recursionStack?.Clear();
             ClearKnownObjects();
             model = null;
-            Context = null;
+            UserState = null;
         }
 
         protected private virtual void ClearKnownObjects()

--- a/src/protobuf-net.Core/SerializationContext.cs
+++ b/src/protobuf-net.Core/SerializationContext.cs
@@ -1,12 +1,12 @@
 ﻿using ProtoBuf.Internal;
-using System;
+using System.Runtime.Serialization;
 
 namespace ProtoBuf
 {
     /// <summary>
     /// Additional information about a serialization operation
     /// </summary>
-    public class SerializationContext
+    public sealed class SerializationContext
     {
         private bool frozen;
         internal void Freeze() { frozen = true; }
@@ -21,40 +21,34 @@ namespace ProtoBuf
             set { if (context != value) { ThrowIfFrozen(); context = value; } }
         }
 
-        private static readonly SerializationContext @default;
-
-        static SerializationContext()
-        {
-            @default = new SerializationContext();
-            @default.Freeze();
-        }
         /// <summary>
         /// A default SerializationContext, with minimal information.
         /// </summary>
-        internal static SerializationContext Default => @default;
+        internal static SerializationContext Default { get; } = new SerializationContext { frozen = true };
 
-        private System.Runtime.Serialization.StreamingContextStates state = System.Runtime.Serialization.StreamingContextStates.Persistence;
+        private StreamingContextStates state = StreamingContextStates.Persistence;
+
         /// <summary>
         /// Gets or sets the source or destination of the transmitted data.
         /// </summary>
-        public System.Runtime.Serialization.StreamingContextStates State
+        public StreamingContextStates State
         {
             get { return state; }
             set { if (state != value) { ThrowIfFrozen(); state = value; } }
         }
 
-		/// <summary>
-		/// Convert a SerializationContext to a StreamingContext
-		/// </summary>
-		public static implicit operator System.Runtime.Serialization.StreamingContext(SerializationContext ctx)
+        /// <summary>
+        /// Convert a SerializationContext to a StreamingContext
+        /// </summary>
+        public static implicit operator StreamingContext(SerializationContext ctx)
         {
-            if (ctx == null) return new System.Runtime.Serialization.StreamingContext(System.Runtime.Serialization.StreamingContextStates.Persistence);
-            return new System.Runtime.Serialization.StreamingContext(ctx.state, ctx.context);
+            if (ctx == null) return new StreamingContext(StreamingContextStates.Persistence);
+            return new StreamingContext(ctx.state, ctx.context);
         }
         /// <summary>
         /// Convert a StreamingContext to a SerializationContext
         /// </summary>
-        public static implicit operator SerializationContext (System.Runtime.Serialization.StreamingContext ctx)
+        public static implicit operator SerializationContext(StreamingContext ctx)
         {
             SerializationContext result = new SerializationContext
             {
@@ -63,6 +57,34 @@ namespace ProtoBuf
             };
 
             return result;
+        }
+
+        /// <summary>
+        /// Create a StreamingContext from a serialization context
+        /// </summary>
+        public static StreamingContext AsStreamingContext(ISerializationContext context)
+        {
+            var userState = context?.UserState;
+            if (userState is SerializationContext ctx) return new StreamingContext(ctx.state, ctx.context);
+            return new StreamingContext(StreamingContextStates.Persistence, userState);
+        }
+
+        /// <summary>
+        /// Creates a frozen SerializationContext from a serialization context
+        /// </summary>
+        public static SerializationContext AsSerializationContext(ISerializationContext context)
+        {
+            var userState = context?.UserState;
+            return userState switch
+            {
+                null => Default,
+                SerializationContext ctx => ctx,
+                _ => new SerializationContext
+                {
+                    context = context,
+                    frozen = true,
+                },
+            };
         }
     }
 

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -340,9 +340,9 @@ namespace ProtoBuf.Serializers
             {
                 using var ms = new MemoryStream();
                 // this <object> sneakily finds the correct base-type
-                context.Model.Serialize<object>(ms, value, context.Context);
+                context.Model.Serialize<object>(ms, value, context.UserState);
                 ms.Position = 0;
-                return context.Model.Deserialize<T>(ms, typed, context.Context);
+                return context.Model.Deserialize<T>(ms, typed, context.UserState);
             }
         }
 

--- a/src/protobuf-net.Test/WellKnownTypes.cs
+++ b/src/protobuf-net.Test/WellKnownTypes.cs
@@ -91,7 +91,7 @@ namespace ProtoBuf.Schemas
             HasTimestamp hazTs;
             using (var ms = new MemoryStream())
             {
-                model.Serialize(ms, hazDt, null);
+                model.Serialize(ms, hazDt);
                 ms.Position = 0;
 #pragma warning disable CS0618
                 hazTs = (HasTimestamp)model.Deserialize(ms, null, typeof(HasTimestamp));

--- a/src/protobuf-net/Compiler/CompilerContext.cs
+++ b/src/protobuf-net/Compiler/CompilerContext.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Globalization;
 using ProtoBuf.Internal.Serializers;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 
 namespace ProtoBuf.Compiler
 {
@@ -1446,7 +1447,7 @@ namespace ProtoBuf.Compiler
             {
                 EmitCall(typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsSerializationContext)));
             }
-            else if (asType == typeof(SerializationContext))
+            else if (asType == typeof(StreamingContext))
             {
                 EmitCall(typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsStreamingContext)));
             }

--- a/src/protobuf-net/Compiler/CompilerContext.cs
+++ b/src/protobuf-net/Compiler/CompilerContext.cs
@@ -1420,7 +1420,7 @@ namespace ProtoBuf.Compiler
         //    Emit(value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
         //}
 
-        internal void LoadSerializationContext(bool oldApi) // old api = SerializationContext; new api = ISerializationContext
+        internal void LoadSerializationContext(Type asType) // old api = SerializationContext; new api = ISerializationContext
         {
             LoadState();
             switch (_signature)
@@ -1438,9 +1438,21 @@ namespace ProtoBuf.Compiler
                     ThrowHelper.ThrowInvalidOperationException($"Cannot load context for {_signature}");
                     break;
             }
-            if (oldApi)
+            if (asType == typeof(ISerializationContext))
             {
-                LoadValue(typeof(ISerializationContext).GetProperty(nameof(ISerializationContext.Context)));
+                // fine, done
+            }
+            else if (asType == typeof(SerializationContext))
+            {
+                EmitCall(typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsSerializationContext)));
+            }
+            else if (asType == typeof(SerializationContext))
+            {
+                EmitCall(typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsStreamingContext)));
+            }
+            else
+            {
+                ThrowHelper.ThrowArgumentException($"Unexpected context type: {asType.NormalizeName()}");
             }
         }
 

--- a/src/protobuf-net/Compiler/CompilerContextScope.cs
+++ b/src/protobuf-net/Compiler/CompilerContextScope.cs
@@ -115,14 +115,12 @@ namespace ProtoBuf.Compiler
                         else if (parameterType == typeof(SerializationContext))
                         {
                             il.Emit(OpCodes.Ldarg_1);
-                            il.EmitCall(OpCodes.Callvirt, typeof(ISerializationContext).GetProperty(nameof(ISerializationContext.Context)).GetGetMethod(), null);
+                            il.EmitCall(OpCodes.Call, typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsSerializationContext)), null);
                         }
                         else if (parameterType == typeof(StreamingContext))
                         {
                             il.Emit(OpCodes.Ldarg_1);
-                            il.EmitCall(OpCodes.Callvirt, typeof(ISerializationContext).GetProperty(nameof(ISerializationContext.Context)).GetGetMethod(), null);
-                            MethodInfo op = typeof(SerializationContext).GetMethod("op_Implicit", new Type[] { typeof(SerializationContext) });
-                            il.EmitCall(OpCodes.Call, op, null);
+                            il.EmitCall(OpCodes.Call, typeof(SerializationContext).GetMethod(nameof(SerializationContext.AsStreamingContext)), null);
                         }
                         else
                         {
@@ -141,7 +139,7 @@ namespace ProtoBuf.Compiler
                     method.DefineParameter(2, ParameterAttributes.None, "context");
 
                     WriteCall(method.GetILGenerator(), callback);
-                    
+
                     var cctor = type.DefineTypeInitializer();
                     var il = cctor.GetILGenerator();
                     il.Emit(OpCodes.Ldnull);

--- a/src/protobuf-net/Internal/Serializers/CompiledSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/CompiledSerializer.cs
@@ -118,7 +118,7 @@ namespace ProtoBuf.Internal.Serializers
 
         object IProtoTypeSerializer.CreateInstance(ISerializationContext context) => head.CreateInstance(context);
 
-        public void Callback(object value, TypeModel.CallbackType callbackType, SerializationContext context)
+        public void Callback(object value, TypeModel.CallbackType callbackType, ISerializationContext context)
         {
             head.Callback(value, callbackType, context); // these routes only used when bits of the model not compiled
         }

--- a/src/protobuf-net/Internal/Serializers/ExternalSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/ExternalSerializer.cs
@@ -53,7 +53,7 @@ namespace ProtoBuf.Internal.Serializers
         {
             return !(Serializer is IFactory<T> factory) ? null : (object)factory.Create(context);
         }
-        void IProtoTypeSerializer.Callback(object value, TypeModel.CallbackType callbackType, SerializationContext context)
+        void IProtoTypeSerializer.Callback(object value, TypeModel.CallbackType callbackType, ISerializationContext context)
         { }
 
         bool IProtoTypeSerializer.ShouldEmitCreateInstance => false;

--- a/src/protobuf-net/Internal/Serializers/IRuntimeProtoTypeSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/IRuntimeProtoTypeSerializer.cs
@@ -10,7 +10,7 @@ namespace ProtoBuf.Internal.Serializers
         bool HasCallbacks(TypeModel.CallbackType callbackType);
         bool CanCreateInstance();
         object CreateInstance(ISerializationContext context);
-        void Callback(object value, TypeModel.CallbackType callbackType, SerializationContext context);
+        void Callback(object value, TypeModel.CallbackType callbackType, ISerializationContext context);
 
         void EmitCallback(Compiler.CompilerContext ctx, Compiler.Local valueFrom, TypeModel.CallbackType callbackType);
         void EmitCreateInstance(Compiler.CompilerContext ctx, bool callNoteObject = true);

--- a/src/protobuf-net/Internal/Serializers/SubItemSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/SubItemSerializer.cs
@@ -242,7 +242,7 @@ namespace ProtoBuf.Internal.Serializers
             ((IProtoTypeSerializer)Proxy.Serializer).EmitCreateInstance(ctx, callNoteObject);
         }
 
-        void IProtoTypeSerializer.Callback(object value, TypeModel.CallbackType callbackType, SerializationContext context)
+        void IProtoTypeSerializer.Callback(object value, TypeModel.CallbackType callbackType, ISerializationContext context)
         {
             ((IProtoTypeSerializer)Proxy.Serializer).Callback(value, callbackType, context);
         }

--- a/src/protobuf-net/Internal/Serializers/SurrogateSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/SurrogateSerializer.cs
@@ -17,7 +17,7 @@ namespace ProtoBuf.Internal.Serializers
 
         object IProtoTypeSerializer.CreateInstance(ISerializationContext source) => throw new NotSupportedException();
 
-        void IProtoTypeSerializer.Callback(object value, ProtoBuf.Meta.TypeModel.CallbackType callbackType, SerializationContext context) { }
+        void IProtoTypeSerializer.Callback(object value, ProtoBuf.Meta.TypeModel.CallbackType callbackType, ISerializationContext context) { }
 
 
         T ISerializer<T>.Read(ref ProtoReader.State state, T value)

--- a/src/protobuf-net/Internal/Serializers/TagDecorator.cs
+++ b/src/protobuf-net/Internal/Serializers/TagDecorator.cs
@@ -15,7 +15,7 @@ namespace ProtoBuf.Internal.Serializers
 
         public object CreateInstance(ISerializationContext source) => ((IProtoTypeSerializer)Tail).CreateInstance(source);
 
-        public void Callback(object value, TypeModel.CallbackType callbackType, SerializationContext context)
+        public void Callback(object value, TypeModel.CallbackType callbackType, ISerializationContext context)
             => (Tail as IProtoTypeSerializer)?.Callback(value, callbackType, context);
             
         public void EmitCallback(Compiler.CompilerContext ctx, Compiler.Local valueFrom, TypeModel.CallbackType callbackType)

--- a/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
@@ -61,7 +61,7 @@ namespace ProtoBuf.Internal.Serializers
         public Type ExpectedType => typeof(T);
         Type IProtoTypeSerializer.BaseType => typeof(T);
 
-        void IProtoTypeSerializer.Callback(object value, Meta.TypeModel.CallbackType callbackType, SerializationContext context) { }
+        void IProtoTypeSerializer.Callback(object value, Meta.TypeModel.CallbackType callbackType, ISerializationContext context) { }
         object IProtoTypeSerializer.CreateInstance(ISerializationContext source) { throw new NotSupportedException(); }
         private object GetValue(object obj, int index)
         {

--- a/src/protobuf-net/Serializer.Deserialize.cs
+++ b/src/protobuf-net/Serializer.Deserialize.cs
@@ -25,9 +25,20 @@ namespace ProtoBuf
         /// </summary>
         /// <typeparam name="T">The type to be created.</typeparam>
         /// <returns>A new, initialized instance.</returns>
-        public static T Deserialize<T>(Stream source, T value = default, SerializationContext context = default, long length = ProtoReader.TO_EOF)
+        public static T Deserialize<T>(Stream source, T value, SerializationContext context, long length = ProtoReader.TO_EOF)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, context);
+            return state.DeserializeRootImpl<T>(value);
+        }
+
+        /// <summary>
+        /// Creates a new instance from a protocol-buffer stream
+        /// </summary>
+        /// <typeparam name="T">The type to be created.</typeparam>
+        /// <returns>A new, initialized instance.</returns>
+        public static T Deserialize<T>(Stream source, T value = default, object userState = default, long length = ProtoReader.TO_EOF)
+        {
+            using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, userState);
             return state.DeserializeRootImpl<T>(value);
         }
 
@@ -46,18 +57,18 @@ namespace ProtoBuf
         /// <summary>
         /// Creates a new instance from a protocol-buffer stream
         /// </summary>
-        public static T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, SerializationContext context = null)
+        public static T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
         {
-            using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, context);
+            using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, userState);
             return state.DeserializeRootImpl<T>(value);
         }
 
         /// <summary>
         /// Creates a new instance from a protocol-buffer stream
         /// </summary>
-        public static T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, SerializationContext context = null)
+        public static T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
         {
-            using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, context);
+            using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, userState);
             return state.DeserializeRootImpl<T>(value);
         }
     }

--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -352,7 +352,7 @@ namespace ProtoBuf
             /// <returns>The updated instance; this may be different to the instance argument if
             /// either the original instance was null, or the stream defines a known sub-type of the
             /// original instance.</returns>
-            public static bool TryDeserializeWithLengthPrefix(Stream source, PrefixStyle style, TypeResolver resolver, out object value)
+            public static bool TryDeserializeWithLengthPrefix(Stream source, PrefixStyle style, ProtoBuf.TypeResolver resolver, out object value)
             {
                 value = RuntimeTypeModel.Default.DeserializeWithLengthPrefix(source, null, null, style, 0, resolver);
                 return value != null;
@@ -428,5 +428,12 @@ namespace ProtoBuf
         [Obsolete]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static void FlushPool() { }
+
+
+        /// <summary>
+        /// Maps a field-number to a type
+        /// </summary>
+        [Obsolete("Please use ProtoBuf.TypeResolver", true)]
+        public delegate Type TypeResolver(int fieldNumber);
     }
 }

--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Runtime.Serialization;
 
 namespace ProtoBuf
 {
@@ -35,19 +36,24 @@ namespace ProtoBuf
         {
             return RuntimeTypeModel.Default.GetSchema(typeof(T), syntax);
         }
+
         /// <summary>
         /// Create a deep clone of the supplied instance; any sub-items are also cloned.
         /// </summary>
-        public static T DeepClone<T>(T instance, SerializationContext context = null)
-        {
-            return RuntimeTypeModel.Default.DeepClone<T>(instance, context);
-        }
+        public static T DeepClone<T>(T instance, SerializationContext context)
+            => RuntimeTypeModel.Default.DeepClone<T>(instance, context);
+
+        /// <summary>
+        /// Create a deep clone of the supplied instance; any sub-items are also cloned.
+        /// </summary>
+        public static T DeepClone<T>(T instance, object userState = null)
+            => RuntimeTypeModel.Default.DeepClone<T>(instance, userState);
 
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public static long Measure<T>(T value, SerializationContext context = null)
-            => RuntimeTypeModel.Default.Measure<T>(value, context);
+        public static long Measure<T>(T value, object userState = null)
+            => RuntimeTypeModel.Default.Measure<T>(value, userState);
 
         /// <summary>
         /// Applies a protocol-buffer stream to an existing instance.
@@ -124,9 +130,9 @@ namespace ProtoBuf
         /// <typeparam name="T">The type being merged.</typeparam>
         /// <param name="instance">The existing instance to be modified (cannot be null).</param>
         /// <param name="info">The SerializationInfo containing the data to apply to the instance (cannot be null).</param>
-        public static void Merge<T>(System.Runtime.Serialization.SerializationInfo info, T instance) where T : class, System.Runtime.Serialization.ISerializable
+        public static void Merge<T>(SerializationInfo info, T instance) where T : class, ISerializable
         {
-            Merge<T>(info, new System.Runtime.Serialization.StreamingContext(System.Runtime.Serialization.StreamingContextStates.Persistence), instance);
+            Merge<T>(info, new StreamingContext(StreamingContextStates.Persistence), instance);
         }
         /// <summary>
         /// Applies a protocol-buffer from a SerializationInfo to an existing instance.
@@ -135,8 +141,8 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be modified (cannot be null).</param>
         /// <param name="info">The SerializationInfo containing the data to apply to the instance (cannot be null).</param>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public static void Merge<T>(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context, T instance)
-            where T : class, System.Runtime.Serialization.ISerializable
+        public static void Merge<T>(SerializationInfo info, StreamingContext context, T instance)
+            where T : class, ISerializable
         {
             // note: also tried byte[]... it doesn't perform hugely well with either (compared to regular serialization)
             if (info == null) throw new ArgumentNullException(nameof(info));
@@ -145,7 +151,7 @@ namespace ProtoBuf
 
             byte[] buffer = (byte[])info.GetValue(ProtoBinaryField, typeof(byte[]));
             using MemoryStream ms = new MemoryStream(buffer);
-            T result = RuntimeTypeModel.Default.Deserialize<T>(ms, instance, context);
+            T result = RuntimeTypeModel.Default.Deserialize<T>(ms, instance, context.Context);
             if (!ReferenceEquals(result, instance))
             {
                 throw new ProtoException("Deserialization changed the instance; cannot succeed.");


### PR DESCRIPTION
2.4.1:

### ProtoBuf.ProtoReader
ProtoBuf.ProtoReader Create(System.IO.Stream, ProtoBuf.Meta.TypeModel, ProtoBuf.SerializationContext, Int64)
ProtoBuf.SerializationContext get_Context()

### ProtoBuf.ProtoWriter
ProtoBuf.ProtoWriter Create(System.IO.Stream, ProtoBuf.Meta.TypeModel, ProtoBuf.SerializationContext)
ProtoBuf.SerializationContext get_Context()

### ProtoBuf.SerializationContext
System.Runtime.Serialization.StreamingContext op_Implicit(ProtoBuf.SerializationContext)
ProtoBuf.SerializationContext op_Implicit(System.Runtime.Serialization.StreamingContext)

### ProtoBuf.Meta.TypeModel
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, Int64, ProtoBuf.SerializationContext)
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, Int32, ProtoBuf.SerializationContext)
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, ProtoBuf.SerializationContext)
System.Collections.Generic.IEnumerable`1[T] DeserializeItems[T](System.IO.Stream, ProtoBuf.PrefixStyle, Int32, ProtoBuf.SerializationContext)
System.Collections.IEnumerable DeserializeItems(System.IO.Stream, System.Type, ProtoBuf.PrefixStyle, Int32, TypeResolver, ProtoBuf.SerializationContext)
Void Serialize(System.IO.Stream, System.Object, ProtoBuf.SerializationContext)
Void SerializeWithLengthPrefix(System.IO.Stream, System.Object, System.Type, ProtoBuf.PrefixStyle, Int32, ProtoBuf.SerializationContext)

---

3.*

### ProtoBuf.Meta.TypeModel+Formatter
System.Runtime.Serialization.StreamingContext get_Context()
Void set_Context(System.Runtime.Serialization.StreamingContext)

### ProtoBuf.ProtoReader
ProtoBuf.ProtoReader Create(System.IO.Stream, ProtoBuf.Meta.TypeModel, ProtoBuf.SerializationContext, Int64)
ProtoBuf.SerializationContext get_Context()

### ProtoBuf.ProtoWriter
ProtoBuf.ProtoWriter Create(System.IO.Stream, ProtoBuf.Meta.TypeModel, ProtoBuf.SerializationContext)
ProtoBuf.SerializationContext get_Context()

### ProtoBuf.SerializationContext
ProtoBuf.SerializationContext AsSerializationContext(ProtoBuf.ISerializationContext)
System.Runtime.Serialization.StreamingContext AsStreamingContext(ProtoBuf.ISerializationContext)
System.Runtime.Serialization.StreamingContext op_Implicit(ProtoBuf.SerializationContext)
ProtoBuf.SerializationContext op_Implicit(System.Runtime.Serialization.StreamingContext)

### ProtoBuf.Meta.TypeModel
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, ProtoBuf.SerializationContext)
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, Int32, ProtoBuf.SerializationContext)
System.Object Deserialize(System.IO.Stream, System.Object, System.Type, Int64, ProtoBuf.SerializationContext)
System.Collections.Generic.IEnumerable`1[T] DeserializeItems[T](System.IO.Stream, ProtoBuf.PrefixStyle, Int32, ProtoBuf.SerializationContext)
System.Collections.IEnumerable DeserializeItems(System.IO.Stream, System.Type, ProtoBuf.PrefixStyle, Int32, ProtoBuf.TypeResolver, ProtoBuf.SerializationContext)
Void Serialize(System.IO.Stream, System.Object, ProtoBuf.SerializationContext)
Void SerializeWithLengthPrefix(System.IO.Stream, System.Object, System.Type, ProtoBuf.PrefixStyle, Int32, ProtoBuf.SerializationContext)