### PR TITLE
Clear ioBuffer when disposing StreamProtoReader

### DIFF
--- a/src/protobuf-net.Core/ProtoReader.Stream.cs
+++ b/src/protobuf-net.Core/ProtoReader.Stream.cs
@@ -178,6 +178,10 @@ namespace ProtoBuf
                     // make sure we don't pool this if it came from a MemoryStream
                     BufferPool.ReleaseBufferToPool(ref _ioBuffer);
                 }
+                else
+                {
+                    _ioBuffer = null;
+                }
                 Pool<StreamProtoReader>.Put(this);
             }
 


### PR DESCRIPTION
When deserializing a `MemoryStream`, the statically pooled instance of `StreamProtoReader` does not clear it's `_ioBuffer` on disposal when the `_ioBuffer` was initialized from `TryConsumeSegmentRespectingPosition`.