### PR TITLE
Added API Extension for AddSerializer and of protbuf-net.FSharp

### DIFF
--- a/src/protobuf-net.Core/Serializers/MapSerializer.External.cs
+++ b/src/protobuf-net.Core/Serializers/MapSerializer.External.cs
@@ -1,0 +1,23 @@
+﻿using ProtoBuf.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ProtoBuf.Serializers
+{
+    /// <summary>
+    /// ExternalMapSerializer provides a base class for concrete types to inherit from, but only provide the methods for collection management
+    /// It does not require changes to internal protobuf-net state handling
+    /// </summary>
+    /// <typeparam name="TCollection">the collection type being provided (e.g. Map<_,_> for F#) </typeparam>
+    /// <typeparam name="TKey">key to the collection</typeparam>
+    /// <typeparam name="TValue">type of the value held within the collection</typeparam>
+    public abstract class ExternalMapSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)]TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TKey, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : MapSerializer<TCollection, TKey, TValue> where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+    {
+        internal override void Write(ref ProtoWriter.State state, int fieldNumber, WireType wireType, TCollection values, in KeyValuePairSerializer<TKey, TValue> pairSerializer)
+        {
+            var iter = values.GetEnumerator();
+            Write(ref state, fieldNumber, wireType, ref iter, pairSerializer);
+        }
+    }
+}

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.External.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.External.cs
@@ -1,0 +1,34 @@
+﻿using ProtoBuf.Internal;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ProtoBuf.Serializers
+{
+
+    /// <summary>
+    /// ExternalSerializer provides a base class for concrete types to inherit from, but only provide the methods for collection management
+    /// It does not require changes to internal protobuf-net state handling
+    /// </summary>
+    /// <typeparam name="TCollection">the collection type being provided (e.g. Map<_,_> for F#) </typeparam>
+    /// <typeparam name="T">type of the value held within the collection</typeparam>
+
+    public abstract class ExternalSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] T> : RepeatedSerializer<TCollection, T> where TCollection : IEnumerable<T>
+    {
+        internal override long Measure(TCollection values, IMeasuringSerializer<T> serializer, ISerializationContext context, WireType wireType)
+        {
+            var iter = values.GetEnumerator();
+            return Measure(ref iter, serializer, context, wireType);
+        }
+        internal override void WritePacked(ref ProtoWriter.State state, TCollection values, IMeasuringSerializer<T> serializer, WireType wireType)
+        {
+            var iter = values.GetEnumerator();
+            WritePacked(ref state, ref iter, serializer, wireType);
+        }
+
+        internal override void Write(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures category, WireType wireType, TCollection values, ISerializer<T> serializer)
+        {
+            var iter = values.GetEnumerator();
+            Write(ref state, fieldNumber, category, wireType, ref iter, serializer);
+        }
+    }
+}

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.External.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.External.cs
@@ -16,19 +16,46 @@ namespace ProtoBuf.Serializers
     {
         internal override long Measure(TCollection values, IMeasuringSerializer<T> serializer, ISerializationContext context, WireType wireType)
         {
-            var iter = values.GetEnumerator();
-            return Measure(ref iter, serializer, context, wireType);
+            IEnumerator<T> iter = null;
+            try
+            {
+                iter = values.GetEnumerator();
+                return Measure(ref iter, serializer, context, wireType);
+            }
+            finally
+            {
+                if (iter != null)
+                    iter.Dispose();
+            }
         }
         internal override void WritePacked(ref ProtoWriter.State state, TCollection values, IMeasuringSerializer<T> serializer, WireType wireType)
         {
-            var iter = values.GetEnumerator();
-            WritePacked(ref state, ref iter, serializer, wireType);
+            IEnumerator<T> iter = null;
+            try
+            {
+                iter = values.GetEnumerator();
+                WritePacked(ref state, ref iter, serializer, wireType);
+            }
+            finally
+            {
+                if (iter != null)
+                    iter.Dispose();
+            }
         }
 
         internal override void Write(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures category, WireType wireType, TCollection values, ISerializer<T> serializer)
         {
-            var iter = values.GetEnumerator();
-            Write(ref state, fieldNumber, category, wireType, ref iter, serializer);
+            IEnumerator<T> iter = null;
+            try
+            {
+                iter = values.GetEnumerator();
+                Write(ref state, fieldNumber, category, wireType, ref iter, serializer);
+            }
+            finally
+            {
+                if (iter != null)
+                    iter.Dispose();
+            }
         }
     }
 }

