### PR TITLE
[V4] parse Service.Method parameters

### DIFF
--- a/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/IAsyncEnumerableReturnType.cs
+++ b/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/IAsyncEnumerableReturnType.cs
@@ -34,7 +34,10 @@ namespace StreamableTestPackage
     [global::System.ServiceModel.ServiceContract(Name = @"Greeter")]
     public partial interface IIGreeter
     {
-        global::System.Collections.Generic.IAsyncEnumerable<global::StreamableTestPackage.HelloReply> SayHelloAsync(global::System.Collections.Generic.IAsyncEnumerable<global::StreamableTestPackage.HelloRequest> value, global::ProtoBuf.Grpc.CallContext context = default);
+        global::System.Collections.Generic.IAsyncEnumerable<global::StreamableTestPackage.HelloReply> SayHelloAsync(
+            global::System.Collections.Generic.IAsyncEnumerable<global::StreamableTestPackage.HelloRequest> value, 
+            global::ProtoBuf.Grpc.CallContext context = default,
+            global::System.Threading.CancellationToken cancellationToken = default);
 
     }
 

--- a/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/RawReturnTypecs.cs
+++ b/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/RawReturnTypecs.cs
@@ -5,6 +5,9 @@
 // </auto-generated>
 
 #region Designer generated code
+
+using System.Globalization;
+
 #pragma warning disable CS0612, CS0618, CS1591, CS3021, IDE0079, IDE1006, RCS1036, RCS1057, RCS1085, RCS1192
 namespace RawTypeTestPackage
 {
@@ -34,7 +37,7 @@ namespace RawTypeTestPackage
     [global::System.ServiceModel.ServiceContract(Name = @"Greeter")]
     public partial interface IIGreeter
     {
-        global::RawTypeTestPackage.HelloReply SayHelloAsync(global::RawTypeTestPackage.HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default);
+        global::RawTypeTestPackage.HelloReply SayHelloAsync(global::RawTypeTestPackage.HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default, global::System.Threading.CancellationToken cancellationToken = default);
 
     }
 

--- a/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/TaskReturnType.cs
+++ b/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/TaskReturnType.cs
@@ -34,7 +34,7 @@ namespace TaskTestPackage
     [global::System.ServiceModel.ServiceContract(Name = @"Greeter")]
     public partial interface IIGreeter
     {
-        global::System.Threading.Tasks.Task<TaskTestPackage.HelloReply> SayHelloAsync(global::TaskTestPackage.HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default);
+        global::System.Threading.Tasks.Task<TaskTestPackage.HelloReply> SayHelloAsync(global::TaskTestPackage.HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default, global::System.Threading.CancellationToken cancellationToken = default);
 
     }
 

--- a/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/ValueTaskReturnType.cs
+++ b/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/Schemas/Services/ValueTaskReturnType.cs
@@ -34,7 +34,10 @@ namespace ValueTaskTestPackage
     [global::System.ServiceModel.ServiceContract(Name = @"Greeter")]
     public partial interface IIGreeter
     {
-        global::System.Threading.Tasks.ValueTask<ValueTaskTestPackage.HelloReply> SayHelloAsync(global::ValueTaskTestPackage.HelloRequest value, global::ProtoBuf.Grpc.CallContext context = default);
+        global::System.Threading.Tasks.ValueTask<ValueTaskTestPackage.HelloReply> SayHelloAsync(
+            global::ValueTaskTestPackage.HelloRequest value, 
+            global::ProtoBuf.Grpc.CallContext context = default,
+            global::System.Threading.CancellationToken cancellationToken = default);
 
     }
 

--- a/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/ServicesAotTests.cs
+++ b/src/BuildToolsUnitTests/AOT/CSharpToCodeGen/ServicesAotTests.cs
@@ -22,7 +22,9 @@ public class ServicesAotTests : CSharpToCodeGenTestsBase
         
         var serviceMethod = codeGenSet.Files.First().Services.First().ServiceMethods.First();
         Assert.NotNull(serviceMethod);
+        Assert.Equal(CodeGenTypeRepresentation.Raw, serviceMethod.RequestType.Representation);
         Assert.Equal(CodeGenTypeRepresentation.Raw, serviceMethod.ResponseType.Representation);
+        Assert.Equal(CodeGenServiceMethodParametersDescriptor.HasCallContext | CodeGenServiceMethodParametersDescriptor.HasCancellationToken, serviceMethod.ParametersDescriptor);
     }
     
     [Fact]
