### PR TITLE
implement cached measure API and verify that it is working

### DIFF
--- a/src/protobuf-net.Core/MeasureState.cs
+++ b/src/protobuf-net.Core/MeasureState.cs
@@ -1,0 +1,102 @@
+﻿using ProtoBuf.Internal;
+using ProtoBuf.Meta;
+using System;
+using System.Buffers;
+using System.IO;
+
+namespace ProtoBuf
+{
+    /// <summary>
+    /// Represents the outcome of computing the length of an object; since this may have required computing lengths
+    /// for multiple objects, some metadata is retained so that a subsequent serialize operation using
+    /// this instance can re-use the previously calculated lengths. If the object state changes between the
+    /// measure and serialize operations, the behavior is undefined.
+    /// </summary>
+    public struct MeasureState<T> : IDisposable
+    {
+        private readonly TypeModel _model;
+        private readonly T _value;
+        private readonly object _userState;
+
+#pragma warning disable IDE0069 // "not disposed" yes it is - see Dispose (it just isn't a trivial case)
+        private ProtoWriter _writer;
+#pragma warning restore IDE0069
+
+        internal MeasureState(TypeModel model, in T value, object userState)
+        {
+            _model = model;
+            _value = value;
+            _userState = userState;
+            var nullState = ProtoWriter.NullProtoWriter.CreateNullProtoWriter(_model, userState);
+            try
+            {
+                Length = TypeModel.SerializeImpl<T>(ref nullState, _value);
+                _writer = nullState.GetWriter();
+            }
+            catch
+            {
+                nullState.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Releases all resources associated with this value
+        /// </summary>
+        public void Dispose()
+        {
+            var writer = _writer;
+            _writer = null;
+            writer?.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the calculated length of this serialize operation, im bytes
+        /// </summary>
+        public long Length { get; }
+
+        /// <summary>
+        /// Returns the calculated length, disposing the value as a side-effect
+        /// </summary>
+        public long LengthOnly()
+        {
+            var len = Length;
+            Dispose();
+            return len;
+        }
+
+        private void SerializeCore(ProtoWriter.State state)
+        {
+            try
+            {
+                var writer = _writer;
+                if (writer == null) throw new ObjectDisposedException(nameof(MeasureState<T>));
+
+                var targetWriter = state.GetWriter();
+                targetWriter.InitializeFrom(writer);
+                long actual = TypeModel.SerializeImpl<T>(ref state, _value);
+                targetWriter.CopyBack(writer);
+
+                if (actual != Length) ThrowHelper.ThrowInvalidOperationException($"Invalid length; expected {Length}, actual: {actual}");
+            }
+            finally
+            {
+                state.Dispose();
+            }
+        }
+
+        internal int GetLengthHits(out int misses) => _writer.GetLengthHits(out misses);
+
+        /// <summary>
+        /// Perform the calculated serialization operation against the provided target stream. If the object state changes between the
+        /// measure and serialize operations, the behavior is undefined.
+        /// </summary>
+        public void Serialize(Stream stream) => SerializeCore(ProtoWriter.State.Create(stream, _model, _userState));
+
+        /// <summary>
+        /// Perform the calculated serialization operation against the provided target writer. If the object state changes between the
+        /// measure and serialize operations, the behavior is undefined.
+        /// </summary>
+        public void Serialize(IBufferWriter<byte> writer) => SerializeCore(ProtoWriter.State.Create(writer, _model, _userState));
+    }
+}

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -268,18 +268,8 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public long Measure<T>(T value, object userState = null)
-        {
-            var state = ProtoWriter.NullProtoWriter.CreateNullProtoWriter(this, userState);
-            try
-            {
-                return SerializeImpl<T>(ref state, value);
-            }
-            finally
-            {
-                state.Dispose();
-            }
-        }
+        public MeasureState<T> Measure<T>(T value, object userState = null)
+            => new MeasureState<T>(this, value, userState);
 
         /// <summary>
         /// Writes a protocol-buffer representation of the given instance to the supplied writer.

--- a/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
@@ -49,7 +49,7 @@ namespace ProtoBuf
 
             private readonly NullProtoWriter _nullWriter;
 
-            private protected override void Dispose()
+            internal override void Dispose()
             {
                 base.Dispose();
                 Pool<BufferWriterProtoWriter>.Put(this);

--- a/src/protobuf-net.Core/ProtoWriter.Null.cs
+++ b/src/protobuf-net.Core/ProtoWriter.Null.cs
@@ -29,7 +29,7 @@ namespace ProtoBuf
             // this is for use as a sub-component of the buffer-writer
             internal NullProtoWriter(NetObjectCache knownObjects) : base(knownObjects) { }
 
-            private protected override void Dispose()
+            internal override void Dispose()
             {
                 base.Dispose();
                 Pool<NullProtoWriter>.Put(this);

--- a/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
+++ b/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
@@ -873,5 +873,15 @@ namespace ProtoBuf
                 ThrowHelper.ThrowProtoException($"No wire-value is mapped to the enum {rhs} at position {GetPosition()}");
             }
         }
+
+        internal void InitializeFrom(ProtoWriter writer) => netCache?.InitializeFrom(writer?.netCache);
+
+        internal void CopyBack(ProtoWriter writer) => netCache?.CopyBack(writer?.netCache);
+
+        internal int GetLengthHits(out int misses)
+        {
+            misses = netCache?.LengthMisses ?? 0;
+            return netCache?.LengthHits ?? 0;
+        }
     }
 }

--- a/src/protobuf-net.Core/ProtoWriter.Stream.cs
+++ b/src/protobuf-net.Core/ProtoWriter.Stream.cs
@@ -64,7 +64,7 @@ namespace ProtoBuf
                 flushLock = 0;
             }
 
