### PR TITLE
Fixes for #652

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 image: Visual Studio 2019
 
-install:
-  - choco install dotnetcore-sdk --version 3.0.100
-
 skip_branch_with_pr: true
 skip_tags: true
 skip_commits:

--- a/src/Benchmark/DeserializeBenchmarks.cs
+++ b/src/Benchmark/DeserializeBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using System;
@@ -8,7 +9,7 @@ using System.Runtime.CompilerServices;
 
 namespace Benchmark
 {
-    [ClrJob, CoreJob, MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net472), SimpleJob(RuntimeMoniker.NetCoreApp30), MemoryDiagnoser]
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
     public partial class DeserializeBenchmarks

--- a/src/Benchmark/SerializeBenchmarks.cs
+++ b/src/Benchmark/SerializeBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using Google.Protobuf;
 using ProtoBuf;
 using ProtoBuf.Meta;
@@ -8,7 +9,7 @@ using System.IO;
 
 namespace Benchmark
 {
-    [ClrJob, CoreJob, MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net472), SimpleJob(RuntimeMoniker.NetCoreApp30), MemoryDiagnoser]
     public partial class SerializeBenchmarks
     {
 

--- a/src/Benchmark/SpanPerformance.cs
+++ b/src/Benchmark/SpanPerformance.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using System;
@@ -8,7 +9,7 @@ using System.IO;
 #if NEW_API
 namespace Benchmark
 {
-    [ClrJob, CoreJob, MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net472), SimpleJob(RuntimeMoniker.NetCoreApp30), MemoryDiagnoser]
     public class SpanPerformance
     {
         private MemoryStream _ms;

--- a/src/Benchmark/VarintDecodeBenchmarks.cs
+++ b/src/Benchmark/VarintDecodeBenchmarks.cs
@@ -1,6 +1,6 @@
 ﻿#if INTRINSICS
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -10,7 +10,7 @@ using System.Runtime.Intrinsics.X86;
 
 namespace Benchmark
 {
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
     public class VarintDecodeBenchmarks
     {
         readonly byte[] _payload = new byte[16 * 1024];

--- a/src/Benchmark/VarintEncodeBenchmarks.cs
+++ b/src/Benchmark/VarintEncodeBenchmarks.cs
@@ -1,13 +1,14 @@
 ﻿#if INTRINSICS
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using System;
 using System.Numerics;
 
 namespace Benchmark
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp30)]
     public class VarintEncodeBenchmarks
     {
         const int LOOP_SIZE = 2048;

--- a/src/protobuf-net.TestCompatibilityLevel/protobuf-net.TestCompatibilityLevel.csproj
+++ b/src/protobuf-net.TestCompatibilityLevel/protobuf-net.TestCompatibilityLevel.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>ProtoBuf.Test.TestCompatibilityLevel</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes the tests issue in CI and some build warnings - also should be a tad faster since we don't need to install the SDK anymore (it's in the image and roll forward makes it less friendly).

Note: this is a PR to #652, not master!