### PR TITLE
PR: Suggested fix for 'Possible Recursion Detected' exception on specific scenario.

### DIFF
--- a/src/Examples/Recursion.cs
+++ b/src/Examples/Recursion.cs
@@ -1,6 +1,8 @@
 ﻿using System.IO;
 using Xunit;
 using ProtoBuf;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Examples
 {
@@ -9,6 +11,45 @@ namespace Examples
     {
         [ProtoMember(1)]
         public RecursiveObject Yeuch { get; set; }
+    }
+
+    [ProtoContract]
+    public class MySurrogate
+    {
+        [ProtoMember(1)]
+        public TreeNode nonRecursiveObj { get; set; }
+        [ProtoConverter]
+        public static INode From(MySurrogate value)
+        {
+            return value.nonRecursiveObj;
+        }
+        [ProtoConverter]
+        public static MySurrogate To(INode value)
+        {
+            var surrogate = new MySurrogate();
+            if (value is TreeNode nonRecursiveObj)
+                surrogate.nonRecursiveObj = nonRecursiveObj;
+            return surrogate;
+        }
+    }
+    [ProtoContract(Surrogate = typeof(MySurrogate))]
+    public interface INode
+    {
+        public string Name { get; }
+    }
+    [ProtoContract]
+    public class TreeNode : INode
+    {
+        [ProtoMember(1)]
+        public string Name { get; }
+        [ProtoMember(2)]
+        public List<INode> Children { get; }
+        public TreeNode(string Name) : this()
+        {
+            this.Name = Name;
+        }
+        public TreeNode() { Children = new List<INode>(); }
+        public string AsString() => Children != null ? $"{Name} => {{{string.Join(",", Children)}}}" : Name;
     }
     
     public class Recursion
@@ -21,6 +62,27 @@ namespace Examples
                 RecursiveObject obj = new RecursiveObject();
                 obj.Yeuch = obj;
                 Serializer.Serialize(Stream.Null, obj);
+            });
+        }
+
+        [Fact]
+        public void Tree_NoRecursionDetected()
+        {
+            var tree = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToArray().Reverse().Select(letter => new TreeNode(letter.ToString()))
+            .Aggregate((prev, next) => { next.Children.Add(prev); return next; });
+            //A => {B => {C => {D => {E => {F => {G => {H => {I => {J => {K => {L => {M => {N => {...}}}}}}}}}}}}}}
+            var cloned = Serializer.DeepClone(tree);
+            Assert.Equal(tree.AsString(), cloned.AsString());
+        }
+
+        [Fact]
+        public void Graph_RecursionDetected()
+        {
+            Program.ExpectFailure<ProtoException>(() =>
+            {
+                var graph = new TreeNode("A");
+                graph.Children.Add(graph);
+                Serializer.DeepClone(graph);
             });
         }
     }

--- a/src/Examples/Recursion.cs
+++ b/src/Examples/Recursion.cs
@@ -17,18 +17,18 @@ namespace Examples
     public class MySurrogate
     {
         [ProtoMember(1)]
-        public TreeNode nonRecursiveObj { get; set; }
+        public TreeNode treeNode { get; set; }
         [ProtoConverter]
-        public static INode From(MySurrogate value)
+        public static INode From(MySurrogate surrogate)
         {
-            return value.nonRecursiveObj;
+            return surrogate.treeNode;
         }
         [ProtoConverter]
         public static MySurrogate To(INode value)
         {
             var surrogate = new MySurrogate();
-            if (value is TreeNode nonRecursiveObj)
-                surrogate.nonRecursiveObj = nonRecursiveObj;
+            if (value is TreeNode treeNode)
+                surrogate.treeNode = treeNode;
             return surrogate;
         }
     }

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -254,7 +254,7 @@ namespace ProtoBuf
         protected internal virtual void WriteMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(ref State state, T value, ISerializer<T> serializer, PrefixStyle style, bool recursionCheck)
         {
 #pragma warning disable CS0618 // StartSubItem/EndSubItem
-            var tok = state.StartSubItem(TypeHelper<T>.IsReferenceType & recursionCheck ? (object)value : null, style);
+            var tok = state.StartSubItem(TypeHelper<T>.IsReferenceType & !typeof(T).IsInterface & recursionCheck ? (object)value : null, style);
             (serializer ?? TypeModel.GetSerializer<T>(model)).Write(ref state, value);
             state.EndSubItem(tok, style);
 #pragma warning restore CS0618


### PR DESCRIPTION
Hi,

I've had an issue with a specific scenario where interfaces, surrogates and recursion detection are involved. I've created a couple of illustrative unit tests and would like to propose a potential fix for this. Can you check if it makes sense and if this is something you'd like to see integrated?

Thanks.