### PR TITLE
Simpliest support of System.Runtime.Serialization attributes in the static analyzer

### DIFF
--- a/src/BuildToolsUnitTests/AnalyzerTestBase.cs
+++ b/src/BuildToolsUnitTests/AnalyzerTestBase.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -40,6 +41,8 @@ namespace BuildToolsUnitTests
         protected Task<ICollection<Diagnostic>> AnalyzeAsync(string? sourceCode = null, [CallerMemberName] string? callerMemberName = null, bool ignoreCompatibilityLevelAdvice = true, bool ignorePreferAsyncAdvice = true) =>
             AnalyzeAsync(project => string.IsNullOrWhiteSpace(sourceCode) ? project : project.AddDocument(callerMemberName + ".cs", sourceCode).Project, callerMemberName, ignoreCompatibilityLevelAdvice, ignorePreferAsyncAdvice);
 
+        protected Task<ICollection<Diagnostic>> AnalyzeAsync(string sourceCode, Func<Project, Project> projectModifier, [CallerMemberName] string? callerMemberName = null, bool ignoreCompatibilityLevelAdvice = true, bool ignorePreferAsyncAdvice = true) =>
+            AnalyzeAsync(project => projectModifier(project.AddDocument(callerMemberName + ".cs", sourceCode).Project), callerMemberName, ignoreCompatibilityLevelAdvice, ignorePreferAsyncAdvice);
         protected async Task<ICollection<Diagnostic>> AnalyzeAsync(Func<Project, Project> projectModifier, [CallerMemberName] string? callerMemberName = null, bool ignoreCompatibilityLevelAdvice = true, bool ignorePreferAsyncAdvice = true)
         {
             _ = callerMemberName;

--- a/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
@@ -6,6 +6,7 @@ using ProtoBuf.BuildTools.Internal;
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace ProtoBuf.BuildTools.Analyzers
 {
@@ -375,6 +376,7 @@ namespace ProtoBuf.BuildTools.Analyzers
                 switch (ac.Name)
                 {
                     case nameof(ProtoContractAttribute) when ac.InProtoBufNamespace():
+                    case nameof(DataContractAttribute) when ac.InSystemRuntimeSerializationNamespace():
                         Context().SetContract(type, attrib);
                         break;
                     case nameof(ProtoIncludeAttribute) when ac.InProtoBufNamespace():
@@ -412,6 +414,9 @@ namespace ProtoBuf.BuildTools.Analyzers
                             {
                                 case nameof(ProtoMemberAttribute) when ac.InProtoBufNamespace():
                                     Context().AddMember(member, attrib, member.Name);
+                                    break;
+                                case nameof(DataMemberAttribute) when ac.InSystemRuntimeSerializationNamespace():
+                                    Context().AddMemberFromSystemRuntimeSerialization(member, attrib, member.Name);
                                     break;
                                 case nameof(ProtoIgnoreAttribute) when ac.InProtoBufNamespace():
                                     Context().AddIgnore(member, attrib, member.Name);

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace ProtoBuf.BuildTools.Internal
 {
@@ -432,6 +433,19 @@ namespace ProtoBuf.BuildTools.Internal
                     return;
             }
             (_ignores ??= new List<Ignore>()).Add(new Ignore(attrib.GetLocation(blame), memberName));
+        }
+        
+        internal void AddMemberFromSystemRuntimeSerialization(ISymbol blame, AttributeData attrib, string memberName)
+        {
+            if (!attrib.TryGetInt32ByName(nameof(DataMemberAttribute.Order), out var tag))
+                return;
+
+            if (!attrib.TryGetStringByName(nameof(DataMemberAttribute.Name), out var name))
+                name = memberName;
+
+            attrib.TryGetBooleanByName(nameof(DataMemberAttribute.IsRequired), out bool isRequired);
+
+            (_members ??= new List<Member>()).Add(new Member(attrib.GetLocation(blame), tag, memberName, name, blame, isRequired));
         }
 
         internal void AddMember(ISymbol blame, AttributeData attrib, string? memberName)

--- a/src/protobuf-net.BuildTools/Internal/Utils.cs
+++ b/src/protobuf-net.BuildTools/Internal/Utils.cs
@@ -44,6 +44,8 @@ namespace ProtoBuf.BuildTools.Internal
 
         internal static bool InProtoBufNamespace(this INamedTypeSymbol symbol)
             => InNamespace(symbol, ProtoBufNamespace);
+        internal static bool InSystemRuntimeSerializationNamespace(this INamedTypeSymbol symbol)
+            => InNamespace(symbol, "System", "Runtime", "Serialization");
 
         internal static bool InNamespace(this INamedTypeSymbol symbol, string ns0)
         {


### PR DESCRIPTION
This PR addresses the issue https://github.com/protobuf-net/protobuf-net/issues/980

Current implementation adds simpliest support of `DataContractAttribute` and `DataMemberAttribute` which fits my needs. 

Obviously, if we want to maintain some consistency between Serializer and Static Analyzer there must be more changes which should involve analysis of `Xml*` attributes and other nuances of code analysis.

