### PR TITLE
Improve read-only collection/dictionary support

### DIFF
--- a/src/Examples/Issues/Issue820.cs
+++ b/src/Examples/Issues/Issue820.cs
@@ -1,0 +1,56 @@
+﻿using ProtoBuf.Meta;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace ProtoBuf.Issues
+{
+	public class Issue820
+	{
+        [ProtoContract]
+        public record SomeClass
+        {
+            [ProtoMember(1)]
+            public IReadOnlyCollection<string> Collection { get; set; } = Array.Empty<string>();
+
+            [ProtoMember(2)]
+            public IReadOnlyList<string> List { get; set; } = Array.Empty<string>();
+
+            [ProtoMember(3)]
+            public IReadOnlyDictionary<string, string> Map { get; set; } = ImmutableDictionary.Create<string, string>();
+        }
+
+        [Fact]
+        public void CanNotDeserializeIReadonlyCollection()
+        {
+            var orig = new SomeClass
+            {
+                Collection = new string[] { "a", "b", "c" },
+                List = new string[] { "a", "b", "c" }.ToImmutableList(),
+                Map = new Dictionary<string, string>
+                {
+                    ["a"] = "a",
+                    ["b"] = "b",
+                    ["c"] = "c"
+                }
+            };
+
+            static void Equal(SomeClass expected, SomeClass actual)
+            {
+                Assert.Equal(expected.Collection, actual.Collection);
+                Assert.Equal(expected.List, actual.List);
+                Assert.Equal(expected.Map, actual.Map);
+            }
+
+            var model = RuntimeTypeModel.Create();
+
+            // runtime
+            Equal(orig, model.DeepClone(orig));
+
+            // compiled
+            Equal(orig, model.Compile().DeepClone(orig)); 
+        }
+
+    }
+}

--- a/src/Examples/Issues/SO7793527.cs
+++ b/src/Examples/Issues/SO7793527.cs
@@ -107,23 +107,6 @@ namespace Examples.Issues
             Assert.Single(clone.Bars);
         }
 
-        [Fact]
-        public void ProtobufNet_SupportsNakedEnumerables_ButMustBeAddable()
-        {
-            var ser = RuntimeTypeModel.Create();
-            using var ms = new MemoryStream();
-            ser.Serialize(ms, new FooEnumerable { Bars = new[] { new Bar { } } });
-            ms.Position = 0;
-            // let's make Bars non-null in the target object, with something immutable
-            // (an empty array), to see how it goes boom
-            var obj = new FooEnumerable { Bars = Array.Empty<Bar>() };
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var clone = (FooEnumerable)ser.Deserialize(ms, obj, type: typeof(FooEnumerable));
-            });
-            Assert.Equal("For repeated data declared as System.Collections.Generic.IEnumerable`1[Examples.Issues.SO7793527+Bar], the *underlying* collection (Examples.Issues.SO7793527+Bar[]) must implement ICollection<T> and must not declare itself read-only; alternative (more exotic) collections can be used, but must be declared using their well-known form (for example, a member could be declared as ImmutableHashSet<T>)", ex.Message);
-        }
-
         // see https://gist.github.com/gmcelhanon/5391894
         [Serializable, ProtoContract]
         public class GoalPlanningModel1

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -384,8 +384,14 @@ namespace ProtoBuf.Serializers
         where TCreate : TCollection
     {
         protected override TCollection Initialize(TCollection values, ISerializationContext context)
+        {
+            // looks like we can use "values" only if it's non-readonly collection
+            if (values is ICollection<T> collection && !collection.IsReadOnly)
+                return values;
+
             // note: don't call TypeModel.CreateInstance: *we are the factory*
-            => values ?? (typeof(TCreate).IsInterface ? (TCollection)(object)new List<T>() : TypeModel.ActivatorCreate<TCreate>());
+            return typeof(TCreate).IsInterface ? (TCollection)(object)new List<T>() : TypeModel.ActivatorCreate<TCreate>();
+        }
 
         protected override int TryGetCount(TCollection values) => TryGetCountDefault(values); // don't trust them much
 

--- a/src/protobuf-net/Serializers/RepeatedSerializers.cs
+++ b/src/protobuf-net/Serializers/RepeatedSerializers.cs
@@ -93,6 +93,7 @@ namespace ProtoBuf.Serializers
             // pretty normal stuff
             Add(typeof(Dictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), root == current ? targs : new[] { root, targs[0], targs[1] }), false);
             Add(typeof(IDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), new[] { root, targs[0], targs[1] }), false);
+            Add(typeof(IReadOnlyDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateReadOnlyDictionary), new[] { root, targs[0], targs[1] }), false);
             Add(typeof(Queue<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateQueue), new[] { root, targs[0] }), false);
             Add(typeof(Stack<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateStack), new[] { root, targs[0] }), false);
 


### PR DESCRIPTION
I steel think that ability to support data model with read-only properties can be very valuable especially keeping in mind the latest C# features like records and nullability checks, for example:

```csharp
#nullable enable
[ProtoContract]
public record SomeClass
{
    // is better than following variants because 
    [ProtoMember(1)]
    public IReadOnlyCollection<string> Values1 { get; init; } = Array.Empty<string>();

    // every time during reading we should check is Values2 null, 
    // and after that is empty or not (which is effectively covered by foreach loop or linq operations)
    [ProtoMember(2)]
    public IReadOnlyCollection<string>? Values2 { get; init; }

    // in this case, we lose immutability because the collection has official writable interface
    ICollection<string>? _values3;
    [ProtoMember(3)]
    public ICollection<string> Values3 => _values3 ??= new List<string>();

    // this case is already supported but require in most cases repacking because Immutable interfaces
    // are not supported by mutable collection (which are still used in most cases) 
    // in contradiction to ReadOnly interfaces
    [ProtoMember(4)]
    public IImmutableList<string> Values4 { get; init; } = ImmutableList.Create<string>();
}
```

And I understand that the proposed solution will effectively break backward compatibility in some, I think, questionable cases (you can see deleted test), so I will not be upset at all if you reject this pull request.