@@ -33,7 +35,9 @@ public class ServicesAotTests : CSharpToCodeGenTestsBase
 
         var serviceMethod = codeGenSet.Files.First().Services.First().ServiceMethods.First();
         Assert.NotNull(serviceMethod);
+        Assert.Equal(CodeGenTypeRepresentation.AsyncEnumerable, serviceMethod.RequestType.Representation);
         Assert.Equal(CodeGenTypeRepresentation.AsyncEnumerable, serviceMethod.ResponseType.Representation);
+        Assert.Equal(CodeGenServiceMethodParametersDescriptor.HasCallContext | CodeGenServiceMethodParametersDescriptor.HasCancellationToken, serviceMethod.ParametersDescriptor);
     }
     
     [Fact]
@@ -44,7 +48,9 @@ public class ServicesAotTests : CSharpToCodeGenTestsBase
 
         var serviceMethod = codeGenSet.Files.First().Services.First().ServiceMethods.First();
         Assert.NotNull(serviceMethod);
+        Assert.Equal(CodeGenTypeRepresentation.Raw, serviceMethod.RequestType.Representation);
         Assert.Equal(CodeGenTypeRepresentation.Task, serviceMethod.ResponseType.Representation);
+        Assert.Equal(CodeGenServiceMethodParametersDescriptor.HasCallContext | CodeGenServiceMethodParametersDescriptor.HasCancellationToken, serviceMethod.ParametersDescriptor);
     }
     
     [Fact]
@@ -55,6 +61,8 @@ public class ServicesAotTests : CSharpToCodeGenTestsBase
 
         var serviceMethod = codeGenSet.Files.First().Services.First().ServiceMethods.First();
         Assert.NotNull(serviceMethod);
+        Assert.Equal(CodeGenTypeRepresentation.Raw, serviceMethod.RequestType.Representation);
         Assert.Equal(CodeGenTypeRepresentation.ValueTask, serviceMethod.ResponseType.Representation);
+        Assert.Equal(CodeGenServiceMethodParametersDescriptor.HasCallContext | CodeGenServiceMethodParametersDescriptor.HasCancellationToken, serviceMethod.ParametersDescriptor);
     }
 }

--- a/src/protobuf-net.BuildTools/Internal/CodeGen/Parsers/ServiceMethodCodeGenModelParser.cs
+++ b/src/protobuf-net.BuildTools/Internal/CodeGen/Parsers/ServiceMethodCodeGenModelParser.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Microsoft.CodeAnalysis;
+using ProtoBuf.BuildTools.Internal;
 using ProtoBuf.Internal.CodeGen.Abstractions;
 using ProtoBuf.Internal.CodeGen.Providers;
 using ProtoBuf.Reflection.Internal.CodeGen;
@@ -15,23 +16,60 @@ internal sealed class ServiceMethodCodeGenModelParser : SymbolCodeGenModelParser
     public override CodeGenServiceMethod Parse(IMethodSymbol symbol)
     {
         var responseType = ParseResponseType(symbol);
-        
+        var (requestType, parametersDescriptor) = ParseParameters(symbol);
+
         return new CodeGenServiceMethod(symbol.Name)
         {
-            ResponseType = responseType
+            RequestType = requestType,
+            ResponseType = responseType,
+            ParametersDescriptor = parametersDescriptor
         };
     }
 
