### PR TITLE
Positional record types with inheritance

### DIFF
--- a/src/protobuf-net.Core/ProtoContractAttribute.cs
+++ b/src/protobuf-net.Core/ProtoContractAttribute.cs
@@ -24,7 +24,7 @@ namespace ProtoBuf
 
         /// <summary>
         /// Gets or sets the fist offset to use with implicit field tags;
-        /// only uesd if ImplicitFields is set.
+        /// only used if ImplicitFields is set.
         /// </summary>
         public int ImplicitFirstTag
         {

--- a/src/protobuf-net.Test/RecordTypeTests.cs
+++ b/src/protobuf-net.Test/RecordTypeTests.cs
@@ -49,5 +49,31 @@ namespace ProtoBuf.Test
             Assert.Equal("def", clone.LastName);
             Assert.Equal(123, clone.Count);
         }
+        
+        [ProtoContract]
+        [ProtoInclude(1, typeof(PositionalRecordWithAttributesWithInheritance))]
+        public abstract record BasePositionalRecordWithAttributesWithInheritance(
+            [property: ProtoMember(2)] string FirstName,
+            [property: ProtoMember(3)] string LastName
+        );
+        
+        [ProtoContract]
+        public record PositionalRecordWithAttributesWithInheritance (
+            string FirstName,
+            string LastName,
+            [property: ProtoMember(1)] int Count
+        ) : BasePositionalRecordWithAttributesWithInheritance(FirstName, LastName);
+        
+        [Fact]
+        public void CanRoundTripPositionalRecordWithAttributesWithInheritance()
+        {
+            var obj = new PositionalRecordWithAttributesWithInheritance("abc", "def", 123);
+            var model = RuntimeTypeModel.Create();
+            var clone = model.DeepClone(obj);
+            Assert.NotSame(obj, clone);
+            Assert.Equal("abc", clone.FirstName);
+            Assert.Equal("def", clone.LastName);
+            Assert.Equal(123, clone.Count);
+        }
     }
 }

--- a/src/protobuf-net.Test/RecordTypeTests.cs
+++ b/src/protobuf-net.Test/RecordTypeTests.cs
@@ -1,4 +1,5 @@
-﻿using ProtoBuf.Meta;
+﻿using System;
+using ProtoBuf.Meta;
 using Xunit;
 
 namespace ProtoBuf.Test
@@ -22,6 +23,25 @@ namespace ProtoBuf.Test
         public void CanRoundTripPositionalRecord()
         {
             var obj = new PositionalRecord("abc", "def", 123);
+            var model = RuntimeTypeModel.Create();
+            var clone = model.DeepClone(obj);
+            Assert.NotSame(obj, clone);
+            Assert.Equal("abc", clone.FirstName);
+            Assert.Equal("def", clone.LastName);
+            Assert.Equal(123, clone.Count);
+        }
+        
+        [ProtoContract]
+        public record PositionalRecordWithAttributes(
+            [property: ProtoMember(1)] string FirstName,
+            [property: ProtoMember(2)] string LastName,
+            [property: ProtoMember(3)] int Count
+        );
+        
+        [Fact]
+        public void CanRoundTripPositionalRecordWithAttributes()
+        {
+            var obj = new PositionalRecordWithAttributes("abc", "def", 123);
             var model = RuntimeTypeModel.Create();
             var clone = model.DeepClone(obj);
             Assert.NotSame(obj, clone);

--- a/src/protobuf-net.Test/RecordTypeTests.cs
+++ b/src/protobuf-net.Test/RecordTypeTests.cs
@@ -47,50 +47,5 @@ namespace ProtoBuf.Test
             Assert.Equal("def", clone.LastName);
             Assert.Equal(123, clone.Count);
         }
-        
-        [ProtoContract]
-        public record PositionalRecordWithAttributes(
-            [property: ProtoMember(1)] string FirstName,
-            [property: ProtoMember(2)] string LastName,
-            [property: ProtoMember(3)] int Count
-        );
-        
-        [Fact]
-        public void CanRoundTripPositionalRecordWithAttributes()
-        {
-            var obj = new PositionalRecordWithAttributes("abc", "def", 123);
-            var model = RuntimeTypeModel.Create();
-            var clone = model.DeepClone(obj);
-            Assert.NotSame(obj, clone);
-            Assert.Equal("abc", clone.FirstName);
-            Assert.Equal("def", clone.LastName);
-            Assert.Equal(123, clone.Count);
-        }
-        
-        [ProtoContract]
-        [ProtoInclude(1, typeof(PositionalRecordWithAttributesWithInheritance))]
-        public abstract record BasePositionalRecordWithAttributesWithInheritance(
-            [property: ProtoMember(2)] string FirstName,
-            [property: ProtoMember(3)] string LastName
-        );
-        
-        [ProtoContract]
-        public record PositionalRecordWithAttributesWithInheritance (
-            string FirstName,
-            string LastName,
-            [property: ProtoMember(1)] int Count
-        ) : BasePositionalRecordWithAttributesWithInheritance(FirstName, LastName);
-        
-        [Fact]
-        public void CanRoundTripPositionalRecordWithAttributesWithInheritance()
-        {
-            var obj = new PositionalRecordWithAttributesWithInheritance("abc", "def", 123);
-            var model = RuntimeTypeModel.Create();
-            var clone = model.DeepClone(obj);
-            Assert.NotSame(obj, clone);
-            Assert.Equal("abc", clone.FirstName);
-            Assert.Equal("def", clone.LastName);
-            Assert.Equal(123, clone.Count);
-        }
     }
 }

