### PR TITLE
Set UserState to null when disposing ProtoReader

### DIFF
--- a/src/protobuf-net.Core/ProtoReader.cs
+++ b/src/protobuf-net.Core/ProtoReader.cs
@@ -146,6 +146,7 @@ namespace ProtoBuf
                 stringInterner = null;
             }
             netCache.Clear();
+            UserState = null;
         }
 
         private protected enum Read32VarintMode


### PR DESCRIPTION
Fixes #814 