-            protected private override void Dispose()
+            internal override void Dispose()
             {
                 base.Dispose();
                 Pool<StreamProtoWriter>.Put(this);

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -226,7 +226,7 @@ namespace ProtoBuf
         partial void OnDispose();
         partial void OnInit(bool impactCount);
 
-        protected private virtual void Dispose()
+        internal virtual void Dispose()
         {
             OnDispose();
             Cleanup();

--- a/src/protobuf-net.Test/MeasureTests.cs
+++ b/src/protobuf-net.Test/MeasureTests.cs
@@ -1,0 +1,171 @@
+﻿using Newtonsoft.Json;
+using Pipelines.Sockets.Unofficial.Buffers;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProtoBuf.Test
+{
+    public class MeasureTests
+    {
+        [Fact]
+        public void TestMeasure_Stream()
+        {
+            var orig = Invent();
+            using var measure = Serializer.Measure(orig);
+            Assert.Equal(10330, measure.Length);
+
+            var measureHits = measure.GetLengthHits(out var measureMisses);
+            Log?.WriteLine($"After measure: {measureHits} hits, {measureMisses} misses");
+
+            var expectedJson = JsonConvert.SerializeObject(orig);
+
+            using var ms = new MemoryStream();
+            measure.Serialize(ms);
+
+            var serializeHits = measure.GetLengthHits(out var serializeMisses);
+            Log?.WriteLine($"After serialize: {serializeHits} hits, {serializeMisses} misses");
+
+            Assert.Equal(10330, ms.Length);
+            Assert.Equal(measureMisses, serializeMisses);
+            Assert.True(measureHits <= serializeHits, "expected no fewer hits");
+
+            ms.Position = 0;
+            var clone = Serializer.Deserialize<MeasureMe>(ms);
+            Assert.NotSame(orig, clone);
+            var actualJson = JsonConvert.SerializeObject(clone);
+            Assert.Equal(expectedJson, actualJson);
+
+            Log?.WriteLine(ToHex(ms));
+        }
+
+        public MeasureTests(ITestOutputHelper log) => Log = log;
+        private ITestOutputHelper Log { get; }
+
+        [Fact]
+        public void TestMeasure_Buffer()
+        {
+            var orig = Invent();
+            using var measure = Serializer.Measure(orig);
+            Assert.Equal(10330, measure.Length);
+
+            var measureHits = measure.GetLengthHits(out var measureMisses);
+            Log?.WriteLine($"After measure: {measureHits} hits, {measureMisses} misses");
+
+            var expectedJson = JsonConvert.SerializeObject(orig);
+
+            using var bw = BufferWriter<byte>.Create(blockSize: 7);
+            measure.Serialize(bw);
+
+            var serializeHits = measure.GetLengthHits(out var serializeMisses);
+            Log?.WriteLine($"After serialize: {serializeHits} hits, {serializeMisses} misses");
+
+            Assert.Equal(10330, bw.Length);
+            Assert.Equal(measureMisses, serializeMisses);
+            Assert.True(measureHits < serializeHits, "expected more hits");
+
+            using var payload = bw.Flush();
+            var ros = payload.Value;
+            Assert.Equal(10330, ros.Length);
+
+            var clone = Serializer.Deserialize<MeasureMe>(ros);
+            Assert.NotSame(orig, clone);
+            var actualJson = JsonConvert.SerializeObject(clone);
+            Assert.Equal(expectedJson, actualJson);
+
+            int segments = CountSegments(ros);
+            Log?.WriteLine($"segments: {segments}");
+            Log?.WriteLine(ToHex(ros));
+        }
+
+        static string ToHex(MemoryStream bytes)
+        {
+            if (!bytes.TryGetBuffer(out var buffer)) return "n/a";
+            return BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count);
+        }
+
+        static int CountSegments(ReadOnlySequence<byte> bytes)
+        {
+            if (bytes.IsEmpty) return 0;
+            if (bytes.IsSingleSegment) return 1;
+            int count = 0;
+            foreach (var _ in bytes)
+                count++;
+            return count;
+        }
+
+        static string ToHex(ReadOnlySequence<byte> bytes)
+        {
+            int len = checked((int)bytes.Length);
+            var arr = ArrayPool<byte>.Shared.Rent(len);
+            try
+            {
+                bytes.CopyTo(arr);
+                return BitConverter.ToString(arr, 0, len);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(arr);
+            }
+        }
+
+        private MeasureMe Invent()
+        {
+            var rand = new Random(12345);
+            string alphabet = " 0123456789 abcdefghijklmnopqrstuvwxyz ";
+            unsafe string InventString()
+            {
+                const int MAXLEN = 64;
+                char* c = stackalloc char[MAXLEN];
+                var len = rand.Next(MAXLEN);
+                for (int i = 0; i < len; i++)
+                {
+                    c[i] = alphabet[rand.Next(alphabet.Length)];
+                }
+                return new string(c, 0, len);
+            }
+            var orig = new MeasureMe
+            {
+                Name = InventString(),
+            };
+            for (int i = 0; i < 250; i++)
+            {
+                Thing thing = rand.Next(10) > 7 ? new SubThing { SubId = rand.Next(10000) } : new Thing();
+                thing.Id = rand.Next(10000);
+                thing.Name = InventString();
+                orig.Things.Add(thing);
+            }
+            return orig;
+        }
+
+        [ProtoContract]
+        public class MeasureMe
+        {
+            [ProtoMember(1)]
+            public string Name { get; set; }
+
+            [ProtoMember(2)]
+            public List<Thing> Things { get; } = new List<Thing>();
+        }
+
+        [ProtoContract]
+        [ProtoInclude(3, typeof(SubThing))]
+        public class Thing
+        {
+            [ProtoMember(1)]
+            public int Id { get; set; }
+            [ProtoMember(2)]
+            public string Name { get; set; }
+        }
+
+        [ProtoContract]
+        public class SubThing : Thing
+        {
+            [ProtoMember(1)]
+            public int SubId { get; set; }
+        }
+    }
+}

--- a/src/protobuf-net.Test/protobuf-net.Test.csproj
+++ b/src/protobuf-net.Test/protobuf-net.Test.csproj
@@ -7,6 +7,7 @@
     <WithSpans>true</WithSpans>
     <NoWarn>$(NoWarn);IDE0060;IDE1006;xUnit1004</NoWarn>
     <RootNamespace>ProtoBuf.Test</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework)=='netcoreapp3.0'">
     <DefineConstants>FEAT_COMPILER;NO_NHIBERNATE;COREFX;PLAT_NO_EMITDLL;PLAT_ARRAY_BUFFER_WRITER</DefineConstants>
@@ -22,6 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.0.25" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='net462'">
     <PackageReference Include="NHibernate" Version="4.1.1.4000" />

--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -52,7 +52,7 @@ namespace ProtoBuf
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public static long Measure<T>(T value, object userState = null)
+        public static MeasureState<T> Measure<T>(T value, object userState = null)
             => RuntimeTypeModel.Default.Measure<T>(value, userState);
 
         /// <summary>


### PR DESCRIPTION
currently only impacts buffer-writer implementation, since `Stream` doesn't currently write calculated lengths to the cache