### PR TITLE
observe that tuple-like inherently disable some features

### DIFF
--- a/src/protobuf-net.Test/Issues/Issue964.cs
+++ b/src/protobuf-net.Test/Issues/Issue964.cs
@@ -1,0 +1,82 @@
+﻿using ProtoBuf.Meta;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    public class Issue964
+    {
+        [Fact]
+        public void CannotAddFieldsToAutoTuple()
+        {
+            var mt = RuntimeTypeModel.Create().Add(typeof(TestClass), applyDefaultBehaviour: true);
+            var ioe = Assert.Throws<InvalidOperationException>(() =>
+            {
+                mt.Add(1, nameof(TestClass.Expiry));
+            });
+            Assert.Equal("This operation is not supported for tuple-like types; to disable tuple-like type discovery, use applyDefaultBehaviour: false when first adding the type to the model.", ioe.Message);
+        }
+
+        [Fact]
+        public void CanAddFieldsToAutoTupleWithDiscoveryDisabled()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.Add(typeof(TestClass), applyDefaultBehaviour: false)
+                .Add(1, nameof(TestClass.Expiry))
+                .Add(2, nameof(TestClass.Value));
+        }
+
+        [Fact]
+        public void AssertDataEquivalent()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.Add(typeof(TestClass), applyDefaultBehaviour: false)
+                .Add(1, nameof(TestClass.Expiry))
+                .Add(2, nameof(TestClass.Value));
+
+            var expiry = new DateTime(2022, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var memoryStreamA = new MemoryStream();
+            model.Serialize(memoryStreamA, new TestClass("some data", expiry));
+            var memoryStreamB = new MemoryStream();
+            model.Serialize(memoryStreamB, new ContractClass("some data", expiry));
+
+            memoryStreamA.Seek(0, SeekOrigin.Begin);
+            memoryStreamB.Seek(0, SeekOrigin.Begin);
+
+            var a = memoryStreamA.ToArray();
+            var b = memoryStreamB.ToArray();
+
+            Assert.True(a.SequenceEqual(b));
+        }
+
+
+        class TestClass
+        {
+            public DateTime Expiry { get; }
+            public string Value { get; }
+
+            public TestClass(string value, DateTime expiry)
+            {
+                Value = value;
+                Expiry = expiry;
+            }
+        }
+
+        [ProtoContract]
+        class ContractClass
+        {
+            [ProtoMember(1)]
+            public DateTime Expiry { get; }
+            [ProtoMember(2)]
+            public string Value { get; }
+
+            public ContractClass(string value, DateTime expiry)
+            {
+                Value = value;
+                Expiry = expiry;
+            }
+        }
+    }
+}

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -217,6 +217,7 @@ namespace ProtoBuf.Meta
         /// <returns>The set of callbacks.</returns>
         public MetaType SetCallbacks(MethodInfo beforeSerialize, MethodInfo afterSerialize, MethodInfo beforeDeserialize, MethodInfo afterDeserialize)
         {
+            CheckSetCallbacks();
             CallbackSet callbacks = Callbacks;
             callbacks.BeforeSerialize = beforeSerialize;
             callbacks.AfterSerialize = afterSerialize;
@@ -224,6 +225,14 @@ namespace ProtoBuf.Meta
             callbacks.AfterDeserialize = afterDeserialize;
             return this;
         }
+
+        private void CheckSetCallbacks()
+        {
+            // note: historically value-type was also disabled, but that works from v3
+            ThrowIfFrozen();
+            ThrowIfAutoTuple();
+        }
+
         /// <summary>
         /// Assigns the callbacks to use during serialiation/deserialization.
         /// </summary>
@@ -234,7 +243,7 @@ namespace ProtoBuf.Meta
         /// <returns>The set of callbacks.</returns>
         public MetaType SetCallbacks(string beforeSerialize, string afterSerialize, string beforeDeserialize, string afterDeserialize)
         {
-            if (IsValueType) throw new InvalidOperationException();
+            CheckSetCallbacks();
             CallbackSet callbacks = Callbacks;
             callbacks.BeforeSerialize = ResolveMethod(beforeSerialize, true);
             callbacks.AfterSerialize = ResolveMethod(afterSerialize, true);
@@ -368,6 +377,7 @@ namespace ProtoBuf.Meta
         {
             RuntimeTypeModel.VerifyFactory(factory, Type);
             ThrowIfFrozen();
+            ThrowIfAutoTuple();
             this.factory = factory;
             return this;
         }
@@ -1568,13 +1578,19 @@ namespace ProtoBuf.Meta
             return AddField(fieldNumber, memberName, itemType, defaultType, null);
         }
 
+        private void ThrowIfAutoTuple()
+        {
+            if (IsAutoTuple) Throw();
+            static void Throw() => throw new InvalidOperationException("This operation is not supported for tuple-like types; to disable tuple-like type discovery, use applyDefaultBehaviour: false when first adding the type to the model.");
+        }
+
         private ValueMember AddField(int fieldNumber, string memberName, Type itemType, Type defaultType, object defaultValue)
         {
             MemberInfo mi = null;
             MemberInfo[] members = Type.GetMember(memberName, Type.IsEnum ? BindingFlags.Static | BindingFlags.Public : BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (members is not null && members.Length == 1) mi = members[0];
             if (mi is null) throw new ArgumentException("Unable to determine member: " + memberName, nameof(memberName));
-
+            ThrowIfAutoTuple();
             Type miType;
             PropertyInfo pi = null;
             switch (mi.MemberType)


### PR DESCRIPTION
i.e. fields, callbacks; alternative considered was to have *using* these features disable the tuple-like type behaviour, but that seemed to be more surprising and error-prone ("I tried to add a callback; now I have no data", "I tried to add an extra field, now I only have 1 field")


fixes #964