+    private (CodeGenServiceMethod.Type requestType, CodeGenServiceMethodParametersDescriptor parametersDescriptor) ParseParameters(IMethodSymbol symbol)
+    {
+        var parameters = symbol.Parameters;
+        CodeGenServiceMethod.Type requestType = null;
+        var parametersDescriptor = CodeGenServiceMethodParametersDescriptor.None;
+
+        foreach (var parameter in parameters)
+        {
+            // skipping known predefined types
+            // (we know that CallContext \ CancellationToken can not be a user request message type)
+            if (IsGrpcCallContext(parameter))
+            {
+                parametersDescriptor |= CodeGenServiceMethodParametersDescriptor.HasCallContext;
+                continue;
+            }
+
+            if (IsCancellationToken(parameter))
+            {
+                parametersDescriptor |= CodeGenServiceMethodParametersDescriptor.HasCancellationToken;
+                continue;
+            }
+            
+            // after we have passed predefined types,
+            // we know it is a user message type. Let's parse it!
+            requestType = ParseServiceMethodType(parameter.Type);
+        }
+
+        return (requestType, parametersDescriptor);
+    } 
+    
     private CodeGenServiceMethod.Type ParseResponseType(IMethodSymbol symbol)
     {
-        var namedTypeSymbol = symbol.ReturnType as INamedTypeSymbol;
-        
+        return ParseServiceMethodType(symbol.ReturnType);
+    }
+
+    private CodeGenServiceMethod.Type ParseServiceMethodType(ITypeSymbol typeSymbol)
+    {
+        var namedTypeSymbol = typeSymbol as INamedTypeSymbol;
         if (namedTypeSymbol.Arity == 0)
         {
             // simply it is a raw type
             return new CodeGenServiceMethod.Type
             {
-                RawType = ParseContext.GetContractType(symbol.ReturnType.ToString()),
+                RawType = ParseContext.GetContractType(typeSymbol.ToString()),
                 Representation = CodeGenTypeRepresentation.Raw
             }; 
         }
@@ -46,11 +84,15 @@ internal sealed class ServiceMethodCodeGenModelParser : SymbolCodeGenModelParser
         };
     }
 
+    private bool IsGrpcCallContext(IParameterSymbol parameterSymbol) => parameterSymbol.Type.ToString() == "ProtoBuf.Grpc.CallContext" && parameterSymbol.Type.InProtoBufNamespace();
+    
+    private bool IsCancellationToken(IParameterSymbol parameterSymbol) => parameterSymbol.Type.ToString() == "System.Threading.CancellationToken" && parameterSymbol.Type.InThreadingNamespace();
+
     private CodeGenTypeRepresentation DetermineGenericTypeRepresentation(INamedTypeSymbol symbol) => symbol.ToString() switch
     {
-        "System.Collections.Generic.IAsyncEnumerable<T>" => CodeGenTypeRepresentation.AsyncEnumerable,
-        "System.Threading.Tasks.Task<T>" or "System.Threading.Tasks.Task<TResult>" => CodeGenTypeRepresentation.Task,
-        "System.Threading.Tasks.ValueTask<T>" or "System.Threading.Tasks.ValueTask<TResult>" => CodeGenTypeRepresentation.ValueTask,
+        "System.Collections.Generic.IAsyncEnumerable<T>" when symbol.InGenericCollectionsNamespace() => CodeGenTypeRepresentation.AsyncEnumerable,
+        "System.Threading.Tasks.Task<T>" or "System.Threading.Tasks.Task<TResult>" when symbol.InThreadingTasksNamespace() => CodeGenTypeRepresentation.Task,
+        "System.Threading.Tasks.ValueTask<T>" or "System.Threading.Tasks.ValueTask<TResult>" when symbol.InThreadingTasksNamespace() => CodeGenTypeRepresentation.ValueTask,
         _ => CodeGenTypeRepresentation.Raw
     };
 }

--- a/src/protobuf-net.BuildTools/Internal/Utils.cs
+++ b/src/protobuf-net.BuildTools/Internal/Utils.cs
@@ -41,17 +41,34 @@ namespace ProtoBuf.BuildTools.Internal
         }
 
         internal const string ProtoBufNamespace = "ProtoBuf";
+        internal const string GenericCollectionsNamespace = "System.Collections.Generic";
+        internal const string ThreadingNamespace = "System.Threading";
+        internal const string ThreadingTasksNamespace = "System.Threading.Tasks";
 
