### PR TITLE
don't skip empty packed arrays by default

### DIFF
--- a/src/Examples/Issues/Issue44.cs
+++ b/src/Examples/Issues/Issue44.cs
@@ -59,10 +59,7 @@ namespace Examples.Issues
             PEVerify.AssertValid(name + ".dll");
         }
         static bool SerializeDateTimeKind(TypeModel model)
-        {
-            return (bool)typeof(TypeModel).GetMethod(
-                "SerializeDateTimeKind", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).Invoke(model, null);
-        }
+            => (model.Options & TypeModel.TypeModelOptions.IncludeDateTimeKind) != 0;
 
         static void CompareDates(HazTime expected, HazTime actual, bool withKind, string model)
         {

--- a/src/Examples/ListTests.cs
+++ b/src/Examples/ListTests.cs
@@ -253,8 +253,9 @@ namespace Examples
            
             item.ListNoDefault = new List<int>();
             clone = Serializer.DeepClone(item);
-            Assert.Null(clone.ListNoDefault);
-           
+            Assert.NotNull(clone.ListNoDefault);
+            Assert.Empty(clone.ListNoDefault);
+
             item.ListNoDefault.Add(123);
             clone = Serializer.DeepClone(item);
             Assert.NotNull(clone.ListNoDefault);
@@ -292,7 +293,8 @@ namespace Examples
 
             item.ItemArray = new int[0];
             clone = Serializer.DeepClone(item);
-            Assert.Null(clone.ItemArray);
+            Assert.NotNull(clone.ItemArray);
+            Assert.Empty(clone.ItemArray);
 
             item.ItemArray = new int[1] { 123 };
             clone = Serializer.DeepClone(item);
@@ -329,7 +331,8 @@ namespace Examples
 
             item.Custom = new CustomEnumerable();
             clone = Serializer.DeepClone(item);
-            Assert.Null(clone.Custom);
+            Assert.NotNull(clone.Custom);
+            Assert.Empty(clone.Custom);
 
             item.Custom.Add(123);
             clone = Serializer.DeepClone(item);

--- a/src/protobuf-net.Core/Internal/PrimaryTypeProvider.TimeSpan.cs
+++ b/src/protobuf-net.Core/Internal/PrimaryTypeProvider.TimeSpan.cs
@@ -37,7 +37,7 @@ namespace ProtoBuf.Internal
         void ISerializer<DateTime>.Write(ref ProtoWriter.State state, DateTime value)
         {
             var model = state.Model;
-            var includeKind = model != null && model.SerializeDateTimeKind();
+            var includeKind = model != null && model.HasOption(Meta.TypeModel.TypeModelOptions.IncludeDateTimeKind);
             ((ISerializer<ScaledTicks>)this).Write(ref state, ScaledTicks.Create(value, includeKind));
         }
 

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -26,19 +26,42 @@ namespace ProtoBuf.Meta
             => SerializerCache<TProvider, T>.InstanceField;
 
         /// <summary>
-        /// Should the <c>Kind</c> be included on date/time values?
+        /// Specifies optional behaviors associated with a type model
         /// </summary>
-        protected internal virtual bool SerializeDateTimeKind() => false;
+        [Flags]
+        public enum TypeModelOptions
+        {
+            /// <summary>
+            /// No additional options
+            /// </summary>
+            None = 0,
+            /// <summary>
+            /// Should the deserializer attempt to avoid duplicate copies of the same string?
+            /// </summary>
+            InternStrings = 1 << 0,
+            /// <summary>
+            /// Should the <c>Kind</c> be included on date/time values?
+            /// </summary>
+            IncludeDateTimeKind = 1 << 1,
+            /// <summary>
+            /// Should zero-length packed arrays be serialized? (this is the v2 behavior, but skipping them is more efficient)
+            /// </summary>
+            SkipZeroLengthPackedArrays = 1 << 2,
+        }
+
+        [MethodImpl(ProtoReader.HotPath)]
+        internal bool HasOption(TypeModelOptions options)
+            => (Options & options) != 0;
+
+
+        [MethodImpl(ProtoReader.HotPath)]
+        internal bool OmitsOption(TypeModelOptions options)
+            => (Options & options) == 0;
 
         /// <summary>
-        /// Global switch that determines whether a single instance of the same string should be used during deserialization.
+        /// Specifies optional behaviors associated with this model
         /// </summary>
-        public bool InternStrings => GetInternStrings();
-
-        /// <summary>
-        /// Global switch that determines whether a single instance of the same string should be used during deserialization.
-        /// </summary>
-        protected internal virtual bool GetInternStrings() => false;
+        public virtual TypeModelOptions Options => 0;
 
         /// <summary>
         /// Resolve a System.Type to the compiler-specific type

--- a/src/protobuf-net.Core/ProtoReader.cs
+++ b/src/protobuf-net.Core/ProtoReader.cs
@@ -110,7 +110,7 @@ namespace ProtoBuf
             _depth = _fieldNumber = 0;
 
             blockEnd64 = long.MaxValue;
-            InternStrings = (model ?? TypeModel.DefaultModel)?.InternStrings ?? false;
+            InternStrings = (model ?? TypeModel.DefaultModel)?.HasOption(TypeModel.TypeModelOptions.InternStrings) ?? false;
             WireType = WireType.None;
 #if FEAT_DYNAMIC_REF
             trapCount = 1;

--- a/src/protobuf-net.Reflection/Internal/CustomProtogenSerializer.cs
+++ b/src/protobuf-net.Reflection/Internal/CustomProtogenSerializer.cs
@@ -8,11 +8,8 @@ namespace ProtoBuf.Reflection.Internal
     {
         private CustomProtogenSerializer() { }
         internal static TypeModel Instance { get; } = new CustomProtogenSerializer();
-        protected override bool GetInternStrings() => false;
 
         protected override ISerializer<T> GetSerializer<T>() =>
             SerializerCache.Get<CustomProtogenSerializerServices, T>();
-
-        protected override bool SerializeDateTimeKind() => false;
     }
 }

