### PR TITLE
Fix bug in pre-measured subtypes

### DIFF
--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -521,11 +521,12 @@ namespace ProtoBuf
         {
             long length;
             object obj = default;
-            if (TypeHelper<T>.IsReferenceType)
+            IObjectSerializer<T> objSerializer = default;
+            if (TypeHelper<T>.IsReferenceType && (objSerializer = serializer as IObjectSerializer<T>) is object)
             {
                 obj = value;
                 if (obj is null) return 0;
-                if (writer.netCache.TryGetKnownLength(obj, typeof(T), out length))
+                if (writer.netCache.TryGetKnownLength(obj, objSerializer.BaseType, out length))
                     return length;
             }
 
@@ -537,9 +538,9 @@ namespace ProtoBuf
             writer.SetWriteState(oldState); // make sure we leave it how we found it
 
             // cache it if we can
-            if (TypeHelper<T>.IsReferenceType)
+            if (TypeHelper<T>.IsReferenceType && objSerializer is object)
             {   // we know it isn't null; we'd have exited above
-                writer.netCache.SetKnownLength(obj, typeof(T), length);
+                writer.netCache.SetKnownLength(obj, objSerializer.BaseType, length);
             }
             return length;
         }

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -253,6 +253,18 @@ namespace ProtoBuf.Serializers
     }
 
     /// <summary>
+    /// A serializer capable of representing complex objects that may warrant length caching
+    /// </summary>
+    public interface IObjectSerializer<T> : ISerializer<T>
+    {
+        /// <summary>
+        /// The effective <see cref="BaseType"/> that this serializer represents; in the case of
+        /// an object hierarchy, this is the base-type.
+        /// </summary>
+        Type BaseType { get; }
+    }
+
+    /// <summary>
     /// Abstract API capable of serializing/deserializing objects as part of a type hierarchy
     /// </summary>
     public interface ISubTypeSerializer<T> where T : class

--- a/src/protobuf-net.Test/Issues/GrpcIssue100.cs
+++ b/src/protobuf-net.Test/Issues/GrpcIssue100.cs
@@ -1,0 +1,114 @@
+﻿using ProtoBuf.Internal.Serializers;
+using ProtoBuf.Meta;
+using ProtoBuf.Serializers;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ProtoBuf.Issues
+{
+    // context: https://github.com/protobuf-net/protobuf-net.Grpc/issues/100
+    public class GrpcIssue100
+    {
+        public GrpcIssue100(ITestOutputHelper log) => _log = log;
+        private readonly ITestOutputHelper _log;
+        private void Log(string message) => _log?.WriteLine(message);
+
+        private static TestObject GetTestInstance() => new TestObject
+        {
+            Test = new TestThingy { SomeText = "abc", SomeText2 = "def" }
+        };
+
+        [Fact]
+        public void MeasuredSerialize()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            MeasuredSerializeImpl(model);
+
+            model.CompileInPlace();
+            MeasuredSerializeImpl(model);
+
+            MeasuredSerializeImpl(model.Compile());
+        }
+        private void MeasuredSerializeImpl(TypeModel model)
+        {
+            var typed = TypeModel.GetSerializer<TestThingy>(model) as IObjectSerializer<TestThingy>;
+            Assert.Equal(typeof(TestBase), typed?.BaseType);
+
+            var obj = GetTestInstance();
+            var ms = new MemoryStream();
+            model.Serialize(ms, obj); // regular serialize
+            Assert.Equal(14, ms.Length);
+            var expected = BitConverter.ToString(ms.GetBuffer(), 0, (int)ms.Length);
+            Log(expected);
+            Assert.Equal("0A-0C-0A-05-0A-03-64-65-66-12-03-61-62-63", expected);
+
+            /*
+Field #1: 0A String Length = 12, Hex = 0C, UTF8 = "  defabc"
+As sub-object :
+  Field #1: 0A String Length = 5, Hex = 0C, UTF8 = " def"
+  As sub-object :
+    Field #1: 0A String Length = 3, Hex = 0C, UTF8 = "def"
+  Field #2: 65 String Length = 3, Hex = 66, UTF8 = "abc"
+             */
+
+
+            // now try measured
+            if ((object)RuntimeTypeModel.Default is IMeasuredProtoOutput<IBufferWriter<byte>> writer)
+            {
+                using var measured = writer.Measure(obj);
+                Assert.Equal(ms.Length, measured.Length);
+
+#if !NET462
+
+                int hitsBefore = measured.GetLengthHits(out int missesBefore);
+
+                var abw = new ArrayBufferWriter<byte>();
+                writer.Serialize(measured, abw);
+                Assert.Equal(ms.Length, abw.WrittenCount);
+
+                var mem = abw.WrittenMemory;
+                Assert.True(MemoryMarshal.TryGetArray(mem, out var segment));
+                var actual = BitConverter.ToString(segment.Array, segment.Offset, segment.Count);
+                Log(actual);
+                Assert.Equal(expected, actual);
+
+                int hitsAfter = measured.GetLengthHits(out int missesAfter);
+
+                Log($"hits: {hitsAfter - hitsBefore}, misses: {missesAfter - missesBefore}");
+                Assert.True(hitsAfter > hitsBefore, "got hits");
+                Assert.Equal(0, missesBefore - missesBefore);
+#endif
+            }
+        }
+
+        [ProtoContract]
+        public class TestObject
+        {
+            [ProtoMember(1)]
+            public TestThingy Test { get; set; }
+        }
+
+        [ProtoContract]
+        [ProtoInclude(1, typeof(TestThingy))]
+        public abstract class TestBase
+        {
+            [ProtoMember(2)]
+            public string SomeText { get; set; }
+
+            public abstract string SomeText2 { get; set; }
+        }
+
+        [ProtoContract]
+        public class TestThingy : TestBase
+        {
+            [ProtoMember(1)]
+            public override string SomeText2 { get; set; }
+        }
+    }
+}

