### PR TITLE
Fixes failing tests due to git differences

### DIFF
--- a/src/protobuf-net.Test/Meta/FieldOffset.cs
+++ b/src/protobuf-net.Test/Meta/FieldOffset.cs
@@ -28,7 +28,7 @@ message Foo {
       Bar Bar = 42;
    }
 }
-", proto);
+", proto, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ message Foo {
       Bar Bar = 38;
    }
 }
-", proto);
+", proto, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ message Foo {
       Bar Bar = 46;
    }
 }
-", proto);
+", proto, ignoreLineEndingDifferences: true);
         }
     }
 


### PR DESCRIPTION
Just sprinkling the needed `ignoreLineEndingDifferences: true` on the 3 that need it.