### PR TITLE
Expose Name Normalizer via MSBuild and add Tests

### DIFF
--- a/src/protobuf-net.MSBuild.Test/BuildTests.cs
+++ b/src/protobuf-net.MSBuild.Test/BuildTests.cs
@@ -122,5 +122,11 @@ namespace ProtoBuf.Build
         {
             BuildProject("Data/Proj4/Proj.csproj");
         }
+
+        [Fact]
+        public void NameNormalizationTest()
+        {
+            BuildProject("Data/Proj5/Proj.csproj");
+        }
     }
 }

--- a/src/protobuf-net.MSBuild.Test/Data/Proj5/Program.cs
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj5/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main()
+    {
+        var x = new TestNS.TestMessage();
+        var y = x.snake_case_name;
+    }
+}

--- a/src/protobuf-net.MSBuild.Test/Data/Proj5/Proj.csproj
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj5/Proj.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>TestNS</RootNamespace>
+    <TargetFramework>net461</TargetFramework>
+    <ProtoNameNormalization>original</ProtoNameNormalization>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)/../Common.props"/>
+</Project>

--- a/src/protobuf-net.MSBuild.Test/Data/Proj5/Test.proto
+++ b/src/protobuf-net.MSBuild.Test/Data/Proj5/Test.proto
@@ -1,0 +1,5 @@
+﻿syntax = "proto2";
+
+message TestMessage {
+  optional string snake_case_name = 1;
+}

--- a/src/protobuf-net.MSBuild/GenerateProtoBufCode.cs
+++ b/src/protobuf-net.MSBuild/GenerateProtoBufCode.cs
@@ -23,6 +23,8 @@ namespace ProtoBuf.MSBuild
 
         public string Services { get; set; }
 
+        public string NameNormalizaton { get; set; }
+
         [Output]
         public ITaskItem[] ProtoCodeFile { get; set; }
 
@@ -105,7 +107,8 @@ namespace ProtoBuf.MSBuild
 
             var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                ["services"] = Services
+                ["services"] = Services,
+                ["names"] = NameNormalizaton
             };
 
             var codeFiles = new List<ITaskItem>();

--- a/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
+++ b/src/protobuf-net.MSBuild/build/protobuf-net.MSBuild.targets
@@ -33,6 +33,7 @@
       DefaultNamespace="$(RootNamespace)"
       Language="$(Language)"
       Services="$(GrpcServices)"
+      NameNormalizaton="$(ProtoNameNormalization)"
     >
       <Output 
         TaskParameter="ProtoCodeFile"


### PR DESCRIPTION
Hi,

Currently at my work, we use protobuf-net 2.0.0.668. We have a DSL-first workflow. Eventually, we want to migrate from .NET Framework to .NET Core and so the older Windows-based protogen tool will not work for us.

The MSBuild Task is vastly superior to the prebuild target we are currently running, but there are some migratory issues:

First, the change to names, our snake case names were changed to camel case. I did some digging and found the NameNormalizer and exposed it via MSBuild.

Second, the removal of "Specified" methods, in particular for booleans, I did some digging but I could not find a way to generate these easily as option. 

This is my first open source contribution, so let me know if I did anything wrong. Also, is it possible to backport these changes to the stable release, 2.4.* ?