--- a/src/protobuf-net/Internal/Serializers/CompiledSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/CompiledSerializer.cs
@@ -7,13 +7,15 @@ using System.Threading;
 
 namespace ProtoBuf.Internal.Serializers
 {
-    internal sealed class InheritanceCompiledSerializer<TBase, T> : CompiledSerializer, ISerializer<T>, ISubTypeSerializer<T>, IFactory<T>
+    internal sealed class InheritanceCompiledSerializer<TBase, T> : CompiledSerializer, ISerializer<T>, ISubTypeSerializer<T>, IFactory<T>, IObjectSerializer<T>
         where TBase : class
         where T : class, TBase
     {
         private readonly Compiler.ProtoSerializer<T> subTypeSerializer;
         private readonly Compiler.ProtoSubTypeDeserializer<T> subTypeDeserializer;
         private readonly Func<ISerializationContext, T> factory;
+
+        Type IObjectSerializer<T>.BaseType => typeof(TBase);
 
         T ISerializer<T>.Read(ref ProtoReader.State state, T value)
         {
@@ -73,11 +75,13 @@ namespace ProtoBuf.Internal.Serializers
     }
 
     internal class SimpleCompiledSerializer<T> : CompiledSerializer,
-        ISerializer<T>, IFactory<T>
+        ISerializer<T>, IFactory<T>, IObjectSerializer<T>
     {
         protected readonly Compiler.ProtoSerializer<T> serializer;
         protected readonly Compiler.ProtoDeserializer<T> deserializer;
         private readonly Func<ISerializationContext, T> factory;
+
+        Type IObjectSerializer<T>.BaseType => typeof(T);
 
         public SimpleCompiledSerializer(IProtoTypeSerializer head, RuntimeTypeModel model)
             : base(head)

--- a/src/protobuf-net/Internal/Serializers/TypeSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TypeSerializer.cs
@@ -24,11 +24,13 @@ namespace ProtoBuf.Internal.Serializers
         abstract internal void Init(int[] fieldNumbers, IRuntimeProtoSerializerNode[] serializers, MethodInfo[] baseCtorCallbacks, bool isRootType, bool useConstructor, CallbackSet callbacks, Type constructType, MethodInfo factory, SerializerFeatures features);
     }
 
-    internal sealed class InheritanceTypeSerializer<TBase, T> : TypeSerializer<T>, ISubTypeSerializer<T>
+    internal sealed class InheritanceTypeSerializer<TBase, T> : TypeSerializer<T>, ISubTypeSerializer<T>, IObjectSerializer<T>
         where TBase : class
         where T : class, TBase
     {
         public override bool HasInheritance => true;
+
+        Type IObjectSerializer<T>.BaseType => typeof(TBase);
 
         internal override Type BaseType => typeof(TBase);
 
@@ -104,8 +106,10 @@ namespace ProtoBuf.Internal.Serializers
 
         public override bool IsSubType => true;
     }
-    internal class TypeSerializer<T> : TypeSerializer, ISerializer<T>, IFactory<T>, IProtoTypeSerializer
+    internal class TypeSerializer<T> : TypeSerializer, ISerializer<T>, IFactory<T>, IProtoTypeSerializer, IObjectSerializer<T>
     {
+        Type IObjectSerializer<T>.BaseType => typeof(T);
+
         public virtual bool HasInheritance => false;
         public virtual void EmitReadRoot(CompilerContext context, Local valueFrom)
             => ((IRuntimeProtoSerializerNode)this).EmitRead(context, valueFrom);

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1460,7 +1460,7 @@ namespace ProtoBuf.Meta
                 serType = typeof(IObjectSerializer<>).MakeGenericType(runtimeType);
                 type.AddInterfaceImplementation(serType);
                 il = CompilerContextScope.Implement(type, serType, "get_" + nameof(IObjectSerializer<string>.BaseType));
-                il.Emit(OpCodes.Ldtoken, inheritanceRoot ?? runtimeType);
+                CompilerContext.LoadValue(il, inheritanceRoot ?? runtimeType);
                 il.Emit(OpCodes.Ret);
 
                 // and we emit the sub-type serializer whenever inheritance is involved

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1456,6 +1456,13 @@ namespace ProtoBuf.Meta
                 var featuresGetter = serType.GetProperty(nameof(ISerializer<string>.Features)).GetGetMethod();
                 type.DefineMethodOverride(GetFeaturesMethod(serializer.Features), featuresGetter);
 
+                // always emit IObjectSerializer<T> (enabled length caching; base type is needed for rooting)
+                serType = typeof(IObjectSerializer<>).MakeGenericType(runtimeType);
+                type.AddInterfaceImplementation(serType);
+                il = CompilerContextScope.Implement(type, serType, "get_" + nameof(IObjectSerializer<string>.BaseType));
+                il.Emit(OpCodes.Ldtoken, inheritanceRoot ?? runtimeType);
+                il.Emit(OpCodes.Ret);
+
                 // and we emit the sub-type serializer whenever inheritance is involved
                 if (serializer.HasInheritance)
                 {


### PR DESCRIPTION
- impact: the wrong known length can be retrieved if a serializer is used with a non-root `<T>`
- cause: the code used `typeof(T)` for the outermost object, when it should have used the base-type (which is not available)
- resolution: make the base-type available via a new API, and only use the length if this new API is detected

xref: https://github.com/protobuf-net/protobuf-net.Grpc/issues/100