--- a/src/protobuf-net.Test/Meta/Lists.cs
+++ b/src/protobuf-net.Test/Meta/Lists.cs
@@ -388,23 +388,23 @@ namespace ProtoBuf.unittest.Meta
             var orig = new PackedData { ListInt32 = new List<int>(), ListSingle = new List<float>(), ListDouble = new List<double>()};
 
             var clone = RoundTrip(model, orig, "Runtime", out int len);
-            Assert.Equal(0, len); //, "Runtime");
-            Assert.Null(clone.ListDouble);
-            Assert.Null(clone.ListInt32);
-            Assert.Null(clone.ListSingle);
+            Assert.Equal(6, len); //, "Runtime");
+            Assert.Empty(clone.ListDouble);
+            Assert.Empty(clone.ListInt32);
+            Assert.Empty(clone.ListSingle);
 
             model.CompileInPlace();
             clone = RoundTrip(model, orig, "CompileInPlace", out len);
-            Assert.Equal(0, len); //, "CompileInPlace");
-            Assert.Null(clone.ListDouble);
-            Assert.Null(clone.ListInt32);
-            Assert.Null(clone.ListSingle);
+            Assert.Equal(6, len); //, "CompileInPlace");
+            Assert.Empty(clone.ListDouble);
+            Assert.Empty(clone.ListInt32);
+            Assert.Empty(clone.ListSingle);
 
             clone = RoundTrip(model.Compile(), orig, "Compile", out len);
-            Assert.Equal(0, len); //, "Compile");
-            Assert.Null(clone.ListDouble);
-            Assert.Null(clone.ListInt32);
-            Assert.Null(clone.ListSingle);
+            Assert.Equal(6, len); //, "Compile");
+            Assert.Empty(clone.ListDouble);
+            Assert.Empty(clone.ListInt32);
+            Assert.Empty(clone.ListSingle);
         }
 
 #pragma warning disable IDE0060
@@ -504,23 +504,23 @@ namespace ProtoBuf.unittest.Meta
             var orig = new PackedData { ArrayInt32 = new int[0], ArraySingle = new float[0], ArrayDouble = new double[0] };
 
             var clone = RoundTrip(model, orig, "Runtime", out int len);
-            Assert.Equal(0, len); //, "Runtime");
-            Assert.Null(clone.ArrayDouble);
-            Assert.Null(clone.ArrayInt32);
-            Assert.Null(clone.ArraySingle);
+            Assert.Equal(6, len); //, "Runtime");
+            Assert.Empty(clone.ArrayDouble);
+            Assert.Empty(clone.ArrayInt32);
+            Assert.Empty(clone.ArraySingle);
 
             model.CompileInPlace();
             clone = RoundTrip(model, orig, "CompileInPlace", out len);