-        internal static bool InProtoBufNamespace(this INamedTypeSymbol symbol)
+        internal static bool InGenericCollectionsNamespace(this ISymbol symbol)
+            => InNamespace(symbol, GenericCollectionsNamespace);
+        
+        internal static bool InThreadingNamespace(this ISymbol symbol)
+            => InNamespace(symbol, ThreadingNamespace);
+        
+        internal static bool InThreadingTasksNamespace(this ISymbol symbol)
+            => InNamespace(symbol, ThreadingTasksNamespace);
+        
+        internal static bool InProtoBufNamespace(this ISymbol symbol)
             => InNamespace(symbol, ProtoBufNamespace);
 
-        internal static bool InNamespace(this INamedTypeSymbol symbol, string ns0)
+        internal static bool InNamespace(this ISymbol symbol, string ns0)
         {
-            var cs = symbol.ContainingNamespace;
-            return cs.Name == ns0 && cs.ContainingNamespace.IsGlobalNamespace;
+            var namespaceSymbol = symbol.ContainingNamespace;
+            do
+            {
+                if (namespaceSymbol.ToString() == ns0) return true;
+            } while ((namespaceSymbol = namespaceSymbol.ContainingNamespace) is not null);
+
+            return false;
         }
 
-        internal static bool InNamespace(this INamedTypeSymbol symbol, string ns0, string ns1)
+        internal static bool InNamespace(this ISymbol symbol, string ns0, string ns1)
         {
             var ns = symbol.ContainingNamespace;
             if (ns.Name != ns1) return false;
@@ -59,7 +76,7 @@ namespace ProtoBuf.BuildTools.Internal
             return ns.Name == ns0 && ns.ContainingNamespace.IsGlobalNamespace;
         }
 
-        internal static bool InNamespace(this INamedTypeSymbol symbol, string ns0, string ns1, string ns2)
+        internal static bool InNamespace(this ISymbol symbol, string ns0, string ns1, string ns2)
         {
             var ns = symbol.ContainingNamespace;
             if (ns.Name != ns2) return false;

--- a/src/protobuf-net.Reflection/Internal/CodeGen/CodeGenServiceMethod.cs
+++ b/src/protobuf-net.Reflection/Internal/CodeGen/CodeGenServiceMethod.cs
@@ -27,6 +27,9 @@ internal class CodeGenServiceMethod
         set => _responseType = value;
     }
 
+    public CodeGenServiceMethodParametersDescriptor ParametersDescriptor { get; set; }
+        = CodeGenServiceMethodParametersDescriptor.None;
+
     internal void FixupPlaceholders(CodeGenParseContext context)
     {
     }

--- a/src/protobuf-net.Reflection/Internal/CodeGen/CodeGenServiceMethodParameters.cs
+++ b/src/protobuf-net.Reflection/Internal/CodeGen/CodeGenServiceMethodParameters.cs
@@ -1,0 +1,24 @@
+﻿#nullable enable
+using System;
+using Google.Protobuf.Reflection;
+
+namespace ProtoBuf.Reflection.Internal.CodeGen;
+
+[Flags]
+internal enum CodeGenServiceMethodParametersDescriptor
+{
+    /// <summary>
+    /// None additional parameters are passed
+    /// </summary>
+    None = 0,
+    
+    /// <summary>
+    /// Among parameters 'Protobuf.Grpc.CallContext' exists
+    /// </summary>
+    HasCallContext = 1,
+    
+    /// <summary>
+    /// Among parameters 'System.Threading.CancellationToken' exists
+    /// </summary>
+    HasCancellationToken = 2,
+}


### PR DESCRIPTION
- supported Service.Method message parameter. Determines rawType as `CodeGenType` + representation (probably only useful for `IAsyncEnumerable<T>` when incoming request is marked as `stream`)
- determined  if parameters have `CallContext` & `CancellationToken` parameter. I dont think we need more than a enum `CodeGenServiceMethodParametersDescritpor` for that (do we?)