### PR TITLE
Improve protogen understanding of --proto_path

### DIFF
--- a/src/protogen/Program.cs
+++ b/src/protogen/Program.cs
@@ -276,11 +276,15 @@ namespace protogen
         // with thanks to "Dave": https://stackoverflow.com/a/340454/23354
         public static string MakeRelativePath(string fromPath, string toPath)
         {
-#if NETCOREAPP2_0 || NETCOREAPP2_1
+#if !NETFRAMEWORK
             return Path.GetRelativePath(fromPath, toPath);
 #else
             if (String.IsNullOrEmpty(fromPath)) throw new ArgumentNullException(nameof(fromPath));
             if (String.IsNullOrEmpty(toPath)) throw new ArgumentNullException(nameof(toPath));
+            // make sure there is a trailing '/', else Uri.MakeRelativeUri won't work as expected
+            char lastChar = fromPath[fromPath.Length - 1];
+            if (lastChar != Path.DirectorySeparatorChar && lastChar != Path.AltDirectorySeparatorChar)
+                fromPath += Path.DirectorySeparatorChar;
 
             Uri fromUri = new Uri(fromPath, UriKind.RelativeOrAbsolute);
             if (!fromUri.IsAbsoluteUri)


### PR DESCRIPTION
The lookup of files uses a somewhat flawed `MakeRelativePath` method :
- it doesn't always use the builtin `Path.GetRelativePath` when available
- when not using `Path.GetRelativePath` (and only then), it requires that
  the `proto_path` ends with a directory separator.

This is part of what has been seen in #406.