### PR TITLE
Added optional flag for pre-pending Enum name to Enum values to Proto generation

### DIFF
--- a/src/Examples/EnumTests.cs
+++ b/src/Examples/EnumTests.cs
@@ -75,6 +75,29 @@ enum blah {
 ", proto, ignoreLineEndingDifferences: true);
         }
 
+        [Fact]
+        public void EnumPrefixGenerationTest()
+        {
+            var options = new SchemaGenerationOptions { Syntax = ProtoSyntax.Proto2 };
+            options.Types.Add(typeof(EnumFoo));
+            options.Flags |= SchemaGenerationFlags.PrefixEnumValuesWithEnumName;
+            
+            string proto = Serializer.GetProto(options);
+
+            Assert.Equal(@"syntax = ""proto2"";
+package Examples.DesignIdeas;
+
+message EnumFoo {
+   optional blah Bar = 1 [default = B];
+}
+enum blah {
+   blah_B = 0;
+   blah_A = -1;
+   blah_C = 1;
+}
+", proto, ignoreLineEndingDifferences: true);
+        }
+
 
         [Fact]
         public void TestNonNullValues()

--- a/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
+++ b/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
@@ -68,6 +68,10 @@ namespace ProtoBuf.Meta
         /// Record the sub-type relationship formally in schemas
         /// </summary>
         PreserveSubType = 1 << 1,
+        /// <summary>
+        /// Prepend enum name to enum fields
+        /// </summary>
+        PrefixEnumValuesWithEnumName = 1 << 2
     }
 
 

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1995,7 +1995,6 @@ namespace ProtoBuf.Meta
             {
                 var enums = GetEnumValues();
 
-
                 bool allValid = IsValidEnum(enums);
                 if (!allValid) NewLine(builder, indent).Append("/* for context only");
                 NewLine(builder, indent).Append("enum ").Append(GetSchemaTypeName(callstack)).Append(" {");
@@ -2025,19 +2024,23 @@ namespace ProtoBuf.Meta
 
                 bool haveWrittenZero = false;
                 // write zero values **first**
+
+                string enumPrefix = flags.HasFlag(SchemaGenerationFlags.PrefixEnumValuesWithEnumName) ? GetSchemaTypeName(callstack) + "_" : "";
+
                 foreach (var member in enums)
                 {
                     var parsed = member.TryGetInt32();
                     if (parsed.HasValue && parsed.Value == 0)
                     {
-                        NewLine(builder, indent + 1).Append(member.Name).Append(" = 0;");
+                        NewLine(builder, indent + 1).Append(enumPrefix + member.Name).Append(" = 0;");
                         haveWrittenZero = true;
                     }
                 }
 
                 if (syntax == ProtoSyntax.Proto3 && !haveWrittenZero)
                 {
-                    NewLine(builder, indent + 1).Append("ZERO = 0; // proto3 requires a zero value as the first item (it can be named anything)");
+                    NewLine(builder, indent + 1)
+                        .Append(enumPrefix + "ZERO = 0; // proto3 requires a zero value as the first item (it can be named anything)");
                 }
 
                 // note array is already sorted, so zero would already be first
@@ -2047,11 +2050,11 @@ namespace ProtoBuf.Meta
                     if (parsed.HasValue)
                     {
                         if (parsed.Value == 0) continue;
-                        NewLine(builder, indent + 1).Append(member.Name).Append(" = ").Append(parsed.Value).Append(';');
+                        NewLine(builder, indent + 1).Append(enumPrefix + member.Name).Append(" = ").Append(parsed.Value).Append(';');
                     }
                     else
                     {
-                        NewLine(builder, indent + 1).Append("// ").Append(member.Name).Append(" = ").Append(member.Value).Append(';').Append(" // note: enums should be valid 32-bit integers");
+                        NewLine(builder, indent + 1).Append("// ").Append(enumPrefix + member.Name).Append(" = ").Append(member.Value).Append(';').Append(" // note: enums should be valid 32-bit integers");
                     }
                 }
                 if (HasReservations) AppendReservations();

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -2026,7 +2026,6 @@ namespace ProtoBuf.Meta
                 // write zero values **first**
 
                 string enumPrefix = flags.HasFlag(SchemaGenerationFlags.PrefixEnumValuesWithEnumName) ? GetSchemaTypeName(callstack) + "_" : "";
-
                 foreach (var member in enums)
                 {
                     var parsed = member.TryGetInt32();


### PR DESCRIPTION
Added a new flag in ```SchemaGenerationFlags``` for applying ```( EnumName_ + ValueName )``` to the generation of enum values.

Google's Proto compiler requires globally unique enum field names. Adding this prefix fixes compilation issues with Google's proto library. Most generators (C# for sure) will strip the prefix because it is part of Protobuf style guidelines.
