### PR TITLE
Merge 2.4.2

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -47,6 +47,10 @@ Other changes:
 - as a consequence of the above, the "setter" may not be invoked (to an empty array) when previously it might have been; this again is consistent with how non-"packed" works
 - common stacks (`Stack<T>`, `ConcurrentStack<T>`) now preserve order correctly
 
+## 2.4.2
+
+- add `IProtoInput<T>` / `IProtoOutput<T>` API for discovering input/output capabilities (this is to allow testing for 3.0 features)
+
 ## 2.4.1
 
 - fixes for .NET Core 3, thanks @szehetner

--- a/src/protobuf-net.Core/IProtoInputT.cs
+++ b/src/protobuf-net.Core/IProtoInputT.cs
@@ -1,0 +1,13 @@
+﻿namespace ProtoBuf
+{
+    /// <summary>
+    /// Represents the ability to serialize values to an output of type <typeparamref name="TOutput"/>
+    /// </summary>
+    public interface IProtoOutput<TOutput>
+    {
+        /// <summary>
+        /// Serialize the provided value
+        /// </summary>
+        void Serialize<T>(TOutput destination, T value, object userState = null);
+    }
+}

--- a/src/protobuf-net.Core/IProtoReaderT.cs
+++ b/src/protobuf-net.Core/IProtoReaderT.cs
@@ -1,0 +1,13 @@
+﻿namespace ProtoBuf
+{
+    /// <summary>
+    /// Represents the ability to deserialize values from an input of type <typeparamref name="TInput"/>
+    /// </summary>
+    public interface IProtoInput<TInput>
+    {
+        /// <summary>
+        /// Deserialize a value from the input
+        /// </summary>
+        T Deserialize<T>(TInput source, T value = default, object userState = null);
+    }
+}

--- a/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 
 namespace ProtoBuf.Meta
@@ -7,18 +8,34 @@ namespace ProtoBuf.Meta
         IProtoInput<Stream>,
         IProtoInput<ArraySegment<byte>>,
         IProtoInput<byte[]>,
-        IProtoOutput<Stream>
+        IProtoInput<ReadOnlyMemory<byte>>,
+        IProtoInput<ReadOnlySequence<byte>>,
+        IProtoOutput<Stream>,
+        IProtoOutput<IBufferWriter<byte>>
     {
         T IProtoInput<Stream>.Deserialize<T>(Stream source, T value, object userState)
             => Deserialize<T>(source, value, userState);
-
-        void IProtoOutput<Stream>.Serialize<T>(Stream destination, T value, object userState)
-            => Serialize<T>(destination, value, userState);
 
         T IProtoInput<ArraySegment<byte>>.Deserialize<T>(ArraySegment<byte> source, T value, object userState)
             => Deserialize<T>(new ReadOnlyMemory<byte>(source.Array, source.Offset, source.Count), value, userState);
 
         T IProtoInput<byte[]>.Deserialize<T>(byte[] source, T value, object userState)
             => Deserialize<T>(new ReadOnlyMemory<byte>(source), value, userState);
+
+        T IProtoInput<ReadOnlyMemory<byte>>.Deserialize<T>(ReadOnlyMemory<byte> source, T value, object userState)
+            => Deserialize<T>(source, value, userState);
+
+        T IProtoInput<ReadOnlySequence<byte>>.Deserialize<T>(ReadOnlySequence<byte> source, T value, object userState)
+            => Deserialize<T>(source, value, userState);
+
+
+
+
+        void IProtoOutput<Stream>.Serialize<T>(Stream destination, T value, object userState)
+            => Serialize<T>(destination, value, userState);
+
+
+        void IProtoOutput<IBufferWriter<byte>>.Serialize<T>(IBufferWriter<byte> destination, T value, object userState)
+            => Serialize<T>(destination, value, userState);
     }
 }

--- a/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+
+namespace ProtoBuf.Meta
+{
+    partial class TypeModel : IProtoInput<Stream>, IProtoOutput<Stream>
+    {
+        T IProtoInput<Stream>.Deserialize<T>(Stream source, T value, object userState)
+            => Deserialize<T>(source, value, userState);
+
+        void IProtoOutput<Stream>.Serialize<T>(Stream destination, T value, object userState)
+            => Serialize<T>(destination, value, userState);
+    }
+}

--- a/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.InputOutput.cs
@@ -1,13 +1,24 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace ProtoBuf.Meta
 {
-    partial class TypeModel : IProtoInput<Stream>, IProtoOutput<Stream>
+    partial class TypeModel :
+        IProtoInput<Stream>,
+        IProtoInput<ArraySegment<byte>>,
+        IProtoInput<byte[]>,
+        IProtoOutput<Stream>
     {
         T IProtoInput<Stream>.Deserialize<T>(Stream source, T value, object userState)
             => Deserialize<T>(source, value, userState);
 
         void IProtoOutput<Stream>.Serialize<T>(Stream destination, T value, object userState)
             => Serialize<T>(destination, value, userState);
+
+        T IProtoInput<ArraySegment<byte>>.Deserialize<T>(ArraySegment<byte> source, T value, object userState)
+            => Deserialize<T>(new ReadOnlyMemory<byte>(source.Array, source.Offset, source.Count), value, userState);
+
+        T IProtoInput<byte[]>.Deserialize<T>(byte[] source, T value, object userState)
+            => Deserialize<T>(new ReadOnlyMemory<byte>(source), value, userState);
     }
 }

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -1,3 +1,4 @@
+
 ﻿using ProtoBuf.Internal;
 using ProtoBuf.Serializers;
 using System;

