### PR TITLE
Don't require output directive when listing services in protogen gRPC reflection.

### DIFF
--- a/src/protogen/GrpcTools.cs
+++ b/src/protogen/GrpcTools.cs
@@ -33,7 +33,8 @@ namespace ProtoBuf
                 Console.Error.WriteLine($"Unknown gRPC mode: '{modeString}'");
                 return 1;
             }
-            if (string.IsNullOrWhiteSpace(outPath))
+            if (string.IsNullOrWhiteSpace(outPath) &&
+                mode == GrpcMode.Get)
             {
                 Console.Error.WriteLine($"Missing output directive; please specify --csharp_out etc");
                 return 1;


### PR DESCRIPTION
Fixes issue:

```
protogen --grpc list https://localhost:5001
Missing output directive; please specify --csharp_out etc
```