### PR TITLE
allow IEnumerable<T> properties to be cleared by using the same behaviour as null would have used

### DIFF
--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -437,7 +437,15 @@ namespace ProtoBuf.Serializers
             }
             else
             {
-                ThrowInvalidCollectionType(values);
+                if (typeof(TCollection) == typeof(IEnumerable<T>))
+                {
+                    // this is a recognised case; we'll use the same default type as Initialize
+                    values = Initialize(default, context);
+                }
+                else
+                {
+                    ThrowInvalidCollectionType(values);
+                }
             }
             return values;
         }

--- a/src/protobuf-net.Test/Issues/OverwriteEnumerable.cs
+++ b/src/protobuf-net.Test/Issues/OverwriteEnumerable.cs
@@ -1,0 +1,35 @@
+﻿using ProtoBuf.Meta;
+using ProtoBuf.unittest;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    public class OverwriteEnumerable
+    {
+        [Fact]
+        public void Execute()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            ExecuteImpl(model);
+            model.CompileInPlace();
+            ExecuteImpl(model);
+            ExecuteImpl(model.CompileAndVerify());
+        }
+        private void ExecuteImpl(TypeModel model)
+        {
+            var obj = new TypeWithEnumerableProperty { Values = new List<string> { "val1", "val2", "val3" } };
+            var clone = model.DeepClone(obj);
+            Assert.NotSame(obj, clone);
+            Assert.Equal("val1,val2,val3", string.Join(",", clone.Values));
+        }
+    }
+    [ProtoContract]
+    public partial class TypeWithEnumerableProperty
+    {
+        [ProtoMember(1, OverwriteList = true)]
+        public IEnumerable<string> Values { get; set; } = Enumerable.Empty<string>();
+    }
+}


### PR DESCRIPTION
(follows on from email conversation - use-case is as per test added)