--- a/src/protobuf-net.Test/RecordTypeTests.cs
+++ b/src/protobuf-net.Test/RecordTypeTests.cs
@@ -31,6 +31,23 @@ namespace ProtoBuf.Test
             Assert.Equal(123, clone.Count);
         }
         
+        [ProtoInclude(1, typeof(PositionalRecordWithInheritance))]
+        public record BasePositionalRecordWithInheritance(string FirstName, string LastName);
+        
+        public record PositionalRecordWithInheritance(string FirstName, string LastName, int Count) : BasePositionalRecordWithInheritance(FirstName, LastName);
+
+        [Fact]
+        public void CanRoundTripPositionalRecordWithInheritance()
+        {
+            var obj = new PositionalRecordWithInheritance("abc", "def", 123);
+            var model = RuntimeTypeModel.Create();
+            var clone = model.DeepClone(obj);
+            Assert.NotSame(obj, clone);
+            Assert.Equal("abc", clone.FirstName);
+            Assert.Equal("def", clone.LastName);
+            Assert.Equal(123, clone.Count);
+        }
+        
         [ProtoContract]
         public record PositionalRecordWithAttributes(
             [property: ProtoMember(1)] string FirstName,

--- a/src/protobuf-net/Compiler/Local.cs
+++ b/src/protobuf-net/Compiler/Local.cs
@@ -38,7 +38,7 @@ namespace ProtoBuf.Compiler
             if (ctx is object)
             {
                 // only *actually* dispose if this is context-bound; note that non-bound
-                // objects are cheekily re-used, and *must* be left intact agter a "using" etc
+                // objects are cheekily re-used, and *must* be left intact after a "using" etc
                 ctx.ReleaseToPool(value);
                 value = null; 
                 ctx = null;

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -614,7 +614,7 @@ namespace ProtoBuf.Meta
         [Flags]
         internal enum AttributeFamily
         {
-            None = 0, ProtoBuf = 1, DataContractSerialier = 2, XmlSerializer = 4, AutoTuple = 8
+            None = 0, ProtoBuf = 1, DataContractSerializer = 2, XmlSerializer = 4, AutoTuple = 8
         }
         private static Type GetBaseType(MetaType type)
         {
@@ -947,7 +947,7 @@ namespace ProtoBuf.Meta
                     case "System.Runtime.Serialization.DataContractAttribute":
                         if (!model.AutoAddProtoContractTypesOnly)
                         {
-                            family |= AttributeFamily.DataContractSerialier;
+                            family |= AttributeFamily.DataContractSerializer;
                         }
                         break;
                 }
@@ -1155,7 +1155,7 @@ namespace ProtoBuf.Meta
                 }
             }
 
-            if (!ignore && !done && HasFamily(family, AttributeFamily.DataContractSerialier))
+            if (!ignore && !done && HasFamily(family, AttributeFamily.DataContractSerializer))
             {
                 attrib = GetAttribute(attribs, "System.Runtime.Serialization.DataMemberAttribute");
                 if (attrib is object)

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -142,10 +142,6 @@ namespace ProtoBuf.Meta
                 ThrowIfFrozen();
                 derivedMeta.ThrowIfFrozen();
 
-                if (IsAutoTuple || derivedMeta.IsAutoTuple)
-                {
-                    ThrowTupleTypeWithInheritance(derivedType);
-                }
                 if (surrogateType is object) ThrowSubTypeWithSurrogate(Type);
                 if (derivedMeta.surrogateType is object) ThrowSubTypeWithSurrogate(derivedType);
 
@@ -160,12 +156,6 @@ namespace ProtoBuf.Meta
             {
                 model.ReleaseLock(opaqueToken);
             }
-        }
-
-        private static void ThrowTupleTypeWithInheritance(Type type)
-        {
-            ThrowHelper.ThrowInvalidOperationException(
-                $"Tuple-based types cannot be used in inheritance hierarchies: {type.NormalizeName()}");
         }
 
         private void SetBaseType(MetaType baseType)
