### PR TITLE
Include DateTimeKind for all DateTimes if TypeMode.IncludeDateTimeKin…

### DIFF
--- a/src/Examples/Issues/Issue748.cs
+++ b/src/Examples/Issues/Issue748.cs
@@ -1,0 +1,62 @@
+﻿using ProtoBuf.Meta;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+    [ProtoContract]
+    public class TestContract
+    {
+        [ProtoMember(1)]
+        public DateTime DateTime { get; set; }
+
+        [ProtoMember(2)]
+        public string Test { get; set; }
+    }
+
+    public class Issue748
+    {
+        [Theory]
+        [MemberData(nameof(DateTimes))]
+        public void ShouldIncludeDateTimeKindForDateTime(DateTime dateTime, DateTimeKind dateTimeKind)
+        {
+            var typeModel = CreateTypeModel();
+            var sourceObject = new TestContract
+            {
+                DateTime = DateTime.SpecifyKind(dateTime, dateTimeKind),
+                Test = "abc"
+            };
+
+            using var sourceStream = new MemoryStream();
+            typeModel.Serialize(sourceStream, sourceObject);
+            var destinationStream = new MemoryStream(sourceStream.ToArray());
+            var deserializedObject = typeModel.Deserialize<TestContract>(destinationStream);
+
+            Assert.Equal(dateTime, deserializedObject.DateTime);
+            Assert.Equal(dateTimeKind, deserializedObject.DateTime.Kind);
+        }
+
+        public static IEnumerable<object[]> DateTimes =>
+            new List<object[]>
+            {
+                new object[] { DateTime.MinValue, DateTimeKind.Utc },
+                new object[] { DateTime.MinValue, DateTimeKind.Local },
+                new object[] { DateTime.MinValue, DateTimeKind.Unspecified },
+                new object[] { new DateTime(2020, 12, 25), DateTimeKind.Utc },
+                new object[] { new DateTime(2020, 12, 25), DateTimeKind.Local },
+                new object[] { new DateTime(2020, 12, 25), DateTimeKind.Unspecified },
+                new object[] { DateTime.MaxValue, DateTimeKind.Utc },
+                new object[] { DateTime.MaxValue, DateTimeKind.Local },
+                new object[] { DateTime.MaxValue, DateTimeKind.Unspecified }
+            };
+
+        public static TypeModel CreateTypeModel()
+        {
+            var typeModel = RuntimeTypeModel.Create();
+            typeModel.IncludeDateTimeKind = true;
+            return typeModel;
+        }
+    }
+}

--- a/src/protobuf-net.Core/BclHelpers.cs
+++ b/src/protobuf-net.Core/BclHelpers.cs
@@ -270,30 +270,7 @@ namespace ProtoBuf
         [MethodImpl(ProtoReader.HotPath)]
         private static void WriteDateTimeImpl(ref ProtoWriter.State state, DateTime value, bool includeKind)
         {
-            TimeSpan delta;
-            switch (state.WireType)
-            {
-                case WireType.StartGroup:
-                case WireType.String:
-                    if (value == DateTime.MaxValue)
-                    {
-                        delta = TimeSpan.MaxValue;
-                        includeKind = false;
-                    }
-                    else if (value == DateTime.MinValue)
-                    {
-                        delta = TimeSpan.MinValue;
-                        includeKind = false;
-                    }
-                    else
-                    {
-                        delta = value - EpochOrigin[0];
-                    }
-                    break;
-                default:
-                    delta = value - EpochOrigin[0];
-                    break;
-            }
+            TimeSpan delta = value - EpochOrigin[0];
             WriteTimeSpanImpl(ref state, delta, includeKind ? value.Kind : DateTimeKind.Unspecified);
         }
 


### PR DESCRIPTION
#748 

Change inculdes the fix for ignored DateTimeKind property in DateTime for DateTime.MinValue and DateTime.MaxValue, when IncludeDateTimeKind is set to true.

Unfortunatly the proposed fix breakes `LegacyDateTimeBehaviors` unit tesst.
Hence, I bealive it can't be merged without adding additional flag on TypeModel like `UseLegacyDateTimeBehaviors` set by default to true, to ensure that legacy behavior is still working for those who need it.

If you think it's a right approach I can implement it.