### PR TITLE
more frugal emits on full dll write

### DIFF
--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -61,7 +61,9 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Specifies optional behaviors associated with this model
         /// </summary>
-        public virtual TypeModelOptions Options => 0;
+        public virtual TypeModelOptions Options => DefaultOptions;
+
+        internal const TypeModelOptions DefaultOptions = 0; // important: WriteConstructorsAndOverrides only overrides if different
 
         /// <summary>
         /// Resolve a System.Type to the compiler-specific type


### PR DESCRIPTION
1. don't write a new .Features method for every single type; only emit one method per "features" value
2. don't override TypeModel.Options unless we have something interesting to say
3. don't include [Serializable] on the generated types