-            Assert.Equal(0, len); //, "CompileInPlace");
-            Assert.Null(clone.ArrayDouble);
-            Assert.Null(clone.ArrayInt32);
-            Assert.Null(clone.ArraySingle);
+            Assert.Equal(6, len); //, "CompileInPlace");
+            Assert.Empty(clone.ArrayDouble);
+            Assert.Empty(clone.ArrayInt32);
+            Assert.Empty(clone.ArraySingle);
 
             clone = RoundTrip(model.Compile(), orig, "Compile", out len);
-            Assert.Equal(0, len); //, "Compile");
-            Assert.Null(clone.ArrayDouble);
-            Assert.Null(clone.ArrayInt32);
-            Assert.Null(clone.ArraySingle);
+            Assert.Equal(6, len); //, "Compile");
+            Assert.Empty(clone.ArrayDouble);
+            Assert.Empty(clone.ArrayInt32);
+            Assert.Empty(clone.ArraySingle);
         }
         [Fact]
         public void TestNullRoundTrip()

--- a/src/protobuf-net.Test/NestedDictionarySupport.cs
+++ b/src/protobuf-net.Test/NestedDictionarySupport.cs
@@ -12,7 +12,7 @@ namespace ProtoBuf
         public void DictionaryListList_Empty() => RoundTripWithoutValue(new HazDictionaryWithLists(), "");
 
         [Theory]
-        [InlineData(new object[] { new int[] { }, "D2-02-00-0A-00" })] // field 42, length 0, field 1 = (empty)
+        [InlineData(new object[] { new int[] { }, "D2-02-02-0A-00" })] // field 42, length 0, field 1 = (empty)
         [InlineData(new object[] { new int[] { 7 }, "D2-02-02-08-07" })] // field 42, length 2; field 1 = 7
         [InlineData(new object[] { new int[] { 4, 5}, "D2-02-04-0A-02-04-05" })] // field 42, length 4; field 1 = 4, field 1 = 5
         // note: v2 was "D2-02-04-08-04-08-05", but this is equivalent as 'packed'

--- a/src/protobuf-net.Test/NestedDictionarySupport.cs
+++ b/src/protobuf-net.Test/NestedDictionarySupport.cs
@@ -12,7 +12,7 @@ namespace ProtoBuf
         public void DictionaryListList_Empty() => RoundTripWithoutValue(new HazDictionaryWithLists(), "");
 
         [Theory]
-        [InlineData(new object[] { new int[] { }, "D2-02-00" })] // field 42, length 0
+        [InlineData(new object[] { new int[] { }, "D2-02-00-0A-00" })] // field 42, length 0, field 1 = (empty)
         [InlineData(new object[] { new int[] { 7 }, "D2-02-02-08-07" })] // field 42, length 2; field 1 = 7
         [InlineData(new object[] { new int[] { 4, 5}, "D2-02-04-0A-02-04-05" })] // field 42, length 4; field 1 = 4, field 1 = 5
         // note: v2 was "D2-02-04-08-04-08-05", but this is equivalent as 'packed'

--- a/src/protobuf-net/Internal/Serializers/DateTimeSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/DateTimeSerializer.cs
@@ -14,10 +14,10 @@ namespace ProtoBuf.Internal.Serializers
 
         private readonly bool includeKind, wellKnown;
 
-        public DateTimeSerializer(DataFormat dataFormat, ProtoBuf.Meta.TypeModel model)
+        public DateTimeSerializer(DataFormat dataFormat, Meta.TypeModel model)
         {
             wellKnown = dataFormat == DataFormat.WellKnown;
-            includeKind = model?.SerializeDateTimeKind() == true;
+            includeKind = model?.HasOption(Meta.TypeModel.TypeModelOptions.IncludeDateTimeKind) == true;
         }
 
         public object Read(ref ProtoReader.State state, object value)


### PR DESCRIPTION
1. main change: don't skip empty packed arrays by default; reason: v2 didn't, which means properties can be null unexpectedly
2. this is now a flag on TypeModel that defaults to v2 (don't skip)
3. while we're there, let's clean up how optional flags are handled on TypeModel so we don't need to keep adding extra properties
4. fix up tests that expected empty packed arrays to not be serialized