### PR TITLE
feat: option to write source type into schema

### DIFF
--- a/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
+++ b/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
@@ -68,7 +68,10 @@ namespace ProtoBuf.Meta
         /// Record the sub-type relationship formally in schemas
         /// </summary>
         PreserveSubType = 1 << 1,
+
+        /// <summary>
+        /// Include source type full name into generated schema
+        /// </summary>
+        WriteSourceType = 1 << 2,
     }
-
-
 }

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1999,6 +1999,7 @@ namespace ProtoBuf.Meta
                 bool allValid = IsValidEnum(enums);
                 if (!allValid) NewLine(builder, indent).Append("/* for context only");
                 NewLine(builder, indent).Append("enum ").Append(GetSchemaTypeName(callstack)).Append(" {");
+                AddSourceType();
                 AddNamespace(imports);
 
                 if (Type.IsDefined(typeof(FlagsAttribute), true))
@@ -2062,6 +2063,7 @@ namespace ProtoBuf.Meta
             {
                 ValueMember[] fieldsArr = GetFields();
                 NewLine(builder, indent).Append("message ").Append(GetSchemaTypeName(callstack)).Append(" {");
+                AddSourceType();
                 AddNamespace(imports);
                 foreach (ValueMember member in fieldsArr)
                 {
@@ -2194,7 +2196,16 @@ namespace ProtoBuf.Meta
                 if (HasReservations) AppendReservations();
                 NewLine(builder, indent).Append('}');
             }
-
+            void AddSourceType()
+            {
+                bool includeSourceType = (flags & SchemaGenerationFlags.WriteSourceType) != 0;
+                if (includeSourceType)
+                {
+                    NewLine(builder, indent + 1)
+                        .Append("// source type: ")
+                        .Append(Type.FullName); 
+                }
+            }
             void AddNamespace(HashSet<string> imports)
             {
                 if (!multipleNamespaceSupport || IsAutoTuple || string.IsNullOrWhiteSpace(Type.Namespace) || Type.Namespace == package)


### PR DESCRIPTION
It's looks like cosmetic thing, but sometimes it's really useful to know exact base type of message, especially if package does not match source type namespace. Of course, it disabled by default.