### PR TITLE
Updated KeyValuePairSerializer to allow null value

### DIFF
--- a/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
+++ b/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
@@ -46,8 +46,6 @@ namespace ProtoBuf.Internal
             }
             if (TypeHelper<TKey>.IsReferenceType && TypeHelper<TKey>.ValueChecker.IsNull(key))
                 key = TypeModel.CreateInstance<TKey>(state.Context, _keySerializer);
-            if (TypeHelper<TValue>.IsReferenceType && TypeHelper<TValue>.ValueChecker.IsNull(value))
-                value = TypeModel.CreateInstance<TValue>(state.Context, _valueSerializer);
 
             return new KeyValuePair<TKey, TValue>(key, value);
         }


### PR DESCRIPTION
Updated KeyValuePairSerializer (used by MapSerializer) to allow value to be null. It still makes sense to not allow null for key since that is a requirement of the C# Dictionary.

This change fixes an issue I saw while upgrading from V2 to V3. V3 didn't properly deserialize a Dictionary<> when the value in the KeyValuePair was null however this worked fine on version 2.4.4. I found that this only happened when deserializing as a Dictionary<> and if you deserialize as a KeyValuePair<> array it worked as expected. I tracked this down to the internal KeyValuePairSerializer.