### PR TITLE
Fix hard ref-emit fail

### DIFF
--- a/src/protobuf-net.Test/Issues/SO_DictionaryFail.cs
+++ b/src/protobuf-net.Test/Issues/SO_DictionaryFail.cs
@@ -1,0 +1,65 @@
+﻿using ProtoBuf.Meta;
+using ProtoBuf.unittest;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    public class SO_DictionaryFail
+    {
+        [Fact]
+        public void TupleDictionary()
+        {
+
+
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            model.Add<Tuple<Dictionary<string,double>, Dictionary<string,double>>>();
+            //Test(model);
+
+            var dll = model.CompileAndVerify();
+
+            //model.CompileInPlace();
+            //Test(model);
+
+            //Test(model.Compile());
+
+            Test(dll);
+        }
+
+        private static void Test(TypeModel model)
+        {
+            var data = Tuple.Create(
+                new Dictionary<string, double>
+                {
+                                {"abc", 123 },
+                                {"def", 456 },
+                                {"ghi", 789 },
+                },
+                new Dictionary<string, double>
+                {
+                                {"jkl", 1011 },
+                                {"mno", 1213 },
+                });
+
+            var clone = model.DeepClone(data);
+            Assert.NotSame(data, clone);
+            var x = clone.Item1;
+            Assert.Equal(3, x.Count);
+            Assert.True(x.TryGetValue("abc", out var val));
+            Assert.Equal(123, val);
+            Assert.True(x.TryGetValue("def", out val));
+            Assert.Equal(456, val);
+            Assert.True(x.TryGetValue("ghi", out val));
+            Assert.Equal(789, val);
+
+            var y = clone.Item2;
+            Assert.Equal(2, y.Count);
+            Assert.True(y.TryGetValue("jkl", out val));
+            Assert.Equal(1011, val);
+            Assert.True(y.TryGetValue("mno", out val));
+            Assert.Equal(1213, val);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Issues/SO_DictionaryFail.cs
+++ b/src/protobuf-net.Test/Issues/SO_DictionaryFail.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.unittest;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace ProtoBuf.Test.Issues
@@ -11,19 +12,17 @@ namespace ProtoBuf.Test.Issues
         [Fact]
         public void TupleDictionary()
         {
-
-
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
             model.Add<Tuple<Dictionary<string,double>, Dictionary<string,double>>>();
-            //Test(model);
+            Test(model);
 
-            var dll = model.CompileAndVerify();
+            var dll = model.CompileAndVerify(deleteOnSuccess: false);
 
-            //model.CompileInPlace();
-            //Test(model);
+            model.CompileInPlace();
+            Test(model);
 
-            //Test(model.Compile());
+            Test(model.Compile());
 
             Test(dll);
         }
@@ -33,18 +32,32 @@ namespace ProtoBuf.Test.Issues
             var data = Tuple.Create(
                 new Dictionary<string, double>
                 {
-                                {"abc", 123 },
-                                {"def", 456 },
-                                {"ghi", 789 },
+                    {"abc", 123 },
+                    {"def", 456 },
+                    {"ghi", 789 },
                 },
                 new Dictionary<string, double>
                 {
-                                {"jkl", 1011 },
-                                {"mno", 1213 },
+                    {"jkl", 1011 },
+                    {"mno", 1213 },
                 });
 
-            var clone = model.DeepClone(data);
+            
+
+            using var ms = new MemoryStream();
+            model.Serialize(ms, data);
+            var hex = BitConverter.ToString(ms.GetBuffer(), 0, (int)ms.Length);
+
+            // verified against 2.4.1
+            const string expected = "0A-0E-0A-03-61-62-63-11-00-00-00-00-00-C0-5E-40-0A-0E-0A-03-64-65-66-11-00-00-00-00-00-80-7C-40-0A-0E-0A-03-67-68-69-11-00-00-00-00-00-A8-88-40-12-0E-0A-03-6A-6B-6C-11-00-00-00-00-00-98-8F-40-12-0E-0A-03-6D-6E-6F-11-00-00-00-00-00-F4-92-40";
+            Assert.Equal(expected, hex);
+
+
+
+            ms.Position = 0;
+            var clone = model.Deserialize<Tuple<Dictionary<string, double>, Dictionary<string, double>>>(ms);
             Assert.NotSame(data, clone);
+
             var x = clone.Item1;
             Assert.Equal(3, x.Count);
             Assert.True(x.TryGetValue("abc", out var val));

--- a/src/protobuf-net/Internal/Serializers/MapDecorator.cs
+++ b/src/protobuf-net/Internal/Serializers/MapDecorator.cs
@@ -49,6 +49,7 @@ namespace ProtoBuf.Internal.Serializers
 
         public void EmitWrite(CompilerContext ctx, Local valueFrom)
         {
+            _ = Serializer; // this is to force a type-check
             var method = typeof(MapSerializer<TCollection, TKey, TValue>).GetMethod(nameof(MapSerializer<TCollection, TKey, TValue>.WriteMap));
 
             using var loc = ctx.GetLocalWithValue(ExpectedType, valueFrom);

--- a/src/protobuf-net/Internal/Serializers/RepeatedDecorator.cs
+++ b/src/protobuf-net/Internal/Serializers/RepeatedDecorator.cs
@@ -54,6 +54,7 @@ namespace ProtoBuf.Internal.Serializers
 
         public void EmitRead(CompilerContext ctx, Local valueFrom)
         {
+            _ = Serializer; // this is to force a type-check
             var method = typeof(RepeatedSerializer<TCollection, T>).GetMethod(nameof(RepeatedSerializer<TCollection, T>.ReadRepeated));
 
             using var loc = ctx.GetLocalWithValue(ExpectedType, valueFrom);

--- a/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
@@ -44,8 +44,13 @@ namespace ProtoBuf.Internal.Serializers
                 {
                     serializer = new TagDecorator(i + 1, wireType, false, tail);
                 }
+                else if (repeated.IsMap)
+                {
+                    serializer = ValueMember.CreateMap(repeated, model, DataFormat.Default, DataFormat.Default, DataFormat.Default, asReference, false, true, false, i + 1);
+                }
                 else
                 {
+
                     SerializerFeatures listFeatures = wireType.AsFeatures() | SerializerFeatures.OptionPackedDisabled;
                     serializer = RepeatedDecorator.Create(repeated, i + 1, listFeatures);
                 }


### PR DESCRIPTION
Tuple-like types with nested data were not correctly checking for "map"-like data; this means that it was emitting the wrong method on the repeated serializer. It was all downhill from there.