--- a/src/protobuf-net.FSharp.Test/Tests.fs
+++ b/src/protobuf-net.FSharp.Test/Tests.fs
@@ -1,0 +1,143 @@
+module ProtoBuf.FSharp.Test.Tests
+
+open System
+open Xunit
+open ProtoBuf
+open ProtoBuf.Meta
+open System.IO
+open ProtoBuf.FSharp
+
+[<Fact>]
+let ``Test Map`` () =
+    let model = 
+        (RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<Map<_,_>>, typeof<FSharpMapFactory>)
+
+    let source = 
+        ["a", 1; "b", 2; "c", 3]
+        |> Map.ofList
+
+    use ms = new MemoryStream (1024)
+
+    model.Serialize(ms, source)
+    ms.Position <- 0L
+
+    let dest = model.Deserialize<Map<string,int>>(ms)
+
+    Assert.True(source.Equals(dest))
+
+[<Fact>]
+let ``Test List`` () =
+    let model = 
+        (RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<_ list>, typeof<FSharpListFactory>)
+
+    let source = 
+        ["a", 1; "b", 2; "c", 3]
+
+    use ms = new MemoryStream (1024)
+
+    model.Serialize(ms, source)
+    ms.Position <- 0L
+
+    let dest = model.Deserialize<(string * int) list>(ms)
+
+    Assert.True(source.Equals(dest))
+
+[<Fact>]
+let ``Test Set`` () =
+    let model = 
+        (RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<Set<_>>, typeof<FSharpSetFactory>)
+
+    let source = 
+        ["a", 1; "b", 2; "c", 3]
+        |> Set.ofList
+
+    use ms = new MemoryStream (1024)
+
+    model.Serialize(ms, source)
+    ms.Position <- 0L
+
+    let dest = model.Deserialize<Set<string * int>>(ms)
+
+    Assert.True(source.Equals(dest))
+
+[<Fact>]
+let ``Test All`` () =
+    let model = 
+        (((RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<Map<_,_>>, typeof<FSharpMapFactory>))
+                .AddSerializer (typeof<_ list>, typeof<FSharpListFactory>))
+                    .AddSerializer (typeof<Set<_>>, typeof<FSharpSetFactory>)
+
+    let source = ["a", 1; "b", 2; "c", 3]
+    let map = Map.ofList source
+    let set = Set.ofList source
+
+    use ms = new MemoryStream (1024)
+
+    model.Serialize(ms, source)
+    ms.Position <- 0L
+    let dest = model.Deserialize<(string * int) list>(ms)
+
+    ms.Position <- 0L
+    model.Serialize(ms, set)
+    ms.Position <- 0L
+    let setdest = model.Deserialize<Set<string * int>>(ms)
+
+    ms.Position <- 0L
+    model.Serialize(ms, map)
+    ms.Position <- 0L
+    let mapdest = model.Deserialize<Map<string, int>>(ms)
+
+    Assert.True(source.Equals(dest))
+    Assert.True(set.Equals(setdest))
+    Assert.True(map.Equals(mapdest))
+
+[<Fact>]
+let ``Test complex`` () =
+    let model = 
+        (((RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<Map<_,_>>, typeof<FSharpMapFactory>))
+                .AddSerializer (typeof<_ list>, typeof<FSharpListFactory>))
+                    .AddSerializer (typeof<Set<_>>, typeof<FSharpSetFactory>)
+
+    let source = ["a", 1; "b", 2; "c", 3]
+    let set = Set.ofList source
+    let map = 
+        ["first", set; "second", set; "third", set]
+        |> Map.ofSeq
+
+    use ms = new MemoryStream(1024)
+
+    model.Serialize(ms, map)
+    ms.Position <- 0L
+    let dest = model.Deserialize<(Map<string, Set<string * int>>)>(ms)
+
+    Assert.True(map.Equals(dest))
+
+[<Fact>]
+let ``Test more complex`` () =
+    let model = 
+        (((RuntimeTypeModel.Create ("fsharp"))
+            .AddSerializer (typeof<Map<_,_>>, typeof<FSharpMapFactory>))
+                .AddSerializer (typeof<_ list>, typeof<FSharpListFactory>))
+                    .AddSerializer (typeof<Set<_>>, typeof<FSharpSetFactory>)
+
+    let source = ["a", 1; "b", 2; "c", 3]
+    let set = Set.ofList source
+    let map = 
+        ["first", set; "second", set; "third", set]
+        |> Map.ofSeq
+    let map2 = 
+        ["Alpha", map; "Beta", map; "Kappa", map]
+        |> Map.ofSeq
+
+    use ms = new MemoryStream(10240)
+
+    model.Serialize(ms, map2)
+    ms.Position <- 0L
+    let dest = model.Deserialize<(Map<string,Map<string, Set<string * int>>>)>(ms)
+
+    Assert.True(map2.Equals(dest))

