### PR TITLE
allow semicolon as option separator when parsing protobuf files

### DIFF
--- a/src/protobuf-net.Reflection.Test/Schemas/issues/issue833.proto
+++ b/src/protobuf-net.Reflection.Test/Schemas/issues/issue833.proto
@@ -1,0 +1,65 @@
+﻿syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+message Request {
+    string message = 1;
+}
+
+message Response {
+    string message = 1;
+}
+
+message OptionDefinition {
+    string title = 1;
+    string message = 2;
+    OptionDefinitionInner inner = 3;
+}
+
+message OptionDefinitionInner {
+    int32 min = 1;
+    int32 max = 2;
+}
+
+extend google.protobuf.MethodOptions {
+  OptionDefinition option1 = 9998;
+}
+
+extend google.protobuf.MethodOptions {
+  OptionDefinition option2 = 9999;
+}
+
+service TestService {
+    
+    rpc Request1(Request) returns (Response) {
+        option (option1) = {
+            title: "test request 1 title (option 1)";
+            message: "test request 1 messsage (option 1)";
+            inner: {}
+        };
+        option (option2) = {
+            title: "test request 1 title (option 2)";
+            message: "test request 1 messsage (option 2)";
+            inner: {
+                min: 1;
+                max: 10;
+            }
+        };
+    }
+
+    rpc Request2(Request) returns (Response) {
+        option (option1) = {
+            title: "test request 2 title (option 1)";
+            message: "test request 2 messsage (option 1)";
+            inner: {
+                min: 20;
+                max: 100;
+            }
+        };
+        option (option2) = {
+            title: "test request 2 title (option 2)";
+            message: "test request 2 messsage (option 2)";
+            inner: {}
+        };
+    }
+}

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -2955,7 +2955,14 @@ namespace ProtoBuf.Reflection
                     ReadOption(ref obj, parent, nameParts);
                     any = true;
 
-                    tokens.ConsumeIf(TokenType.Symbol, ","); // comma between elements is optional
+                    // comma between elements is optional
+                    var consumedComma = tokens.ConsumeIf(TokenType.Symbol, ",");
+
+                    // alternatively, semicolons are also valid element separators
+                    if (!consumedComma)
+                    {
+                        tokens.ConsumeIf(TokenType.Symbol, ";");
+                    }
                 }
                 if (!any)
                 {


### PR DESCRIPTION
While not explicitely defined in the protobuf spec (which is incomplete anyway), the protoc compiler allows semicolons as an "option separator". Some projects make heavy use of this, for example protoc-gen-openapiv2: https://github.com/grpc-ecosystem/grpc-gateway/blob/master/protoc-gen-openapiv2/options/openapiv2.proto#L25

closes https://github.com/protobuf-net/protobuf-net/issues/833