@@ -552,7 +542,6 @@ namespace ProtoBuf.Meta
             }
             if (IsAutoTuple)
             {
-                if (involvedInInheritance) ThrowTupleTypeWithInheritance(Type);
                 ConstructorInfo ctor = ResolveTupleConstructor(Type, out MemberInfo[] mapping);
                 if (ctor is null) throw new InvalidOperationException();
                 return (IProtoTypeSerializer)Activator.CreateInstance(typeof(TupleSerializer<>).MakeGenericType(Type),


### PR DESCRIPTION
Fixes #743 

This pull request adds support for using C# 9 record types with inheritance. 

For example, the following syntax:

```csharp

        [ProtoInclude(1, typeof(PositionalRecordWithInheritance))]
        public record BasePositionalRecordWithInheritance(string FirstName, string LastName);
        
        public record PositionalRecordWithInheritance(string FirstName, string LastName, int Count) : BasePositionalRecordWithInheritance(FirstName, LastName);

```

Currently throws the following exception:

```
ProtoBuf.Test.RecordTypeTests.CanRoundTripPositionalRecordWithInheritance

System.InvalidOperationException: Tuple-based types cannot be used in inheritance hierarchies: ProtoBuf.Test.RecordTypeTests+PositionalRecordWithInher...

System.InvalidOperationException
Tuple-based types cannot be used in inheritance hierarchies: ProtoBuf.Test.RecordTypeTests+PositionalRecordWithInheritance
   at ProtoBuf.Internal.ThrowHelper.ThrowInvalidOperationException(String message, Exception innerException) in C:\git\protobuf-net\src\protobuf-net.Core\Internal\ThrowHelper.cs:line 55
   at ProtoBuf.Meta.MetaType.ThrowTupleTypeWithInheritance(Type type) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 167
   at ProtoBuf.Meta.MetaType.AddSubType(Int32 fieldNumber, Type derivedType, DataFormat dataFormat) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 147
   at ProtoBuf.Meta.MetaType.ApplyDefaultBehaviourImpl(CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 715
   at ProtoBuf.Meta.MetaType.ApplyDefaultBehaviour(CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 642
   at ProtoBuf.Meta.RuntimeTypeModel.FindOrAddAuto(Type type, Boolean demand, Boolean addWithContractOnly, Boolean addEvenIfAutoDisabled, CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\RuntimeTypeModel.cs:line 749
   at ProtoBuf.Meta.MetaType.ApplyDefaultBehaviourImpl(CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 652
   at ProtoBuf.Meta.MetaType.ApplyDefaultBehaviour(CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\MetaType.cs:line 642
   at ProtoBuf.Meta.RuntimeTypeModel.FindOrAddAuto(Type type, Boolean demand, Boolean addWithContractOnly, Boolean addEvenIfAutoDisabled, CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\RuntimeTypeModel.cs:line 749
   at ProtoBuf.Meta.RuntimeTypeModel.<GetServicesSlow>g__GetServicesImpl|88_0(RuntimeTypeModel model, Type type, CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\RuntimeTypeModel.cs:line 1028
   at ProtoBuf.Meta.RuntimeTypeModel.GetServicesSlow(Type type, CompatibilityLevel ambient) in C:\git\protobuf-net\src\protobuf-net\Meta\RuntimeTypeModel.cs:line 998
   at ProtoBuf.Meta.RuntimeTypeModel.GetSerializer[T]() in C:\git\protobuf-net\src\protobuf-net\Meta\RuntimeTypeModel.cs:line 961
   at ProtoBuf.Meta.TypeModel.TryGetSerializer[T](TypeModel model) in C:\git\protobuf-net\src\protobuf-net.Core\Meta\TypeModel.cs:line 1460
   at ProtoBuf.Meta.TypeModel.DeepClone[T](T value, Object userState) in C:\git\protobuf-net\src\protobuf-net.Core\Meta\TypeModel.cs:line 1521
   at ProtoBuf.Test.RecordTypeTests.CanRoundTripPositionalRecordWithInheritance() in C:\git\protobuf-net\src\protobuf-net.Test\RecordTypeTests.cs:line 44
```

To my surprise, just removing the checks that guard against mixing tuples with inheritance fixed the entire issue. The tests are green, ~~and no other new tests are broken~~. I'd be interested to hear feedback about this.

P.S. My OCD triggered a in few places, so I fixed some typos. I hope that's OK.

Edit: an example test broke. See my comment below.