--- a/src/protobuf-net.FSharp.Test/Tests.fs
+++ b/src/protobuf-net.FSharp.Test/Tests.fs
@@ -17,6 +17,11 @@ let ``Test Map`` () =
         ["a", 1; "b", 2; "c", 3]
         |> Map.ofList
 
+    let source2 = 
+        ["a", 1.; "b", 2.; "c", 3.]
+        |> Map.ofList
+
+
     use ms = new MemoryStream (1024)
 
     model.Serialize(ms, source)
@@ -25,6 +30,14 @@ let ``Test Map`` () =
     let dest = model.Deserialize<Map<string,int>>(ms)
 
     Assert.True(source.Equals(dest))
+    ms.Position <- 0L
+
+    model.Serialize(ms, source2)
+    ms.Position <- 0L
+
+    let dest2 = model.Deserialize<Map<string,double>>(ms)
+
+    Assert.True(source2.Equals(dest2))
 
 [<Fact>]
 let ``Test List`` () =

--- a/src/protobuf-net.FSharp.Test/protobuf-net.FSharp.Test.fsproj
+++ b/src/protobuf-net.FSharp.Test/protobuf-net.FSharp.Test.fsproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <TargetFrameworks>netcoreapp3.1;net462;net5.0</TargetFrameworks>
+	  <RootNamespace>ProtoBuf.FSharp.Test</RootNamespace>
+  <LangVersion>latest</LangVersion>
+            <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\protobuf-net.Core\protobuf-net.Core.csproj" />
+    <ProjectReference Include="..\protobuf-net.FSharp\protobuf-net.FSharp.csproj" />
+    <ProjectReference Include="..\protobuf-net\protobuf-net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="5.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/protobuf-net.FSharp/FSharpListSerializer.cs
+++ b/src/protobuf-net.FSharp/FSharpListSerializer.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.FSharp.Collections;
+using ProtoBuf.Serializers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ProtoBuf.FSharp
+{
+    /// <summary>
+    /// Serialisation provider for F# lists
+    /// </summary>
+    /// <typeparam name="T">content of list</typeparam>
+    public sealed class FSharpListSerializer<T> : ExternalSerializer<FSharpList<T>, T>
+    {
+        protected override FSharpList<T> AddRange(FSharpList<T> values, ref ArraySegment<T> newValues, ISerializationContext context)
+        {
+            if (values == null || values.IsEmpty)
+            {
+                return ListModule.OfSeq(newValues);
+            }
+            return ListModule.Append(values, ListModule.OfSeq(newValues));
+        }
+
+        protected override FSharpList<T> Clear(FSharpList<T> values, ISerializationContext context)
+        {
+            return ListModule.Empty<T>();
+        }
+
+        protected override int TryGetCount(FSharpList<T> values)
+        {
+            return values.IsEmpty ? 0 : values.Length;
+        }
+    }
+    /// <summary>
+    /// Factory class to provide consistent idiom with in-build protobuf collections.
+    /// This class is the reason for implementation in C# rather than F#: 
+    ///     static classes in F# are module, but module does not allow typeof<module>
+    /// </summary>
+    public static class FSharpListFactory
+    {
+        /// <summary>Create a map serializer that operates on FSharp Maps</summary>
+        public static RepeatedSerializer<FSharpList<T>, T> Create<T>()
+            => new FSharpListSerializer<T>();
+    }
+
+}