--- a/src/protobuf-net.Test/InputOutputAPI.cs
+++ b/src/protobuf-net.Test/InputOutputAPI.cs
@@ -1,0 +1,39 @@
+﻿using ProtoBuf.Meta;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf
+{
+    public class InputOutputAPI
+    {
+        [Fact]
+        public void IsStreamInput() => Assert.True(RuntimeTypeModel.Default is IProtoInput<Stream>);
+        [Fact]
+        public void IsStreamOutput() => Assert.True(RuntimeTypeModel.Default is IProtoOutput<Stream>);
+
+        [ProtoContract]
+        public class SomeModel
+        {
+            [ProtoMember(1)]
+            public int Id { get; set; }
+        }
+        [Fact]
+        public void CanSerializeViaInputOutputAPI()
+        {
+            using (var ms = new MemoryStream())
+            {
+                IProtoOutput<Stream> output = RuntimeTypeModel.Default;
+                var orig = new SomeModel { Id = 42 };
+                output.Serialize(ms, orig);
+
+                ms.Position = 0;
+
+                IProtoInput<Stream> input = RuntimeTypeModel.Default;
+                var clone = input.Deserialize<SomeModel>(ms);
+
+                Assert.NotSame(orig, clone);
+                Assert.Equal(42, clone.Id);
+            }
+        }
+    }
+}

--- a/src/protobuf-net.Test/InputOutputAPI.cs
+++ b/src/protobuf-net.Test/InputOutputAPI.cs
@@ -1,5 +1,7 @@
-﻿using ProtoBuf.Meta;
+﻿using Pipelines.Sockets.Unofficial.Buffers;
+using ProtoBuf.Meta;
 using System;
+using System.Buffers;
 using System.IO;
 using Xunit;
 
@@ -30,33 +32,48 @@ namespace ProtoBuf
         [Fact]
         public void CanSerializeViaInputOutputAPI()
         {
-            using (var ms = new MemoryStream())
-            {
-                IProtoOutput<Stream> output = RuntimeTypeModel.Default;
-                var orig = new SomeModel { Id = 42 };
-                output.Serialize(ms, orig);
+            using var ms = new MemoryStream();
+            IProtoOutput<Stream> output = RuntimeTypeModel.Default;
+            var orig = new SomeModel { Id = 42 };
+            output.Serialize(ms, orig);
 
-                ms.Position = 0;
+            ms.Position = 0;
 
-                IProtoInput<Stream> input = RuntimeTypeModel.Default;
-                var clone = input.Deserialize<SomeModel>(ms);
+            IProtoInput<Stream> input = RuntimeTypeModel.Default;
+            var clone = input.Deserialize<SomeModel>(ms);
 
-                Assert.NotSame(orig, clone);
-                Assert.Equal(42, clone.Id);
+            Assert.NotSame(orig, clone);
+            Assert.Equal(42, clone.Id);
 
-                IProtoInput<byte[]> arrayInput = RuntimeTypeModel.Default;
-                clone = arrayInput.Deserialize<SomeModel>(ms.ToArray());
+            IProtoInput<byte[]> arrayInput = RuntimeTypeModel.Default;
+            clone = arrayInput.Deserialize<SomeModel>(ms.ToArray());
 
-                Assert.NotSame(orig, clone);
-                Assert.Equal(42, clone.Id);
+            Assert.NotSame(orig, clone);
+            Assert.Equal(42, clone.Id);
 
-                var segment = new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
-                IProtoInput<ArraySegment<byte>> segmentInput = RuntimeTypeModel.Default;
-                clone = segmentInput.Deserialize<SomeModel>(segment);
+            var segment = new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
+            IProtoInput<ArraySegment<byte>> segmentInput = RuntimeTypeModel.Default;
+            clone = segmentInput.Deserialize<SomeModel>(segment);
 
-                Assert.NotSame(orig, clone);
-                Assert.Equal(42, clone.Id);
-            }
+            Assert.NotSame(orig, clone);
+            Assert.Equal(42, clone.Id);
+        }
+
+        [Fact]
+        public void CanSerializeViaInputOutputAPI_Buffers()
+        {
+            using var buffer = BufferWriter<byte>.Create();
+            IProtoOutput<IBufferWriter<byte>> output = RuntimeTypeModel.Default;
+
+            var orig = new SomeModel { Id = 42 };
+            output.Serialize(buffer, orig);
+
+            using var payload = buffer.Flush();
+            IProtoInput<ReadOnlySequence<byte>> input = RuntimeTypeModel.Default;
+            var clone = input.Deserialize<SomeModel>(payload.Value);
+
+            Assert.NotSame(orig, clone);
+            Assert.Equal(42, clone.Id);
         }
     }
 }

--- a/src/protobuf-net/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net/Properties/AssemblyInfo.cs
@@ -52,3 +52,5 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(ProtoPartialMemberAttribute))]
 [assembly: TypeForwardedTo(typeof(ProtoPartialIgnoreAttribute))]
 [assembly: TypeForwardedTo(typeof(ImplicitFields))]
+[assembly: TypeForwardedTo(typeof(IProtoInput<>))]
+[assembly: TypeForwardedTo(typeof(IProtoOutput<>))]

--- a/src/version.json
+++ b/src/version.json
@@ -7,7 +7,6 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
-    "^refs/tags/v\\d+\\.\\d+",
-    "^refs/heads/split-reader"
+    "^refs/tags/v\\d+\\.\\d+"
   ]
 }


### PR DESCRIPTION
2.4.2 adds a capability API to allow callers to check for input/output API; we merge that change, and add support for `IBufferWriter<byte>`, `ReadOnlyMemory<byte>` and `ReadOnlySequence<byte>`