### PR TITLE
Handle Struct  which implements IEnumerable<T>

### DIFF
--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -46,13 +46,13 @@ namespace ProtoBuf.Serializers
         /// <summary>Create a serializer that operates on most common collections</summary>
         [MethodImpl(ProtoReader.HotPath)]
         public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
-            where TCollection : class, IEnumerable<T>
+            where TCollection : IEnumerable<T>
             => SerializerCache<EnumerableSerializer<TCollection, TCollection, T>>.InstanceField;
 
         /// <summary>Create a serializer that operates on most common collections</summary>
         [MethodImpl(ProtoReader.HotPath)]
         public static RepeatedSerializer<TCollection, T> CreateEnumerable<TCollection, TCreate, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
-            where TCollection : class, IEnumerable<T>
+            where TCollection : IEnumerable<T>
             where TCreate : TCollection
             => SerializerCache<EnumerableSerializer<TCollection, TCreate, T>>.InstanceField;
 
@@ -380,7 +380,7 @@ namespace ProtoBuf.Serializers
     }
 
     class EnumerableSerializer<TCollection, TCreate, T> : RepeatedSerializer<TCollection, T>
-        where TCollection : class, IEnumerable<T>
+        where TCollection : IEnumerable<T>
         where TCreate : TCollection
     {
         protected override TCollection Initialize(TCollection values, ISerializationContext context)

--- a/src/protobuf-net.Test/Serializers/Collections.cs
+++ b/src/protobuf-net.Test/Serializers/Collections.cs
@@ -14,6 +14,7 @@ namespace ProtoBuf.Serializers
         [Theory]
         [InlineData(typeof(string), null)]
         [InlineData(typeof(DoubleEnumerable), null)] // ambiguous? you can go without, then!
+        [InlineData(typeof(StructEnumerable), typeof(EnumerableSerializer<StructEnumerable, StructEnumerable, int>))]
 
         [InlineData(typeof(int[]), typeof(VectorSerializer<int>))]
         [InlineData(typeof(List<int>), typeof(ListSerializer<int>))]
@@ -193,6 +194,12 @@ namespace ProtoBuf.Serializers
         public class DoubleEnumerable : IEnumerable<string>, IEnumerable<int>
         {
             IEnumerator<string> IEnumerable<string>.GetEnumerator() => throw new NotImplementedException();
+            IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw new NotImplementedException();
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+        }
+
+        public struct StructEnumerable : IEnumerable<int>
+        {
             IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw new NotImplementedException();
             IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
         }


### PR DESCRIPTION
Hi,

The following Enumerable throw an exception:
`        public struct StructEnumerable : IEnumerable<int>
        {
            IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw new NotImplementedException();
            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
        }
`
Exception is due to a class constraint on EnumerableSerializer which I have removed.

If you are ok which the correction, can you publish a new version ?

Regards.