### PR TITLE
Expose fully qualified name for DescriptorProto, EnumDescriptorProto

### DIFF
--- a/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
+++ b/src/protobuf-net.Reflection.Test/Schemas/SchemaTests.cs
@@ -114,6 +114,43 @@ namespace ProtoBuf.Schemas
             }
         }
 
+        [Fact]
+        public void FullyQualifiedNames()
+        {
+            var schemaPath = Path.Combine(Directory.GetCurrentDirectory(), SchemaPath);
+            const string path = "field_types.proto";
+
+            var set = new FileDescriptorSet();
+            set.Add(path, includeInOutput: true);
+            set.Process();
+            foreach (var file in set.Files)
+            {
+                foreach (var messageType in file.MessageTypes)
+                {
+                    if (messageType.Name.Equals("TestObject"))
+                    {
+                        Assert.Equal("example.TestObject", messageType.GetFullyQualifiedName());
+                    }
+
+                    foreach (var nestedType in messageType.NestedTypes)
+                    {
+                        if (nestedType.Name.Equals("NestedObject"))
+                        {
+                            Assert.Equal("example.TestObject.NestedObject", nestedType.GetFullyQualifiedName());
+                        }
+                    }
+
+                    foreach (var nestedEnum in messageType.EnumTypes)
+                    {
+                        if (nestedEnum.Name.Equals("NestedEnum"))
+                        {
+                            Assert.Equal("example.TestObject.NestedEnum", nestedEnum.GetFullyQualifiedName());
+                        }
+                    }
+                }
+            }
+        }
+
         [SkippableFact]
         public void EverythingProtoLangver3()
         {

--- a/src/protobuf-net.Reflection.Test/Schemas/field_types.proto
+++ b/src/protobuf-net.Reflection.Test/Schemas/field_types.proto
@@ -1,4 +1,6 @@
 ﻿syntax = "proto2";
+package example;
+
 enum Foo {
   A = 1;
   B = 2;
@@ -7,4 +9,13 @@ enum Foo {
 message TestObject {
   optional Foo field1 = 1;
   required TestObject field2 = 2;
+  
+  message NestedObject {
+    optional Foo nested1 = 1;
+  }
+  
+  enum NestedEnum {
+    D = 1;
+    E = 0;
+  }
 }

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -2645,6 +2645,12 @@ namespace ProtoBuf.Reflection
     
         public static DescriptorProto GetMessageType(this FieldDescriptorProto field)
             => field?.ResolvedType as DescriptorProto;
+
+        public static string GetFullyQualifiedName(this EnumDescriptorProto @enum) 
+            => @enum.FullyQualifiedName;
+
+        public static string GetFullyQualifiedName(this DescriptorProto message) 
+            => message.FullyQualifiedName;
     }
     
     internal static class ErrorExtensions


### PR DESCRIPTION
This PR exposes the fully qualified name for DescriptorProto and EnumDescriptorProto.  

This was the other info that was also requested in https://github.com/protobuf-net/protobuf-net/issues/532.  