--- a/src/protobuf-net.FSharp/FSharpMapSerializer.cs
+++ b/src/protobuf-net.FSharp/FSharpMapSerializer.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.FSharp.Collections;
+using ProtoBuf;
+using ProtoBuf.Serializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ProtoBuf.FSharp
+{
+    /// <summary>
+    /// Serialization provider for F# Maps
+    /// </summary>
+    /// <typeparam name="TKey">type of map key</typeparam>
+    /// <typeparam name="TValue">type of value</typeparam>
+    public sealed class FSharpMapSerializer<TKey, TValue> : ExternalMapSerializer<FSharpMap<TKey, TValue>, TKey, TValue>
+    {
+        protected override FSharpMap<TKey, TValue> Clear(FSharpMap<TKey, TValue> values, ISerializationContext context)
+            => MapModule.Empty<TKey, TValue>();
+        protected override FSharpMap<TKey, TValue> Initialize(FSharpMap<TKey, TValue> values, ISerializationContext context)
+            => values ?? MapModule.Empty<TKey, TValue>();
+        protected override FSharpMap<TKey, TValue> AddRange(FSharpMap<TKey, TValue> values, ref ArraySegment<KeyValuePair<TKey, TValue>> newValues, ISerializationContext context)
+        {
+            if (values == null || values.IsEmpty)
+            {
+                return MapModule.OfSeq<TKey, TValue>(newValues.Select(r => new Tuple<TKey, TValue>(r.Key, r.Value)));
+            }
+            var map = values;
+            foreach (var pair in newValues)
+            {
+                map = MapModule.Add(pair.Key, pair.Value, map);
+            }
+            return map;
+        }
+        protected override FSharpMap<TKey, TValue> SetValues(FSharpMap<TKey, TValue> values, ref ArraySegment<KeyValuePair<TKey, TValue>> newValues, ISerializationContext context)
+        {
+            if (values.IsEmpty)
+            {
+                return MapModule.OfSeq<TKey, TValue>(newValues.Select(r => new Tuple<TKey, TValue>(r.Key, r.Value)));
+            }
+            var dictionary = new Dictionary<TKey, TValue>(values.Count);
+            foreach (var cur in values)
+            {
+                dictionary.Add(cur.Key, cur.Value);
+            }
+            foreach (var pair in newValues)
+            {
+                dictionary[pair.Key] = pair.Value;
+            }
+            return MapModule.OfSeq<TKey, TValue>(dictionary.Select(r => new Tuple<TKey, TValue>(r.Key, r.Value)));
+        }
+    }
+
+    /// <summary>
+    /// Factory class to provide consistent idiom with in-build protobuf collections.
+    /// This class is the reason for implementation in C# rather than F#: 
+    ///     static classes in F# are module, but module does not allow typeof<module>
+    /// </summary>
+    public static class FSharpMapFactory 
+    {
+        /// <summary>Create a map serializer that operates on FSharp Maps</summary>
+        public static MapSerializer<FSharpMap<TKey, TValue>, TKey, TValue> Create<TKey, TValue>()
+            => new FSharpMapSerializer<TKey, TValue>();
+    }
+}

