### PR TITLE
Add NestedTypes to DynamicallyAccessedMember use

### DIFF
--- a/src/protobuf-net.Core/Internal/DynamicallyAccessedMembersAttribute.cs
+++ b/src/protobuf-net.Core/Internal/DynamicallyAccessedMembersAttribute.cs
@@ -15,7 +15,8 @@ namespace ProtoBuf.Internal
             = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor // construction
             | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties // annotated properties
             | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields // annotated fields and get-only accessors
-            | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods; // callbacks
+            | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods // callbacks
+            | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes; // nested/child objects
 
         internal const DynamicallyAccessedMemberTypes Serializer
             = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;


### PR DESCRIPTION
This prevents nested types - e.g. child objects or arrays of child objects - from being removed by the linker when an application is trimmed.

This only works at the moment in currently unreleased versions of the .NET SDK (e.g. v6.0.100-rc.1.21381.5). It does not work in any publicly released preview up to and including .NET 6 Preview 6.

I observed this when trying to make [SteamKit](https://github.com/steamre/steamkit) trimmable and when trying to produce trimmed builds of [DepotDownloader](https://github.com/steamre/depotdownloader). Whilst simply "not having child objects" could be considered a valid workaround, we build directly from reverse-engineered protobuf files that we have no real control over.

See https://github.com/mono/linker/issues/2185 for more information about use of the attribute.