### PR TITLE
Could we make a version of `MetaType.GetSchemaTypeName()` public?

### DIFF
--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -223,6 +223,11 @@ namespace ProtoBuf.Meta
             callbacks.AfterDeserialize = ResolveMethod(afterDeserialize, true);
             return this;
         }
+        
+        /// <summary>
+        /// Returns the public Type name of this Type used in serialization
+        /// </summary>
+        public string GetSchemaTypeName() => GetSchemaTypeName(null);
 
         internal string GetSchemaTypeName(HashSet<Type> callstack)
         {


### PR DESCRIPTION
I'm generating a list of grpc proto rpc method signatures and I need the Type Name that protobuf-net uses in its `RuntimeTypeModel.GetSchema()`. At the moment I'm using reflection to call the internal method which works as expected, but would obv. prefer to call a public API.