--- a/src/protobuf-net.FSharp/FSharpSetSerializer.cs
+++ b/src/protobuf-net.FSharp/FSharpSetSerializer.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.FSharp.Collections;
+using ProtoBuf.Serializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProtoBuf.FSharp
+{
+    /// <summary>
+    /// Serialisation provider for F# Set unique collection
+    /// </summary>
+    /// <typeparam name="T">content of unique items within the Set</typeparam>
+    public sealed class FSharpSetSerializer<T> : ExternalSerializer<FSharpSet<T>, T>
+    {
+        protected override FSharpSet<T> AddRange(FSharpSet<T> values, ref ArraySegment<T> newValues, ISerializationContext context)
+        {
+            if (values == null || values.IsEmpty)
+            {
+                return SetModule.OfSeq(newValues);
+            }
+            if (newValues.Count == 1)
+            {
+                return SetModule.Add<T>(newValues.Array[newValues.Offset], values);
+            }
+            return SetModule.Union(values, SetModule.OfSeq(newValues));
+        }
+
+        protected override FSharpSet<T> Clear(FSharpSet<T> values, ISerializationContext context)
+        {
+            return SetModule.Empty<T>();
+        }
+
+        protected override int TryGetCount(FSharpSet<T> values)
+        {
+            return values is null ? 0 : values.Count;
+        }
+    }
+
+    /// <summary>
+    /// Factory class to provide consistent idiom with in-build protobuf collections.
+    /// This class is the reason for implementation in C# rather than F#: 
+    ///     static classes in F# are module, but module does not allow typeof<module>
+    /// </summary>
+    public static class FSharpSetFactory
+    {
+        /// <summary>Create a map serializer that operates on FSharp Maps</summary>
+        public static RepeatedSerializer<FSharpSet<T>, T> Create<T>()
+            => new FSharpSetSerializer<T>();
+    }
+}

--- a/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
+++ b/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+	  <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+	  <RootNamespace>ProtoBuf.FSharp</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\protobuf-net.Core\protobuf-net.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/protobuf-net.sln
+++ b/src/protobuf-net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.29230.61
+VisualStudioVersion = 16.0.31911.196
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "protobuf-net", "protobuf-net\protobuf-net.csproj", "{3044FAAC-6DCC-44AA-ADAF-26152FF46922}"
 EndProject
@@ -90,6 +90,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildToolsUnitTests", "BuildToolsUnitTests\BuildToolsUnitTests.csproj", "{9376B70C-ECE5-4D82-8290-2CA27F3761A3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "protobuf-net.BuildTools.Legacy", "protobuf-net.BuildTools.Legacy\protobuf-net.BuildTools.Legacy.csproj", "{B09E5BE2-3DE5-410C-A852-17626F0AC48D}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "protobuf-net.FSharp.Test", "protobuf-net.FSharp.Test\protobuf-net.FSharp.Test.fsproj", "{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "protobuf-net.FSharp", "protobuf-net.FSharp\protobuf-net.FSharp.csproj", "{763193DB-D730-4898-AB6B-986880AB18BF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -266,6 +270,18 @@ Global
 		{B09E5BE2-3DE5-410C-A852-17626F0AC48D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B09E5BE2-3DE5-410C-A852-17626F0AC48D}.VS|Any CPU.ActiveCfg = Debug|Any CPU
 		{B09E5BE2-3DE5-410C-A852-17626F0AC48D}.VS|Any CPU.Build.0 = Debug|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.VS|Any CPU.ActiveCfg = Debug|Any CPU
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A}.VS|Any CPU.Build.0 = Debug|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.VS|Any CPU.ActiveCfg = Debug|Any CPU
+		{763193DB-D730-4898-AB6B-986880AB18BF}.VS|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -300,6 +316,8 @@ Global
 		{6A13934A-418A-4732-8567-0C5DE8F52234} = {F5B07EBF-F1D9-40BF-8EF4-0BCBA45FAF94}
 		{9376B70C-ECE5-4D82-8290-2CA27F3761A3} = {0D637072-686D-4DC7-91E4-87913E5154B4}
 		{B09E5BE2-3DE5-410C-A852-17626F0AC48D} = {F5B07EBF-F1D9-40BF-8EF4-0BCBA45FAF94}
+		{43E0D7CC-2A54-43F9-B66C-8809C3851E2A} = {0D637072-686D-4DC7-91E4-87913E5154B4}
+		{763193DB-D730-4898-AB6B-986880AB18BF} = {F5B07EBF-F1D9-40BF-8EF4-0BCBA45FAF94}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CFE3C0D9-B865-48B9-9CC8-8AEA71EB5C16}


### PR DESCRIPTION
Added RuntimeTypeModel API function AddSerializer to add externally implemented serialization for F# collections and abstract base class for external serializers.
Implemented protobuf-net.FSharp to optionally add F# collections {Map, Set, list} using the AddSerializer at runtime
`
let ``Test Map`` () =
    let model = 
        (RuntimeTypeModel.Create ("fsharp"))
            .AddSerializer (typeof<Map<_,_>>, typeof<FSharpMapFactory>)
`