### PR TITLE
add a shotgun smattering of [DynamicallyAccessedMembers]

### DIFF
--- a/src/protobuf-net.Core/IProtoInputT.cs
+++ b/src/protobuf-net.Core/IProtoInputT.cs
@@ -1,9 +1,12 @@
-﻿namespace ProtoBuf
+﻿using ProtoBuf.Internal;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ProtoBuf
 {
     /// <summary>
     /// Represents the ability to deserialize values from an input of type <typeparamref name="TInput"/>
     /// </summary>
-    public interface IProtoInput<TInput>
+    public interface IProtoInput<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TInput>
     {
         /// <summary>
         /// Deserialize a value from the input

--- a/src/protobuf-net.Core/IProtoOutputT.cs
+++ b/src/protobuf-net.Core/IProtoOutputT.cs
@@ -1,9 +1,12 @@
-﻿namespace ProtoBuf
+﻿using ProtoBuf.Internal;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ProtoBuf
 {
     /// <summary>
     /// Represents the ability to serialize values to an output of type <typeparamref name="TOutput"/>
     /// </summary>
-    public interface IProtoOutput<TOutput>
+    public interface IProtoOutput<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TOutput>
     {
         /// <summary>
         /// Serialize the provided value
@@ -15,7 +18,7 @@
     /// Represents the ability to serialize values to an output of type <typeparamref name="TOutput"/>
     /// with pre-computation of the length
     /// </summary>
-    public interface IMeasuredProtoOutput<TOutput> : IProtoOutput<TOutput>
+    public interface IMeasuredProtoOutput<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TOutput> : IProtoOutput<TOutput>
     {
         /// <summary>
         /// Measure the length of a value in advance of serialization

--- a/src/protobuf-net.Core/Internal/DynamicallyAccessedMembersAttribute.cs
+++ b/src/protobuf-net.Core/Internal/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,154 @@
+﻿namespace ProtoBuf.Internal
+{
+    using System.Diagnostics.CodeAnalysis;
+    internal sealed class DynamicAccess
+    {
+        internal const DynamicallyAccessedMemberTypes ContractType
+            = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor // construction
+            | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties // annotated properties
+            | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields // annotated fields and get-only accessors
+            | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods; // callbacks
+
+        internal const DynamicallyAccessedMemberTypes Serializer
+            = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
+    }
+}
+
+#if PLAT_DYNAMIC_ACCESS_ATTR
+// type forward on net5?
+#else
+// internalized version of https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+// and https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+}
+#endif

--- a/src/protobuf-net.Core/MeasureState.cs
+++ b/src/protobuf-net.Core/MeasureState.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace ProtoBuf
@@ -12,7 +13,7 @@ namespace ProtoBuf
     /// this instance can re-use the previously calculated lengths. If the object state changes between the
     /// measure and serialize operations, the behavior is undefined.
     /// </summary>
-    public struct MeasureState<T> : IDisposable
+    public struct MeasureState<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T> : IDisposable
     {
         private readonly TypeModel _model;
         private readonly T _value;

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -42,7 +43,7 @@ namespace ProtoBuf.Meta
         /// Gets a cached serializer for a type, as offered by a given provider
         /// </summary>
         [MethodImpl(ProtoReader.HotPath)]
-        protected static ISerializer<T> GetSerializer<TProvider, T>()
+        protected static ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.Serializer)] TProvider, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TProvider : class
             => SerializerCache<TProvider, T>.InstanceField;
 
@@ -291,7 +292,7 @@ namespace ProtoBuf.Meta
         /// <param name="value">The existing instance to be serialized (cannot be null).</param>
         /// <param name="dest">The destination stream to write to.</param>
         /// <param name="userState">Additional information about this serialization operation.</param>
-        public long Serialize<T>(Stream dest, T value, object userState = null)
+        public long Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream dest, T value, object userState = null)
         {
             var state = ProtoWriter.State.Create(dest, this, userState);
             try
@@ -310,7 +311,7 @@ namespace ProtoBuf.Meta
         /// <param name="value">The existing instance to be serialized (cannot be null).</param>
         /// <param name="dest">The destination stream to write to.</param>
         /// <param name="userState">Additional information about this serialization operation.</param>
-        public long Serialize<T>(IBufferWriter<byte> dest, T value, object userState = null)
+        public long Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(IBufferWriter<byte> dest, T value, object userState = null)
         {
             var state = ProtoWriter.State.Create(dest, this, userState);
             try
@@ -326,7 +327,7 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public MeasureState<T> Measure<T>(T value, object userState = null, long abortAfter = -1)
+        public MeasureState<T> Measure<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, object userState = null, long abortAfter = -1)
             => new MeasureState<T>(this, value, userState, abortAfter);
 
         /// <summary>
@@ -371,7 +372,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int fieldNumber)
+        public object DeserializeWithLengthPrefix(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int fieldNumber)
             => DeserializeWithLengthPrefix(source, value, type, style, fieldNumber, null, out long _);
 
         /// <summary>
@@ -387,7 +388,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, TypeResolver resolver)
+        public object DeserializeWithLengthPrefix(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver)
             => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out long _);
 
         /// <summary>
@@ -404,7 +405,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out int bytesRead)
+        public object DeserializeWithLengthPrefix(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out int bytesRead)
         {
             object result = DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out long bytesRead64, out bool _, null);
             bytesRead = checked((int)bytesRead64);
@@ -425,9 +426,9 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out long bytesRead) => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out bytesRead, out bool _, null);
+        public object DeserializeWithLengthPrefix(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out long bytesRead) => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out bytesRead, out bool _, null);
 
-        private object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out long bytesRead, out bool haveObject, SerializationContext context)
+        private object DeserializeWithLengthPrefix(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver, out long bytesRead, out bool haveObject, SerializationContext context)
         {
             haveObject = false;
             bool skip;
@@ -508,7 +509,7 @@ namespace ProtoBuf.Meta
         /// <param name="resolver">On a field-by-field basis, the type of object to deserialize (can be null if "type" is specified). </param>
         /// <param name="type">The type of object to deserialize (can be null if "resolver" is specified).</param>
         /// <returns>The sequence of deserialized objects.</returns>
-        public IEnumerable DeserializeItems(System.IO.Stream source, Type type, PrefixStyle style, int expectedField, TypeResolver resolver)
+        public IEnumerable DeserializeItems(System.IO.Stream source, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver)
         {
             return DeserializeItems(source, type, style, expectedField, resolver, null);
         }
@@ -529,7 +530,7 @@ namespace ProtoBuf.Meta
         /// <param name="type">The type of object to deserialize (can be null if "resolver" is specified).</param>
         /// <returns>The sequence of deserialized objects.</returns>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public IEnumerable DeserializeItems(System.IO.Stream source, Type type, PrefixStyle style, int expectedField, TypeResolver resolver, SerializationContext context)
+        public IEnumerable DeserializeItems(System.IO.Stream source, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int expectedField, TypeResolver resolver, SerializationContext context)
         {
             return new DeserializeItemsIterator(this, source, type, style, expectedField, resolver, context);
         }
@@ -549,7 +550,7 @@ namespace ProtoBuf.Meta
         /// <param name="expectedField">The tag of records to return (if non-positive, then no tag is
         /// expected and all records are returned).</param>
         /// <returns>The sequence of deserialized objects.</returns>
-        public IEnumerable<T> DeserializeItems<T>(Stream source, PrefixStyle style, int expectedField)
+        public IEnumerable<T> DeserializeItems<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, PrefixStyle style, int expectedField)
         {
             return DeserializeItems<T>(source, style, expectedField, null);
         }
