### PR TITLE
Clear NewSlot MethodAttribute on GetSerializer override method (#847)

### DIFF
--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1160,7 +1160,7 @@ namespace ProtoBuf.Meta
                 paramTypes[i] = parameters[i].ParameterType;
             }
             MethodBuilder newMethod = type.DefineMethod(baseMethod.Name,
-                (baseMethod.Attributes & ~MethodAttributes.Abstract) | MethodAttributes.Final, baseMethod.CallingConvention, baseMethod.ReturnType, paramTypes);
+                (baseMethod.Attributes & ~(MethodAttributes.Abstract | MethodAttributes.NewSlot)) | MethodAttributes.Final, baseMethod.CallingConvention, baseMethod.ReturnType, paramTypes);
             if (baseMethod.IsGenericMethodDefinition)
             {
                 genericArgs = baseMethod.GetGenericArguments();


### PR DESCRIPTION
In `RuntimeTypeModel.Override`, the new method being generated inherits the `MethodAttributes` of its parent. However, if the parent method has the `NewSlot` attribute set, this prevents the new method from properly acting as an override. The CIL generated by `AssemblyBuilder.Save` for this appears to behave as a normal overridden virtual function, but when emitted by [ILPack](https://github.com/Lokad/ILPack) it instead applies method hiding. I think the intent is for normal virtual override behavior to apply in this situation.

The end result is calls to `MyGeneratedSerializerAssembly.GetSerializer<T>` from within protobuf-net (i.e. without explicit casting) only ends up calling the base `TypeModel.GetSerializer<T>` implementation.

See issue https://github.com/protobuf-net/protobuf-net/issues/847