### PR TITLE
Added a missing overload to DeserializeWithLengthPrefix in TypeModel.cs

### DIFF
--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -381,6 +381,23 @@ namespace ProtoBuf.Meta
         /// <param name="style">How to encode the length prefix.</param>
         /// <param name="expectedField">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
         /// <param name="resolver">Used to resolve types on a per-field basis.</param>
+        /// <param name="context">Additional information about this serialization operation.</param>
+        /// <returns>The updated instance; this may be different to the instance argument if
+        /// either the original instance was null, or the stream defines a known sub-type of the
+        /// original instance.</returns>
+        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, TypeResolver resolver, SerializationContext context)
+            => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out long _, out bool _, context);
+
+        /// <summary>
+        /// Applies a protocol-buffer stream to an existing instance (or null), using length-prefixed
+        /// data - useful with network IO.
+        /// </summary>
+        /// <param name="type">The type being merged.</param>
+        /// <param name="value">The existing instance to be modified (can be null).</param>
+        /// <param name="source">The binary stream to apply to the instance (cannot be null).</param>
+        /// <param name="style">How to encode the length prefix.</param>
+        /// <param name="expectedField">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
+        /// <param name="resolver">Used to resolve types on a per-field basis.</param>
         /// <param name="bytesRead">Returns the number of bytes consumed by this operation (includes length-prefix overheads and any skipped data).</param>
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the


### PR DESCRIPTION
Noticed an overload we need was missing, adding it here