@@ -569,7 +570,7 @@ namespace ProtoBuf.Meta
         /// expected and all records are returned).</param>
         /// <returns>The sequence of deserialized objects.</returns>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public IEnumerable<T> DeserializeItems<T>(Stream source, PrefixStyle style, int expectedField, SerializationContext context)
+        public IEnumerable<T> DeserializeItems<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, PrefixStyle style, int expectedField, SerializationContext context)
         {
             return new DeserializeItemsIterator<T>(this, source, style, expectedField, context);
         }
@@ -631,7 +632,7 @@ namespace ProtoBuf.Meta
         /// <param name="style">How to encode the length prefix.</param>
         /// <param name="dest">The destination stream to write to.</param>
         /// <param name="fieldNumber">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
-        public void SerializeWithLengthPrefix(Stream dest, object value, Type type, PrefixStyle style, int fieldNumber)
+        public void SerializeWithLengthPrefix(Stream dest, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int fieldNumber)
         {
             SerializeWithLengthPrefix(dest, value, type, style, fieldNumber, null);
         }
@@ -648,7 +649,7 @@ namespace ProtoBuf.Meta
         /// <param name="dest">The destination stream to write to.</param>
         /// <param name="fieldNumber">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public void SerializeWithLengthPrefix(Stream dest, object value, Type type, PrefixStyle style, int fieldNumber, SerializationContext context)
