### PR TITLE
Generate gRPC services

### DIFF
--- a/src/protobuf-net.MSBuild.Test/BuildTests.cs
+++ b/src/protobuf-net.MSBuild.Test/BuildTests.cs
@@ -116,5 +116,11 @@ namespace ProtoBuf.Build
             Assert.Single(testLogger.Errors);
             Assert.Single(testLogger.Warnings);
         }
+
+        [Fact]
+        public void ServicesGenTest()
+        {
+            BuildProject("Data/Proj4/Proj.csproj");
+        }
     }
 }

--- a/src/protobuf-net.MSBuild.Test/Data/Common.props
+++ b/src/protobuf-net.MSBuild.Test/Data/Common.props
@@ -8,8 +8,8 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="2.4.0" />
-    <PackageReference Include="protobuf-net.Reflection" Version="2.3.17" />
+    <PackageReference Include="protobuf-net" Version="3.0.0-alpha.*" />
+    <PackageReference Include="protobuf-net.Reflection" Version="3.0.0-alpha.*" />
 <!-- something went very odd here; paths are wrong?
     <Reference Include="protobuf-net">
       <HintPath>$(ProtoBuildAsmRoot)protobuf-net.dll</HintPath>

--- a/src/protobuf-net.MSBuild.Test/Data/Proj4/Program.cs
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj4/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TestNS;
+
+class Program
+{
+    class Greeter : IGreeter
+    {
+        public global::System.Threading.Tasks.ValueTask<HelloReply> SayHelloAsync(HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    static void Main()
+    {
+        var greeter = new Greeter();
+    }
+}

--- a/src/protobuf-net.MSBuild.Test/Data/Proj4/Proj.csproj
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj4/Proj.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>TestNS</RootNamespace>
+    <TargetFramework>net461</TargetFramework>
+    <GrpcServices>true</GrpcServices>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net.Grpc" Version="1.0.21" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)/../Common.props"/>
+</Project>

--- a/src/protobuf-net.MSBuild.Test/Data/Proj4/Test.proto
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj4/Test.proto
@@ -1,0 +1,13 @@
+﻿syntax = "proto3";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/src/protobuf-net.MSBuild/GenerateProtoBufCode.cs
+++ b/src/protobuf-net.MSBuild/GenerateProtoBufCode.cs
@@ -21,6 +21,8 @@ namespace ProtoBuf.MSBuild
 
         public string Language { get; set; }
 
+        public string Services { get; set; }
+
         [Output]
         public ITaskItem[] ProtoCodeFile { get; set; }
 
@@ -101,7 +103,10 @@ namespace ProtoBuf.MSBuild
                 return false;
             }
 
-            var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["services"] = Services
+            };
 
             var codeFiles = new List<ITaskItem>();
             var files = codegen.Generate(set, options: options);

--- a/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
+++ b/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
@@ -32,6 +32,7 @@
       OutputPath="$(ProtoCodeGenerationRoot)"
       DefaultNamespace="$(RootNamespace)"
       Language="$(Language)"
+      Services="$(GrpcServices)"
     >
       <Output 
         TaskParameter="ProtoCodeFile"

--- a/src/protobuf-net.MSBuild/protobuf-net.MSBuild.csproj
+++ b/src/protobuf-net.MSBuild/protobuf-net.MSBuild.csproj
@@ -29,8 +29,8 @@
     </ProjectReference>
     <ProjectReference Include="..\protobuf-net.Core\protobuf-net.Core.csproj"/>
   </ItemGroup>
-
-  <Target Name="CopyBuildFiles" AfterTargets="CoreBuild" BeforeTargets="_CalculateInputsOutputsForPack">
+  
+  <Target Name="CopyBuildFiles" AfterTargets="CoreBuild" BeforeTargets="_CalculateInputsOutputsForPack;_IntermediatePack">
     <ItemGroup>
       <Content Include="$(OutDir)\*.dll" PackagePath="build\" />
     </ItemGroup>

--- a/src/protogen/Program.cs
+++ b/src/protogen/Program.cs
@@ -309,6 +309,7 @@ Parse PROTO_FILES and generate output based on the options given:
                               Specify naming convention rules.
   +oneof={default|enum}       Specify whether 'oneof' should generate enums.
   +listset={yes|no}           Specify whether lists should emit setters
+  +services={yes|no}          Specify whether services should be generated.
   +OPTION=VALUE               Specify a custom OPTION/VALUE pair for the
                               selected code generator.
   --package=PACKAGE           Add a default package (when no package is


### PR DESCRIPTION
- Documents how to generate gRPC service with protogen
- Adds support for generating gRPC services via MSBuild targets
- Fixes packaging of MSBuild targets, which have been broken for all 3.0.0-alpha* packages.