### PR TITLE
Add MessageType and EnumType on FieldDescriptorProto

### DIFF
--- a/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
+++ b/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
@@ -103,11 +103,11 @@ namespace ProtoBuf.Schemas
                     {
                         if (field.Name.Equals("field1"))
                         {
-                            Assert.Equal("Foo", DescriptorExtensions.GetEnumType(field).Name);
+                            Assert.Equal("Foo", field.GetEnumType().Name);
                         }
                         else if (field.Name.Equals("field2"))
                         {
-                            Assert.Equal("TestObject", DescriptorExtensions.GetMessageType(field).Name);
+                            Assert.Equal("TestObject", field.GetMessageType().Name);
                         }
                     }
                 }

--- a/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
+++ b/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
@@ -86,6 +86,34 @@ namespace ProtoBuf.Schemas
 
         private static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
+        [Fact]
+        public void FieldTypes()
+        {
+            var schemaPath = Path.Combine(Directory.GetCurrentDirectory(), SchemaPath);
+            const string path = "field_types.proto";
+
+            var set = new FileDescriptorSet();
+            set.Add(path, includeInOutput: true);
+            set.Process();
+            foreach (var file in set.Files)
+            {
+                foreach (var messageType in file.MessageTypes)
+                {
+                    foreach (var field in messageType.Fields)
+                    {
+                        if (field.Name.Equals("field1"))
+                        {
+                            Assert.Equal("Foo", DescriptorExtensions.GetEnumType(field).Name);
+                        }
+                        else if (field.Name.Equals("field2"))
+                        {
+                            Assert.Equal("TestObject", DescriptorExtensions.GetMessageType(field).Name);
+                        }
+                    }
+                }
+            }
+        }
+
         [SkippableFact]
         public void EverythingProtoLangver3()
         {

--- a/src/protobuf-net.Reflection.Test/Schemas/field_types.proto
+++ b/src/protobuf-net.Reflection.Test/Schemas/field_types.proto
@@ -1,0 +1,10 @@
+﻿syntax = "proto2";
+enum Foo {
+  A = 1;
+  B = 2;
+  C = 0;
+}
+message TestObject {
+  optional Foo field1 = 1;
+  required TestObject field2 = 2;
+}

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -1271,6 +1271,7 @@ namespace Google.Protobuf.Reflection
                                 field.type = FieldDescriptorProto.Type.TypeMessage;
                             }
                             fqn = msg?.FullyQualifiedName;
+                            field.ResolvedType = msg;
                         }
                         else if (TryResolveEnum(field.TypeName, parent, out var @enum, true))
                         {
@@ -1281,6 +1282,7 @@ namespace Google.Protobuf.Reflection
                                 ctx.Errors.Error(field.TypeToken, $"enum {@enum.Name} does not contain value '{field.DefaultValue}'", ErrorCode.EnumValueNotFound);
                             }
                             fqn = @enum?.FullyQualifiedName;
+                            field.ResolvedType = @enum;
                         }
                         else
                         {
@@ -1975,6 +1977,10 @@ namespace Google.Protobuf.Reflection
     /// </summary>
     public partial class FieldDescriptorProto : ISchemaObject, IField
     {
+        /// <summary>
+        /// The resolved type if available.
+        /// </summary>
+        internal IType ResolvedType { get; set; }
 
         /// <summary>
         /// Indicates whether this field is considered "packed" in the given schema
@@ -2632,6 +2638,15 @@ namespace Google.Protobuf.Reflection
 }
 namespace ProtoBuf.Reflection
 {
+    public static class DescriptorExtensions
+    {
+        public static EnumDescriptorProto GetEnumType(this FieldDescriptorProto field)
+            => field?.ResolvedType as EnumDescriptorProto;
+    
+        public static DescriptorProto GetMessageType(this FieldDescriptorProto field)
+            => field?.ResolvedType as DescriptorProto;
+    }
+    
     internal static class ErrorExtensions
     {
         public static void Warn(this List<Error> errors, Token token, string message, ErrorCode code)


### PR DESCRIPTION
@mgravell , I'm looking for a .proto parser that I can use for https://github.com/confluentinc/confluent-kafka-dotnet/

It appears that the one in protobuf-net.Reflection is close, but I cannot seem to find a way to get the corresponding `DescriptorProto` for a given `FieldDescriptorProto` that references the message type.

I believe this PR will help, and also fixes https://github.com/protobuf-net/protobuf-net/issues/532