+        public void SerializeWithLengthPrefix(Stream dest, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int fieldNumber, SerializationContext context)
         {
             if (type is null)
             {
@@ -697,7 +698,7 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, Type type)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
         {
             using var state = ProtoReader.State.Create(source, this, null, ProtoReader.TO_EOF);
             return state.DeserializeRootFallback(value, type);
@@ -714,7 +715,7 @@ namespace ProtoBuf.Meta
         /// original instance.</returns>
         /// <param name="context">Additional information about this serialization operation.</param>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, Type type, SerializationContext context)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, SerializationContext context)
         {
             using var state = ProtoReader.State.Create(source, this, context, ProtoReader.TO_EOF);
             return state.DeserializeRootFallback(value, type);
@@ -730,7 +731,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(Stream source, T value = default, object userState = null)
+        public T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, T value = default, object userState = null)
         {
             using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
@@ -746,7 +747,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
+        public T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
         {
             using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
@@ -762,7 +763,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public unsafe T Deserialize<T>(ReadOnlySpan<byte> source, T value = default, object userState = null)
+        public unsafe T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlySpan<byte> source, T value = default, object userState = null)
         {
             // as an implementation detail, we sometimes need to be able to use iterator blocks etc - which
             // means we need to be able to persist the span as a memory; the only way to do this
@@ -796,7 +797,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
+        public T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
         {
             using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootImpl<T>(value);
@@ -813,7 +814,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object Deserialize(Type type, Stream source, object value = default, object userState = null, long length = ProtoReader.TO_EOF)
+        public object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source, object value = default, object userState = null, long length = ProtoReader.TO_EOF)
         {
             using var state = ProtoReader.State.Create(source, this, userState, length);
             return state.DeserializeRootFallback(value, type);
@@ -829,7 +830,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object Deserialize(Type type, ReadOnlyMemory<byte> source, object value = default, object userState = null)
+        public object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlyMemory<byte> source, object value = default, object userState = null)
         {
             using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootFallback(value, type);
@@ -845,7 +846,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public unsafe object Deserialize(Type type, ReadOnlySpan<byte> source, object value = default, object userState = null)
+        public unsafe object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlySpan<byte> source, object value = default, object userState = null)
         {
             // as an implementation detail, we sometimes need to be able to use iterator blocks etc - which
             // means we need to be able to persist the span as a memory; the only way to do this
@@ -879,7 +880,7 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object Deserialize(Type type, ReadOnlySequence<byte> source, object value = default, object userState = null)
+        public object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlySequence<byte> source, object value = default, object userState = null)
         {
             using var state = ProtoReader.State.Create(source, this, userState);
             return state.DeserializeRootFallback(value, type);
@@ -918,7 +919,7 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, System.Type type, int length)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, int length)
             => Deserialize(source, value, type, length, null);
 
         /// <summary>
@@ -932,7 +933,7 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, System.Type type, long length)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, long length)
             => Deserialize(source, value, type, length, null);
 
         /// <summary>
@@ -947,7 +948,7 @@ namespace ProtoBuf.Meta
         /// original instance.</returns>
         /// <param name="context">Additional information about this serialization operation.</param>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, System.Type type, int length, SerializationContext context)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, int length, SerializationContext context)
             => Deserialize(source, value, type, length == int.MaxValue ? long.MaxValue : (long)length, context);
 
         /// <summary>
@@ -962,7 +963,7 @@ namespace ProtoBuf.Meta
         /// original instance.</returns>
         /// <param name="context">Additional information about this serialization operation.</param>
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        public object Deserialize(Stream source, object value, System.Type type, long length, SerializationContext context)
+        public object Deserialize(Stream source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, long length, SerializationContext context)
         {
             var state = ProtoReader.State.Create(source, this, context, length);
             try
@@ -990,7 +991,7 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         /// <param name="userState">Additional information about this serialization operation.</param>
-        public object Deserialize(ReadOnlyMemory<byte> source, Type type, object value = default, object userState = default)
+        public object Deserialize(ReadOnlyMemory<byte> source, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, object value = default, object userState = default)
         {
             var state = ProtoReader.State.Create(source, this, userState);
             try
@@ -1018,7 +1019,7 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         /// <param name="userState">Additional information about this serialization operation.</param>
-        public object Deserialize(ReadOnlySequence<byte> source, Type type, object value = default, object userState = default)
+        public object Deserialize(ReadOnlySequence<byte> source, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, object value = default, object userState = default)
         {
             var state = ProtoReader.State.Create(source, this, userState);
             try
@@ -1046,10 +1047,10 @@ namespace ProtoBuf.Meta
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
         [Obsolete(ProtoReader.PreferStateAPI, false)]
-        public object Deserialize(ProtoReader source, object value, Type type)
+        public object Deserialize(ProtoReader source, object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
             => source.DefaultState().DeserializeRootFallbackWithModel(value, type, this);
 
-        internal object DeserializeRootAny(ref ProtoReader.State state, Type type, object value, bool autoCreate)
+        internal object DeserializeRootAny(ref ProtoReader.State state, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, object value, bool autoCreate)
         {
             if (!DynamicStub.TryDeserializeRoot(type, this, ref state, ref value, autoCreate))
             {
@@ -1348,7 +1349,7 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Get a typed serializer for <typeparamref name="T"/>
         /// </summary>
-        protected virtual ISerializer<T> GetSerializer<T>()
+        protected virtual ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => this as ISerializer<T>;
 
         internal virtual ISerializer<T> GetSerializerCore<T>(CompatibilityLevel ambient)
@@ -1405,7 +1406,7 @@ namespace ProtoBuf.Meta
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static ISerializer<T> GetSerializer<T>(TypeModel model, CompatibilityLevel ambient = default)
+        internal static ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(TypeModel model, CompatibilityLevel ambient = default)
            => SerializerCache<PrimaryTypeProvider, T>.InstanceField
             ?? model?.GetSerializerCore<T>(ambient)
             ?? NoSerializer<T>(model);
@@ -1506,7 +1507,7 @@ namespace ProtoBuf.Meta
         /// <summary>
         /// Create a deep clone of the supplied instance; any sub-items are also cloned.
         /// </summary>
-        public T DeepClone<T>(T value, object userState = null)
+        public T DeepClone<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, object userState = null)
         {
 #if PLAT_ISREF
             if (!System.Runtime.CompilerServices.RuntimeHelpers.IsReferenceOrContainsReferences<T>())
@@ -1597,7 +1598,7 @@ namespace ProtoBuf.Meta
         /// specified in that hierarchy and cannot be processed.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowUnexpectedSubtype<T>(T value) where T : class
+        public static void ThrowUnexpectedSubtype<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value) where T : class
         {
             if (IsSubType<T>(value)) ThrowUnexpectedSubtype(typeof(T), value.GetType());
         }
@@ -1765,7 +1766,7 @@ namespace ProtoBuf.Meta
         /// </summary>
         /// <param name="type">The type to generate a .proto definition for, or <c>null</c> to generate a .proto that represents the entire model</param>
         /// <returns>The .proto definition as a string</returns>
-        public string GetSchema(Type type) => GetSchema(type, ProtoSyntax.Default);
+        public string GetSchema([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type) => GetSchema(type, ProtoSyntax.Default);
 
         /// <summary>
         /// Suggest a .proto definition for the given type
@@ -1773,7 +1774,7 @@ namespace ProtoBuf.Meta
         /// <param name="type">The type to generate a .proto definition for, or <c>null</c> to generate a .proto that represents the entire model</param>
         /// <returns>The .proto definition as a string</returns>
         /// <param name="syntax">The .proto syntax to use for the operation</param>
-        public string GetSchema(Type type, ProtoSyntax syntax)
+        public string GetSchema([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ProtoSyntax syntax)
         {
             SchemaGenerationOptions options;
             if (type is null && syntax == ProtoSyntax.Default)
@@ -1811,7 +1812,7 @@ namespace ProtoBuf.Meta
         /// </summary>
         /// <returns>A new IFormatter to be used during [de]serialization.</returns>
         /// <param name="type">The type of object to be [de]deserialized by the formatter.</param>
-        public System.Runtime.Serialization.IFormatter CreateFormatter(Type type)
+        public System.Runtime.Serialization.IFormatter CreateFormatter([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
         {
             return new Formatter(this, type);
         }

--- a/src/protobuf-net.Core/ProtoContractAttribute.cs
+++ b/src/protobuf-net.Core/ProtoContractAttribute.cs
@@ -1,5 +1,6 @@
 using ProtoBuf.Internal;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ProtoBuf
 {
@@ -189,6 +190,7 @@ namespace ProtoBuf
         /// <summary>
         /// Defines a serializer to use for this type; the serializer must implement ISerializer-T for this type
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicAccess.Serializer)]
         public Type Serializer { get; set; }
     }
 }

--- a/src/protobuf-net.Core/ProtoIncludeAttribute.cs
+++ b/src/protobuf-net.Core/ProtoIncludeAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using ProtoBuf.Internal;
 using ProtoBuf.Meta;
 
@@ -19,7 +20,7 @@ namespace ProtoBuf
         /// </summary>
         /// <param name="tag">The unique index (within the type) that will identify this data.</param>
         /// <param name="knownType">The additional type to serialize/deserialize.</param>
-        public ProtoIncludeAttribute(int tag, Type knownType)
+        public ProtoIncludeAttribute(int tag, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type knownType)
             : this(tag, knownType is null ? "" : knownType.AssemblyQualifiedName) { }
 
         /// <summary>
@@ -27,7 +28,7 @@ namespace ProtoBuf
         /// </summary>
         /// <param name="tag">The unique index (within the type) that will identify this data.</param>
         /// <param name="knownTypeName">The additional type to serialize/deserialize.</param>
-        public ProtoIncludeAttribute(int tag, string knownTypeName)
+        public ProtoIncludeAttribute(int tag, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] string knownTypeName)
         {
             if (tag <= 0) ThrowHelper.ThrowArgumentOutOfRangeException(nameof(tag), "Tags must be positive integers");
             if (string.IsNullOrEmpty(knownTypeName)) ThrowHelper.ThrowArgumentNullException(nameof(knownTypeName), "Known type cannot be blank");
@@ -43,11 +44,13 @@ namespace ProtoBuf
         /// <summary>
         /// Gets the additional type to serialize/deserialize.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicAccess.ContractType)]
         public string KnownTypeName { get; }
 
         /// <summary>
         /// Gets the additional type to serialize/deserialize.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicAccess.ContractType)]
         public Type KnownType => TypeModel.ResolveKnownType(KnownTypeName, null);
 
         /// <summary>

--- a/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
+++ b/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
@@ -4,6 +4,7 @@ using ProtoBuf.Serializers;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -938,14 +939,14 @@ namespace ProtoBuf
             /// Reads a sub-item from the input reader
             /// </summary>
             [MethodImpl(HotPath)]
-            public T ReadMessage<T>(T value = default)
+            public T ReadMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value = default)
                 => ReadMessage<T>(default, value, null);
 
             /// <summary>
             /// Reads a sub-item from the input reader
             /// </summary>
             [MethodImpl(ProtoReader.HotPath)]
-            public T ReadMessage<T>(SerializerFeatures features, T value = default, ISerializer<T> serializer = null)
+            public T ReadMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializerFeatures features, T value = default, ISerializer<T> serializer = null)
                 => ReadMessage<ISerializer<T>, T>(features, value, serializer ?? TypeModel.GetSerializer<T>(Model));
 
 #pragma warning disable IDE0060 // unused (yet!) features arg
@@ -953,7 +954,7 @@ namespace ProtoBuf
             /// Reads a sub-item from the input reader
             /// </summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            internal T ReadMessage<TSerializer, T>(SerializerFeatures features, T value, in TSerializer serializer)
+            internal T ReadMessage<TSerializer, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializerFeatures features, T value, in TSerializer serializer)
                 where TSerializer : ISerializer<T>
 #pragma warning restore IDE0060
             {
@@ -974,14 +975,14 @@ namespace ProtoBuf
             /// Reads a value or sub-item from the input reader
             /// </summary>
             [MethodImpl(HotPath)]
-            public T ReadAny<T>(T value = default)
+            public T ReadAny<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value = default)
                 => ReadAny<T>(default, value, null);
 
             /// <summary>
             /// Reads a value or sub-item from the input reader
             /// </summary>
             [MethodImpl(HotPath)]
-            public T ReadAny<T>(SerializerFeatures features, T value = default, ISerializer<T> serializer = null)
+            public T ReadAny<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializerFeatures features, T value = default, ISerializer<T> serializer = null)
             {
                 serializer ??= TypeModel.GetSerializer<T>(Model);
                 var serializerFeatures = serializer.Features;
@@ -1013,13 +1014,13 @@ namespace ProtoBuf
             /// Gets the serializer associated with a specific type
             /// </summary>
             [MethodImpl(HotPath)]
-            public ISerializer<T> GetSerializer<T>() => TypeModel.GetSerializer<T>(Model);
+            public ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>() => TypeModel.GetSerializer<T>(Model);
 
             /// <summary>
             /// Reads a sub-item from the input reader
             /// </summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public T ReadBaseType<TBaseType, T>(T value = null, ISubTypeSerializer<TBaseType> serializer = null)
+            public T ReadBaseType<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TBaseType, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value = null, ISubTypeSerializer<TBaseType> serializer = null)
                 where TBaseType : class
                 where T : class, TBaseType
             {
@@ -1030,14 +1031,14 @@ namespace ProtoBuf
             /// Deserialize an instance of the provided type
             /// </summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public T DeserializeRoot<T>(T value = default, ISerializer<T> serializer = null)
+            public T DeserializeRoot<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value = default, ISerializer<T> serializer = null)
             {
                 value = ReadAsRoot<T>(value, serializer ?? TypeModel.GetSerializer<T>(Model));
                 CheckFullyConsumed();
                 return value;
             }
 
-            internal T ReadAsRoot<T>(T value, ISerializer<T> serializer)
+            internal T ReadAsRoot<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, ISerializer<T> serializer)
             {
                 var features = serializer.Features;
                 var category = features.GetCategory();
@@ -1111,7 +1112,7 @@ namespace ProtoBuf
             /// Create an instance of the provided type, respecting any custom factory rules
             /// </summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public T CreateInstance<T>(ISerializer<T> serializer = null)
+            public T CreateInstance<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ISerializer<T> serializer = null)
             {
                 var obj = TypeModel.CreateInstance<T>(Context, serializer);
 #if FEAT_DYNAMIC_REF

--- a/src/protobuf-net.Core/ProtoReader.cs
+++ b/src/protobuf-net.Core/ProtoReader.cs
@@ -4,6 +4,7 @@ using ProtoBuf.Meta;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -272,7 +273,7 @@ namespace ProtoBuf
         /// parsing the message in accordance with the model associated with the reader
         /// </summary>
         [MethodImpl(HotPath)]
-        public static object ReadObject(object value, Type type, ProtoReader reader)
+        public static object ReadObject(object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ProtoReader reader)
             => reader.DefaultState().ReadObject(value, type);
 
         /// <summary>

--- a/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
+++ b/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using ProtoBuf.Serializers;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -318,14 +319,14 @@ namespace ProtoBuf
             /// Writes a sub-item to the writer
             /// </summary>
             [MethodImpl(ProtoReader.HotPath)]
-            public void WriteMessage<T>(SerializerFeatures features, T value, ISerializer<T> serializer = null)
+            public void WriteMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializerFeatures features, T value, ISerializer<T> serializer = null)
                 => _writer.WriteMessage<T>(ref this, value, serializer, PrefixStyle.Base128, features.ApplyRecursionCheck());
 
             /// <summary>
             /// Writes a sub-item to the writer
             /// </summary>
             [MethodImpl(ProtoReader.HotPath)]
-            public void WriteMessage<T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
+            public void WriteMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
             {
                 if (!(TypeHelper<T>.CanBeNull && TypeHelper<T>.ValueChecker.IsNull(value)))
                 {
@@ -337,7 +338,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a sub-item to the writer
             /// </summary>
-            public void WriteGroup<T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
+            public void WriteGroup<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
             {
                 if (!(TypeHelper<T>.CanBeNull && TypeHelper<T>.ValueChecker.IsNull(value)))
                 {
@@ -349,7 +350,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a value or sub-item to the writer
             /// </summary>
-            public void WriteAny<T>(int fieldNumber, T value, ISerializer<T> serializer = null)
+            public void WriteAny<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, T value, ISerializer<T> serializer = null)
             {
                 serializer ??= TypeModel.GetSerializer<T>(Model);
                 WriteAny<T>(fieldNumber, serializer.Features, value, serializer);
@@ -358,7 +359,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a value or sub-item to the writer
             /// </summary>
-            public void WriteAny<T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
+            public void WriteAny<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
             {
                 if (!(TypeHelper<T>.CanBeNull && TypeHelper<T>.ValueChecker.IsNull(value)))
                 {
@@ -390,7 +391,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a sub-type to the input writer
             /// </summary>
-            public void WriteSubType<T>(T value, ISubTypeSerializer<T> serializer = null) where T : class
+            public void WriteSubType<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, ISubTypeSerializer<T> serializer = null) where T : class
             {
                 _writer.WriteSubType<T>(ref this, value, serializer ?? TypeModel.GetSubTypeSerializer<T>(Model));
             }
@@ -398,7 +399,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a sub-type to the input writer
             /// </summary>
-            public void WriteSubType<T>(int fieldNumber, T value, ISubTypeSerializer<T> serializer = null) where T : class
+            public void WriteSubType<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, T value, ISubTypeSerializer<T> serializer = null) where T : class
             {
                 WriteFieldHeader(fieldNumber, WireType.String);
                 _writer.WriteSubType<T>(ref this, value, serializer ?? TypeModel.GetSubTypeSerializer<T>(Model));
@@ -407,7 +408,7 @@ namespace ProtoBuf
             /// <summary>
             /// Writes a base-type to the input writer
             /// </summary>
-            public void WriteBaseType<T>(T value, ISubTypeSerializer<T> serializer = null) where T : class
+            public void WriteBaseType<T>([DynamicallyAccessedMembers(DynamicAccess.ContractType)] T value, ISubTypeSerializer<T> serializer = null) where T : class
                 => (serializer ?? TypeModel.GetSubTypeSerializer<T>(Model)).WriteSubType(ref this, value);
 
             internal TypeModel Model => _writer?.Model;
@@ -416,7 +417,7 @@ namespace ProtoBuf
             /// Gets the serializer associated with a specific type
             /// </summary>
             [MethodImpl(HotPath)]
-            public ISerializer<T> GetSerializer<T>() => TypeModel.GetSerializer<T>(Model);
+            public ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>() => TypeModel.GetSerializer<T>(Model);
 
             internal WireType WireType
             {
@@ -526,7 +527,7 @@ namespace ProtoBuf
             /// object is determined to be a scalar, it is written as though it were
             /// part of a message with field-number 1
             /// </summary>
-            public long SerializeRoot<T>(T value, ISerializer<T> serializer = null)
+            public long SerializeRoot<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, ISerializer<T> serializer = null)
             {
                 try
                 {
@@ -549,7 +550,7 @@ namespace ProtoBuf
                 }
             }
 
-            internal void WriteAsRoot<T>(T value, ISerializer<T> serializer)
+            internal void WriteAsRoot<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, ISerializer<T> serializer)
             {
                 var features = serializer.Features;
                 var category = features.GetCategory();
@@ -672,7 +673,7 @@ namespace ProtoBuf
             }
 #endif
 
-            internal void WriteObject(object value, Type type, PrefixStyle style, int fieldNumber)
+            internal void WriteObject(object value, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, PrefixStyle style, int fieldNumber)
             {
                 var model = Model;
                 if (model is null)

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -251,7 +252,7 @@ namespace ProtoBuf
         /// <summary>
         /// Writes a sub-item to the input writer
         /// </summary>
-        protected internal virtual void WriteMessage<T>(ref State state, T value, ISerializer<T> serializer, PrefixStyle style, bool recursionCheck)
+        protected internal virtual void WriteMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ref State state, T value, ISerializer<T> serializer, PrefixStyle style, bool recursionCheck)
         {
 #pragma warning disable CS0618 // StartSubItem/EndSubItem
             var tok = state.StartSubItem(TypeHelper<T>.IsReferenceType & recursionCheck ? (object)value : null, style);
@@ -263,7 +264,7 @@ namespace ProtoBuf
         /// <summary>
         /// Writes a sub-item to the input writer
         /// </summary>
-        protected internal virtual void WriteSubType<T>(ref State state, T value, ISubTypeSerializer<T> serializer) where T : class
+        protected internal virtual void WriteSubType<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ref State state, T value, ISubTypeSerializer<T> serializer) where T : class
         {
 #pragma warning disable CS0618 // StartSubItem/EndSubItem
             var tok = state.StartSubItem(null, PrefixStyle.Base128);

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -1,6 +1,7 @@
 ﻿using ProtoBuf.Internal;
 using ProtoBuf.Meta;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -196,7 +197,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Abstract API capable of serializing/deserializing messages or values
     /// </summary>
-    public interface ISerializer<T>
+    public interface ISerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>
     {
         /// <summary>
         /// Deserialize an instance from the supplied writer
@@ -217,7 +218,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Provides indirect access to a serializer for a given type
     /// </summary>
-    public interface ISerializerProxy<T>
+    public interface ISerializerProxy<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>
     {
         /// <summary>
         /// Gets the actual serializer for the type
@@ -228,7 +229,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Abstract API capable of measuring values without writing them
     /// </summary>
-    internal interface IMeasuringSerializer<T> : ISerializer<T>
+    internal interface IMeasuringSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T> : ISerializer<T>
     {
         /// <summary>
         /// Measure the given value, reporting the required length for the payload (not including the field-header)
@@ -239,7 +240,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Abstract API capable of serializing/deserializing a sequence of messages or values
     /// </summary>
-    public interface IRepeatedSerializer<T> : ISerializer<T>
+    public interface IRepeatedSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T> : ISerializer<T>
     {
         /// <summary>
         /// Serialize a sequence of values to the supplied writer
@@ -268,7 +269,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Abstract API capable of serializing/deserializing objects as part of a type hierarchy
     /// </summary>
-    public interface ISubTypeSerializer<T> where T : class
+    public interface ISubTypeSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T> where T : class
     {
         /// <summary>
         /// Serialize an instance to the supplied writer
@@ -285,7 +286,7 @@ namespace ProtoBuf.Serializers
     /// Represents the state of an inheritance deserialization operation
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    public struct SubTypeState<T>
+    public struct SubTypeState<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>
         where T : class
     {
         private readonly ISerializationContext _context;
@@ -388,7 +389,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Abstract API capable of serializing/deserializing complex objects with inheritance
     /// </summary>
-    public interface IFactory<T>
+    public interface IFactory<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>
     {
         /// <summary>
         /// Create a new instance of the type

--- a/src/protobuf-net.Core/Serializers/MapSerializer.Concurrent.cs
+++ b/src/protobuf-net.Core/Serializers/MapSerializer.Concurrent.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Meta;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Serializers
@@ -11,7 +12,7 @@ namespace ProtoBuf.Serializers
     {
         /// <summary>Create a map serializer that operates on concurrent dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<TCollection, TKey, TValue> CreateConcurrentDictionary<TCollection, TKey, TValue>()
+        public static MapSerializer<TCollection, TKey, TValue> CreateConcurrentDictionary<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             where TCollection : ConcurrentDictionary<TKey, TValue>
             => SerializerCache<ConcurrentDictionarySerializer<TCollection, TKey, TValue>>.InstanceField;
     }

--- a/src/protobuf-net.Core/Serializers/MapSerializer.Immutable.cs
+++ b/src/protobuf-net.Core/Serializers/MapSerializer.Immutable.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Serializers
@@ -11,17 +12,17 @@ namespace ProtoBuf.Serializers
 
         /// <summary>Create a map serializer that operates on immutable dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<ImmutableDictionary<TKey, TValue>, TKey, TValue> CreateImmutableDictionary<TKey, TValue>()
+        public static MapSerializer<ImmutableDictionary<TKey, TValue>, TKey, TValue> CreateImmutableDictionary<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             => SerializerCache<ImmutableDictionarySerializer<TKey, TValue>>.InstanceField;
 
         /// <summary>Create a map serializer that operates on immutable dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<ImmutableSortedDictionary<TKey, TValue>, TKey, TValue> CreateImmutableSortedDictionary<TKey, TValue>()
+        public static MapSerializer<ImmutableSortedDictionary<TKey, TValue>, TKey, TValue> CreateImmutableSortedDictionary<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             => SerializerCache<ImmutableSortedDictionarySerializer<TKey, TValue>>.InstanceField;
 
         /// <summary>Create a map serializer that operates on immutable dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<IImmutableDictionary<TKey, TValue>, TKey, TValue> CreateIImmutableDictionary<TKey, TValue>()
+        public static MapSerializer<IImmutableDictionary<TKey, TValue>, TKey, TValue> CreateIImmutableDictionary<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             => SerializerCache<ImmutableIDictionarySerializer<TKey, TValue>>.InstanceField;
     }
 

--- a/src/protobuf-net.Core/Serializers/MapSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/MapSerializer.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Serializers
@@ -13,12 +14,12 @@ namespace ProtoBuf.Serializers
     {
         /// <summary>Create a map serializer that operates on dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<Dictionary<TKey, TValue>, TKey, TValue> CreateDictionary<TKey, TValue>()
+        public static MapSerializer<Dictionary<TKey, TValue>, TKey, TValue> CreateDictionary<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             => SerializerCache<DictionarySerializer<TKey, TValue>>.InstanceField;
 
         /// <summary>Create a map serializer that operates on dictionaries</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static MapSerializer<TCollection, TKey, TValue> CreateDictionary<TCollection, TKey, TValue>()
+        public static MapSerializer<TCollection, TKey, TValue> CreateDictionary<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue>()
             where TCollection : IDictionary<TKey, TValue>
             => SerializerCache<DictionarySerializer<TCollection, TKey, TValue>>.InstanceField;
     }
@@ -26,7 +27,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Base class for dictionary-like collection serializers
     /// </summary>
-    public abstract class MapSerializer<TCollection, TKey, TValue> : IRepeatedSerializer<TCollection>, IFactory<TCollection>
+    public abstract class MapSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : IRepeatedSerializer<TCollection>, IFactory<TCollection>
     {
         SerializerFeatures ISerializer<TCollection>.Features => SerializerFeatures.CategoryRepeated;
 

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.Concurrent.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.Concurrent.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Meta;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Serializers
@@ -11,25 +12,25 @@ namespace ProtoBuf.Serializers
     {
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateConcurrentBag<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateConcurrentBag<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : ConcurrentBag<T>
             => SerializerCache<ConcurrentBagSerializer<TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateConcurrentStack<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateConcurrentStack<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : ConcurrentStack<T>
             => SerializerCache<ConcurrentStackSerializer<TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateConcurrentQueue<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateConcurrentQueue<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : ConcurrentQueue<T>
             => SerializerCache<ConcurrentQueueSerializer<TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateIProducerConsumerCollection<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateIProducerConsumerCollection<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : class, IProducerConsumerCollection<T>
             => SerializerCache<ProducerConsumerSerializer<TCollection, T>>.InstanceField;
     }

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -12,52 +13,52 @@ namespace ProtoBuf.Serializers
     {
         /// <summary>Create a serializer that operates on immutable arrays</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableArray<T>, T> CreateImmutableArray<T>()
+        public static RepeatedSerializer<ImmutableArray<T>, T> CreateImmutableArray<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableArraySerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableList<T>, T> CreateImmutableList<T>()
+        public static RepeatedSerializer<ImmutableList<T>, T> CreateImmutableList<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableListSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<IImmutableList<T>, T> CreateImmutableIList<T>()
+        public static RepeatedSerializer<IImmutableList<T>, T> CreateImmutableIList<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableIListSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable queues</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableQueue<T>, T> CreateImmutableQueue<T>()
+        public static RepeatedSerializer<ImmutableQueue<T>, T> CreateImmutableQueue<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableQueueSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable queues</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<IImmutableQueue<T>, T> CreateImmutableIQueue<T>()
+        public static RepeatedSerializer<IImmutableQueue<T>, T> CreateImmutableIQueue<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableIQueueSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable stacks</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableStack<T>, T> CreateImmutableStack<T>()
+        public static RepeatedSerializer<ImmutableStack<T>, T> CreateImmutableStack<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableStackSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable stacks</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<IImmutableStack<T>, T> CreateImmutableIStack<T>()
+        public static RepeatedSerializer<IImmutableStack<T>, T> CreateImmutableIStack<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableIStackSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableHashSet<T>, T> CreateImmutableHashSet<T>()
+        public static RepeatedSerializer<ImmutableHashSet<T>, T> CreateImmutableHashSet<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableHashSetSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<ImmutableSortedSet<T>, T> CreateImmutableSortedSet<T>()
+        public static RepeatedSerializer<ImmutableSortedSet<T>, T> CreateImmutableSortedSet<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableSortedSetSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on immutable sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<IImmutableSet<T>, T> CreateImmutableISet<T>()
+        public static RepeatedSerializer<IImmutableSet<T>, T> CreateImmutableISet<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ImmutableISetSerializer<T>>.InstanceField;
 
 

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Meta;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -16,7 +17,7 @@ namespace ProtoBuf.Serializers
         /// <summary>Create a serializer that indicates that a scenario is not supported</summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Obsolete("Since this isn't supported, you probably shouldn't be doing it...", false)]
-        public static RepeatedSerializer<TCollection, T> CreateNestedDataNotSupported<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateNestedDataNotSupported<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
         {
             ThrowHelper.ThrowNestedDataNotSupported(typeof(TCollection));
             return default;
@@ -25,7 +26,7 @@ namespace ProtoBuf.Serializers
         /// <summary>Create a serializer that indicates that a scenario is not supported</summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Obsolete("Since this isn't supported, you probably shouldn't be doing it...", false)]
-        public static RepeatedSerializer<TCollection, T> CreateNotSupported<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateNotSupported<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
         {
             ThrowHelper.ThrowNotSupportedException($"Repeated data of type {typeof(TCollection)} is not supported");
             return default;
@@ -33,42 +34,42 @@ namespace ProtoBuf.Serializers
 
         /// <summary>Create a serializer that operates on lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<List<T>, T> CreateList<T>()
+        public static RepeatedSerializer<List<T>, T> CreateList<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<ListSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TList, T> CreateList<TList, T>()
+        public static RepeatedSerializer<TList, T> CreateList<TList, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TList : List<T>
             => SerializerCache<ListSerializer<TList, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on most common collections</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : class, IEnumerable<T>
             => SerializerCache<EnumerableSerializer<TCollection, TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on most common collections</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, TCreate, T>()
+        public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, TCreate, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : class, IEnumerable<T>
             where TCreate : TCollection
             => SerializerCache<EnumerableSerializer<TCollection, TCreate, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<T[], T> CreateVector<T>()
+        public static RepeatedSerializer<T[], T> CreateVector<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<VectorSerializer<T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateQueue<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateQueue<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : Queue<T>
             => SerializerCache<QueueSerializer<TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on lists</summary>
         [MethodImpl(ProtoReader.HotPath)]
-        public static RepeatedSerializer<TCollection, T> CreateStack<TCollection, T>()
+        public static RepeatedSerializer<TCollection, T> CreateStack<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             where TCollection : Stack<T>
             => SerializerCache<StackSerializer<TCollection, T>>.InstanceField;
 
@@ -85,7 +86,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Base class for simple collection serializers
     /// </summary>
-    public abstract class RepeatedSerializer<TCollection, TItem> : IRepeatedSerializer<TCollection>, IFactory<TCollection>
+    public abstract class RepeatedSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TItem> : IRepeatedSerializer<TCollection>, IFactory<TCollection>
     {
         TCollection IFactory<TCollection>.Create(ISerializationContext context) => Initialize(default, context);
 

--- a/src/protobuf-net.Core/Serializers/SerializerCache.cs
+++ b/src/protobuf-net.Core/Serializers/SerializerCache.cs
@@ -1,15 +1,16 @@
 ﻿using ProtoBuf.Internal;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace ProtoBuf.Serializers
 {
-    internal static class SerializerCache<TProvider>
+    internal static class SerializerCache<[DynamicallyAccessedMembers(DynamicAccess.Serializer)] TProvider>
              where TProvider : class
     {
         internal static readonly TProvider InstanceField = (TProvider)Activator.CreateInstance(typeof(TProvider), nonPublic: true);
-        public static ISerializer<T> GetSerializer<T>()
+        public static ISerializer<T> GetSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => SerializerCache<TProvider, T>.InstanceField;
     }
 
@@ -19,7 +20,7 @@ namespace ProtoBuf.Serializers
     //    public static readonly TSerializer InstanceField = new TSerializer();
     //}
 
-    internal static class SerializerCache<TProvider, T>
+    internal static class SerializerCache<[DynamicallyAccessedMembers(DynamicAccess.Serializer)] TProvider, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>
          where TProvider : class
     {
         internal static readonly ISerializer<T> InstanceField

--- a/src/protobuf-net.Core/protobuf-net.Core.csproj
+++ b/src/protobuf-net.Core/protobuf-net.Core.csproj
@@ -36,6 +36,7 @@ PLAT_AGGRESSIVE_OPTIMIZE  : use MethodImplOptions.AggressiveOptimization appropr
 FEAT_DYNAMIC_REF          : whether the dynamic type / reference-tracking features are enabled
 FEAT_NULL_LIST_ITEMS      : whether we support retaining nulls in lists
 PLAT_CONCURRENT_CLEAR     : whether the concurrent collections have the necessary Clear method
+PLAT_DYNAMIC_ACCESS_ATTR  : whether the runtime defines DynamicallyAccessedMembersAttribute et al
 TRACK_USAGE               : count writer activity to check disposal/re-use is correct
 -->
 </Project>

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1337,6 +1337,8 @@ namespace ProtoBuf.Meta
 
 
             var serviceType = WriteBasicTypeModel("<Services>" + typeName, module, typeof(object), true);
+            // note: the service could benefit from [DynamicallyAccessedMembers(DynamicAccess.Serializer)], but: that only exists
+            // (on the public API) in net5+, and those platforms don't allow full dll emit (which is when the linker matters)
             WriteSerializers(scope, serviceType);
             WriteEnumsAndProxies(serviceType);
 

--- a/src/protobuf-net/Serializer.Deserialize.cs
+++ b/src/protobuf-net/Serializer.Deserialize.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace ProtoBuf
@@ -14,7 +15,7 @@ namespace ProtoBuf
         /// <typeparam name="T">The type to be created.</typeparam>
         /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
         /// <returns>A new, initialized instance.</returns>
-        public static T Deserialize<T>(Stream source)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default);
             return state.DeserializeRootImpl<T>();
@@ -25,7 +26,7 @@ namespace ProtoBuf
         /// </summary>
         /// <typeparam name="T">The type to be created.</typeparam>
         /// <returns>A new, initialized instance.</returns>
-        public static T Deserialize<T>(Stream source, T value, SerializationContext context, long length = ProtoReader.TO_EOF)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, T value, SerializationContext context, long length = ProtoReader.TO_EOF)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, context, length);
             return state.DeserializeRootImpl<T>(value);
@@ -36,7 +37,7 @@ namespace ProtoBuf
         /// </summary>
         /// <typeparam name="T">The type to be created.</typeparam>
         /// <returns>A new, initialized instance.</returns>
-        public static T Deserialize<T>(Stream source, T value = default, object userState = default, long length = ProtoReader.TO_EOF)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, T value = default, object userState = default, long length = ProtoReader.TO_EOF)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, userState, length);
             return state.DeserializeRootImpl<T>(value);
@@ -48,7 +49,7 @@ namespace ProtoBuf
 		/// <param name="type">The type to be created.</param>
 		/// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
 		/// <returns>A new, initialized instance.</returns>
-        public static object Deserialize(Type type, Stream source)
+        public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default, null, ProtoReader.TO_EOF);
             return state.DeserializeRootFallback(null, type);
@@ -57,19 +58,19 @@ namespace ProtoBuf
         /// <summary>
         /// Creates a new instance from a protocol-buffer stream
         /// </summary>
-        public static T Deserialize<T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlyMemory<byte> source, T value = default, object userState = null)
             => RuntimeTypeModel.Default.Deserialize<T>(source, value, userState);
 
         /// <summary>
         /// Creates a new instance from a protocol-buffer stream
         /// </summary>
-        public static T Deserialize<T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlySequence<byte> source, T value = default, object userState = null)
             => RuntimeTypeModel.Default.Deserialize<T>(source, value, userState);
 
         /// <summary>
         /// Creates a new instance from a protocol-buffer stream
         /// </summary>
-        public static T Deserialize<T>(ReadOnlySpan<byte> source, T value = default, object userState = null)
+        public static T Deserialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ReadOnlySpan<byte> source, T value = default, object userState = null)
             => RuntimeTypeModel.Default.Deserialize<T>(source, value, userState);
     }
 }

--- a/src/protobuf-net/Serializer.Serialize.cs
+++ b/src/protobuf-net/Serializer.Serialize.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -15,7 +16,7 @@ namespace ProtoBuf
         /// </summary>
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="destination">The destination stream to write to.</param>
-        public static void Serialize<T>(Stream destination, T instance)
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream destination, T instance)
             => Serialize<T>(destination, instance, userState: null);
 
         /// <summary>
@@ -24,7 +25,7 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="destination">The destination stream to write to.</param>
         /// <param name="userState">Additional state for this serialization operation</param>
-        public static void Serialize<T>(Stream destination, T instance, object userState)
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream destination, T instance, object userState)
         {
             var state = ProtoWriter.State.Create(destination, RuntimeTypeModel.Default, userState);
             try
@@ -44,7 +45,7 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="destination">The destination stream to write to.</param>
         /// <param name="userState">Additional serialization context</param>
-        public static void Serialize<T>(IBufferWriter<byte> destination, T instance, object userState = null)
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(IBufferWriter<byte> destination, T instance, object userState = null)
         {
             var state = ProtoWriter.State.Create(destination, RuntimeTypeModel.Default, userState);
             try
@@ -63,7 +64,7 @@ namespace ProtoBuf
         /// <typeparam name="T">The type being serialized.</typeparam>
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="info">The destination SerializationInfo to write to.</param>
-        public static void Serialize<T>(SerializationInfo info, T instance) where T : class, ISerializable
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializationInfo info, T instance) where T : class, ISerializable
         {
             Serialize<T>(info, new StreamingContext(StreamingContextStates.Persistence), instance);
         }
@@ -74,7 +75,7 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="info">The destination SerializationInfo to write to.</param>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public static void Serialize<T>(System.Runtime.Serialization.SerializationInfo info, StreamingContext context, T instance) where T : class, System.Runtime.Serialization.ISerializable
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(System.Runtime.Serialization.SerializationInfo info, StreamingContext context, T instance) where T : class, System.Runtime.Serialization.ISerializable
         {
             // note: also tried byte[]... it doesn't perform hugely well with either (compared to regular serialization)
             if (info is null) throw new ArgumentNullException(nameof(info));
@@ -91,7 +92,7 @@ namespace ProtoBuf
         /// <typeparam name="T">The type being serialized.</typeparam>
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="writer">The destination XmlWriter to write to.</param>
-        public static void Serialize<T>(System.Xml.XmlWriter writer, T instance) where T : System.Xml.Serialization.IXmlSerializable
+        public static void Serialize<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(System.Xml.XmlWriter writer, T instance) where T : System.Xml.Serialization.IXmlSerializable
         {
             if (writer is null) throw new ArgumentNullException(nameof(writer));
             if (instance is null) throw new ArgumentNullException(nameof(instance));
@@ -111,7 +112,7 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
         /// <param name="style">How to encode the length prefix.</param>
         /// <param name="destination">The destination stream to write to.</param>
-        public static void SerializeWithLengthPrefix<T>(Stream destination, T instance, PrefixStyle style)
+        public static void SerializeWithLengthPrefix<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream destination, T instance, PrefixStyle style)
         {
             SerializeWithLengthPrefix<T>(destination, instance, style, 0);
         }
@@ -127,7 +128,7 @@ namespace ProtoBuf
         /// <param name="style">How to encode the length prefix.</param>
         /// <param name="destination">The destination stream to write to.</param>
         /// <param name="fieldNumber">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
-        public static void SerializeWithLengthPrefix<T>(Stream destination, T instance, PrefixStyle style, int fieldNumber)
+        public static void SerializeWithLengthPrefix<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream destination, T instance, PrefixStyle style, int fieldNumber)
         {
             RuntimeTypeModel.Default.SerializeWithLengthPrefix(destination, instance, typeof(T), style, fieldNumber);
         }

--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -47,19 +48,19 @@ namespace ProtoBuf
         /// <summary>
         /// Create a deep clone of the supplied instance; any sub-items are also cloned.
         /// </summary>
-        public static T DeepClone<T>(T instance, SerializationContext context)
+        public static T DeepClone<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T instance, SerializationContext context)
             => RuntimeTypeModel.Default.DeepClone<T>(instance, context);
 
         /// <summary>
         /// Create a deep clone of the supplied instance; any sub-items are also cloned.
         /// </summary>
-        public static T DeepClone<T>(T instance, object userState = null)
+        public static T DeepClone<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T instance, object userState = null)
             => RuntimeTypeModel.Default.DeepClone<T>(instance, userState);
 
         /// <summary>
         /// Calculates the length of a protocol-buffer payload for an item
         /// </summary>
-        public static MeasureState<T> Measure<T>(T value, object userState = null, long abortAfter = -1)
+        public static MeasureState<T> Measure<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(T value, object userState = null, long abortAfter = -1)
             => RuntimeTypeModel.Default.Measure<T>(value, userState, abortAfter);
 
         /// <summary>
@@ -71,7 +72,7 @@ namespace ProtoBuf
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public static T Merge<T>(Stream source, T instance)
+        public static T Merge<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, T instance)
         {
             using var state = ProtoReader.State.Create(source, RuntimeTypeModel.Default);
             return state.DeserializeRootImpl<T>(instance);
@@ -88,7 +89,7 @@ namespace ProtoBuf
         /// <typeparam name="TTo">The type of the new object to be created.</typeparam>
         /// <param name="instance">The existing instance to use as a template.</param>
         /// <returns>A new instane of type TNewType, with the data from TOldType.</returns>
-        public static TTo ChangeType<TFrom, TTo>(TFrom instance)
+        public static TTo ChangeType<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TFrom, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TTo>(TFrom instance)
         {
             using var ms = new MemoryStream();
             Serialize<TFrom>(ms, instance);
@@ -102,7 +103,7 @@ namespace ProtoBuf
         /// <typeparam name="T">The type being merged.</typeparam>
         /// <param name="instance">The existing instance to be modified (cannot be null).</param>
         /// <param name="reader">The XmlReader containing the data to apply to the instance (cannot be null).</param>
-        public static void Merge<T>(System.Xml.XmlReader reader, T instance) where T : System.Xml.Serialization.IXmlSerializable
+        public static void Merge<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(System.Xml.XmlReader reader, T instance) where T : System.Xml.Serialization.IXmlSerializable
         {
             if (reader is null) throw new ArgumentNullException(nameof(reader));
             if (instance is null) throw new ArgumentNullException(nameof(instance));
@@ -134,7 +135,7 @@ namespace ProtoBuf
         /// <typeparam name="T">The type being merged.</typeparam>
         /// <param name="instance">The existing instance to be modified (cannot be null).</param>
         /// <param name="info">The SerializationInfo containing the data to apply to the instance (cannot be null).</param>
-        public static void Merge<T>(SerializationInfo info, T instance) where T : class, ISerializable
+        public static void Merge<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializationInfo info, T instance) where T : class, ISerializable
         {
             Merge<T>(info, new StreamingContext(StreamingContextStates.Persistence), instance);
         }
@@ -145,7 +146,7 @@ namespace ProtoBuf
         /// <param name="instance">The existing instance to be modified (cannot be null).</param>
         /// <param name="info">The SerializationInfo containing the data to apply to the instance (cannot be null).</param>
         /// <param name="context">Additional information about this serialization operation.</param>
-        public static void Merge<T>(SerializationInfo info, StreamingContext context, T instance)
+        public static void Merge<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(SerializationInfo info, StreamingContext context, T instance)
             where T : class, ISerializable
         {
             // note: also tried byte[]... it doesn't perform hugely well with either (compared to regular serialization)
@@ -165,7 +166,7 @@ namespace ProtoBuf
         /// <summary>
         /// Precompiles the serializer for a given type.
         /// </summary>
-        public static void PrepareSerializer<T>()
+        public static void PrepareSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
             => RuntimeTypeModel.Default[typeof(T)].CompileInPlace();
 
         /// <summary>
@@ -173,7 +174,7 @@ namespace ProtoBuf
         /// </summary>
         /// <typeparam name="T">The type of object to be [de]deserialized by the formatter.</typeparam>
         /// <returns>A new IFormatter to be used during [de]serialization.</returns>
-        public static System.Runtime.Serialization.IFormatter CreateFormatter<T>()
+        public static System.Runtime.Serialization.IFormatter CreateFormatter<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
         {
             return RuntimeTypeModel.Default.CreateFormatter(typeof(T));
         }
@@ -193,7 +194,7 @@ namespace ProtoBuf
         /// <param name="fieldNumber">The tag of records to return (if non-positive, then no tag is
         /// expected and all records are returned).</param>
         /// <returns>The sequence of deserialized objects.</returns>
-        public static IEnumerable<T> DeserializeItems<T>(Stream source, PrefixStyle style, int fieldNumber)
+        public static IEnumerable<T> DeserializeItems<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, PrefixStyle style, int fieldNumber)
         {
             return RuntimeTypeModel.Default.DeserializeItems<T>(source, style, fieldNumber);
         }
@@ -206,7 +207,7 @@ namespace ProtoBuf
         /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
         /// <param name="style">How to encode the length prefix.</param>
         /// <returns>A new, initialized instance.</returns>
-        public static T DeserializeWithLengthPrefix<T>(Stream source, PrefixStyle style)
+        public static T DeserializeWithLengthPrefix<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, PrefixStyle style)
         {
             return DeserializeWithLengthPrefix<T>(source, style, 0);
         }
@@ -220,7 +221,7 @@ namespace ProtoBuf
         /// <param name="style">How to encode the length prefix.</param>
         /// <param name="fieldNumber">The expected tag of the item (only used with base-128 prefix style).</param>
         /// <returns>A new, initialized instance.</returns>
-        public static T DeserializeWithLengthPrefix<T>(Stream source, PrefixStyle style, int fieldNumber)
+        public static T DeserializeWithLengthPrefix<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, PrefixStyle style, int fieldNumber)
         {
             return (T)RuntimeTypeModel.Default.DeserializeWithLengthPrefix(source, null, typeof(T), style, fieldNumber);
         }
@@ -236,7 +237,7 @@ namespace ProtoBuf
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public static T MergeWithLengthPrefix<T>(Stream source, T instance, PrefixStyle style)
+        public static T MergeWithLengthPrefix<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(Stream source, T instance, PrefixStyle style)
         {
             return (T)RuntimeTypeModel.Default.DeserializeWithLengthPrefix(source, instance, typeof(T), style, 0);
         }
@@ -311,31 +312,31 @@ namespace ProtoBuf
             /// <param name="type">The type to be created.</param>
             /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
             /// <returns>A new, initialized instance.</returns>
-            public static object Deserialize(Type type, Stream source)
+            public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source)
                 => RuntimeTypeModel.Default.Deserialize(type, source);
 
             /// <summary>
             /// Creates a new instance from a protocol-buffer stream
             /// </summary>
-            public static object Deserialize(Type type, Stream source, object instance = null, object userState = null, long length = ProtoReader.TO_EOF)
+            public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source, object instance = null, object userState = null, long length = ProtoReader.TO_EOF)
                 => RuntimeTypeModel.Default.Deserialize(type, source, instance, userState, length);
 
             /// <summary>
             /// Creates a new instance from a protocol-buffer stream
             /// </summary>
-            public static object Deserialize(Type type, ReadOnlyMemory<byte> source, object instance = null, object userState = null)
+            public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlyMemory<byte> source, object instance = null, object userState = null)
                 => RuntimeTypeModel.Default.Deserialize(type, source, instance, userState);
 
             /// <summary>
             /// Creates a new instance from a protocol-buffer stream
             /// </summary>
-            public static object Deserialize(Type type, ReadOnlySequence<byte> source, object instance = null, object userState = null)
+            public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlySequence<byte> source, object instance = null, object userState = null)
                 => RuntimeTypeModel.Default.Deserialize(type, source, instance, userState);
 
             /// <summary>
             /// Creates a new instance from a protocol-buffer stream
             /// </summary>
-            public static object Deserialize(Type type, ReadOnlySpan<byte> source, object instance = null, object userState = null)
+            public static object Deserialize([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, ReadOnlySpan<byte> source, object instance = null, object userState = null)
                 => RuntimeTypeModel.Default.Deserialize(type, source, instance, userState);
 
             /// <summary>Applies a protocol-buffer stream to an existing instance.</summary>
@@ -390,7 +391,7 @@ namespace ProtoBuf
             /// <summary>
             /// Precompiles the serializer for a given type.
             /// </summary>
-            public static void PrepareSerializer(Type type)
+            public static void PrepareSerializer([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
             {
                 RuntimeTypeModel.Default[type].CompileInPlace();
             }

--- a/src/protobuf-net/ServiceModel/XmlProtoSerializer.cs
+++ b/src/protobuf-net/ServiceModel/XmlProtoSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Xml;
@@ -30,7 +31,7 @@ namespace ProtoBuf.ServiceModel
         /// Attempt to create a new serializer for the given model and type
         /// </summary>
         /// <returns>A new serializer instance if the type is recognised by the model; null otherwise</returns>
-        public static XmlProtoSerializer TryCreate(TypeModel model, Type type)
+        public static XmlProtoSerializer TryCreate(TypeModel model, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
         {
             if (model is null) throw new ArgumentNullException(nameof(model));
             if (type is null) throw new ArgumentNullException(nameof(type));
@@ -45,7 +46,7 @@ namespace ProtoBuf.ServiceModel
         /// <summary>
         /// Creates a new serializer for the given model and type
         /// </summary>
-        public XmlProtoSerializer(TypeModel model, Type type)
+        public XmlProtoSerializer(TypeModel model, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type)
         {
             if (model is null) throw new ArgumentNullException(nameof(model));
             if (type is null) throw new ArgumentNullException(nameof(type));


### PR DESCRIPTION
 to help convince the linker not to cull DTOs