### PR TITLE
Include NoPackageAnalysis and DevelopmentDependency properites

### DIFF
--- a/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
+++ b/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
@@ -8,6 +8,8 @@
     <NoWarn>$(NoWarn);RS2007;NU5128</NoWarn>
     <Description>Analyzer and Generator support for protobuf-net, using SDK 3.3.1 (pre .NET 5)</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
+++ b/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
@@ -9,6 +9,8 @@
     <NoWarn>$(NoWarn);RS2007;NU5128</NoWarn>
     <Description>Analyzer and Generator support for protobuf-net</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By including protobuf-net.BuildTools or protobuf-net.BuildTools.legacy in a project includes

    <PackageReference Include="protobuf-net.BuildTools" Version="3.0.91">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
    </PackageReference>

