### PR TITLE
Add assembly info to the generated assemblies (v2)

### DIFF
--- a/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
+++ b/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
@@ -40,24 +40,19 @@ namespace ProtoBuf.unittest.Meta
             // assert
             var fileInfo = FileVersionInfo.GetVersionInfo(outputPath);
 
-            var defaultValue = " ";
-            var expectedVersion        = string.IsNullOrEmpty(version)        ? defaultValue : version;
-            var expectedProductVersion = string.IsNullOrEmpty(productVersion) ? defaultValue : productVersion;
-            var expectedCompanyName    = string.IsNullOrEmpty(companyName)    ? " "          : companyName;
-            var expectedCopyright      = string.IsNullOrEmpty(copyright)      ? defaultValue : copyright;
-            var expectedTrademark      = string.IsNullOrEmpty(trademark)      ? defaultValue : trademark;
-            var expectedTitle          = string.IsNullOrEmpty(title)          ? defaultValue : title;
-            var expectedProductName    = string.IsNullOrEmpty(productName)    ? defaultValue : productName;
-            var expectedDescription    = string.IsNullOrEmpty(description)    ? defaultValue : description;
+            Assert.Equal(Normalize(version),        fileInfo.FileVersion);
+            Assert.Equal(Normalize(companyName),    fileInfo.CompanyName);
+            Assert.Equal(Normalize(copyright),      fileInfo.LegalCopyright);
+            Assert.Equal(Normalize(trademark),      fileInfo.LegalTrademarks);
+            Assert.Equal(Normalize(title),          fileInfo.FileDescription);
+            Assert.Equal(Normalize(productName),    fileInfo.ProductName);
+            Assert.Equal(Normalize(description),    fileInfo.Comments);
+            Assert.Equal(Normalize(productVersion), fileInfo.ProductVersion);
+        }
 
-            Assert.Equal(expectedVersion,        fileInfo.FileVersion);
-            Assert.Equal(expectedCompanyName,    fileInfo.CompanyName);
-            Assert.Equal(expectedCopyright,      fileInfo.LegalCopyright);
-            Assert.Equal(expectedTrademark,      fileInfo.LegalTrademarks);
-            Assert.Equal(expectedTitle,          fileInfo.FileDescription);
-            Assert.Equal(expectedProductName,    fileInfo.ProductName);
-            Assert.Equal(expectedDescription,    fileInfo.Comments);
-            Assert.Equal(expectedProductVersion, fileInfo.ProductVersion);
+        private string Normalize(string value)
+        {
+            return string.IsNullOrEmpty(value) ? " " : value;
         }
     }
 }

--- a/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
+++ b/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
@@ -1,0 +1,61 @@
+﻿using ProtoBuf.Meta;
+using System;
+using System.Diagnostics;
+using Xunit;
+
+namespace ProtoBuf.unittest.Meta
+{
+    public class AssemblyMetadataTests
+    {
+        [Theory()]
+        [InlineData(null, null, null, null, null, null, "1.2.3.4")]
+        [InlineData("", "", "", "", "", "", "1.2.3.4")]
+        [InlineData("Company Name", "", "", "Product Name", "Title", "", "1.2.3.4")]
+        [InlineData("Company Name", "Copyright", "Description", "Product Name", "Title", "Legal Trademark", "1.2.3.4")]
+        public void Test(string companyName, string copyright, string description, string productName, string title,
+            string trademark, string version)
+        {
+            // arrange
+            var outputPath = "AssemblyMetadataTestContract.dll";
+
+            var options = new RuntimeTypeModel.CompilerOptions()
+            {
+                Accessibility = RuntimeTypeModel.Accessibility.Public,
+                TypeName = "Model",
+                OutputPath = outputPath,
+                AssemblyCompanyName = companyName,
+                AssemblyCopyright = copyright,
+                AssemblyDescription = description,
+                AssemblyProductName = productName,
+                AssemblyTitle = title,
+                AssemblyTrademark = trademark,
+                AssemblyVersion = new Version(version)
+            };
+            var model = RuntimeTypeModel.Create();
+
+            // act
+            model.Compile(options);
+
+            // assert
+            var fileInfo = FileVersionInfo.GetVersionInfo(outputPath);
+
+            var defaultValue = " ";
+            var expectedVersion     = string.IsNullOrEmpty(version)     ? defaultValue : version;
+            var expectedCompanyName = string.IsNullOrEmpty(companyName) ? " "          : companyName;
+            var expectedCopyright   = string.IsNullOrEmpty(copyright)   ? defaultValue : copyright;
+            var expectedTrademark   = string.IsNullOrEmpty(trademark)   ? defaultValue : trademark;
+            var expectedTitle       = string.IsNullOrEmpty(title)       ? defaultValue : title;
+            var expectedProductName = string.IsNullOrEmpty(productName) ? defaultValue : productName;
+            var expectedDescription = string.IsNullOrEmpty(description) ? defaultValue : description;
+
+            Assert.Equal(expectedVersion,     fileInfo.FileVersion);
+            Assert.Equal(expectedCompanyName, fileInfo.CompanyName);
+            Assert.Equal(expectedCopyright,   fileInfo.LegalCopyright);
+            Assert.Equal(expectedTrademark,   fileInfo.LegalTrademarks);
+            Assert.Equal(expectedTitle,       fileInfo.FileDescription);
+            Assert.Equal(expectedProductName, fileInfo.ProductName);
+            Assert.Equal(expectedDescription, fileInfo.Comments);
+            Assert.Equal(defaultValue,        fileInfo.ProductVersion);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
+++ b/src/protobuf-net.Test/Meta/AssemblyMetadataTests.cs
@@ -8,12 +8,12 @@ namespace ProtoBuf.unittest.Meta
     public class AssemblyMetadataTests
     {
         [Theory()]
-        [InlineData(null, null, null, null, null, null, "1.2.3.4")]
-        [InlineData("", "", "", "", "", "", "1.2.3.4")]
-        [InlineData("Company Name", "", "", "Product Name", "Title", "", "1.2.3.4")]
-        [InlineData("Company Name", "Copyright", "Description", "Product Name", "Title", "Legal Trademark", "1.2.3.4")]
+        [InlineData(null, null, null, null, null, null, "1.2.3.4", "1.2")]
+        [InlineData("", "", "", "", "", "", "1.2.3.4", "1.2")]
+        [InlineData("Company Name", "", "", "Product Name", "Title", "", "1.2.3.4", "1.2")]
+        [InlineData("Company Name", "Copyright", "Description", "Product Name", "Title", "Legal Trademark", "1.2.3.4", "1.2")]
         public void Test(string companyName, string copyright, string description, string productName, string title,
-            string trademark, string version)
+            string trademark, string version, string productVersion)
         {
             // arrange
             var outputPath = "AssemblyMetadataTestContract.dll";
@@ -29,7 +29,8 @@ namespace ProtoBuf.unittest.Meta
                 AssemblyProductName = productName,
                 AssemblyTitle = title,
                 AssemblyTrademark = trademark,
-                AssemblyVersion = new Version(version)
+                AssemblyVersion = new Version(version),
+                AssemblyProductVersion = new Version(productVersion)
             };
             var model = RuntimeTypeModel.Create();
 
@@ -40,22 +41,23 @@ namespace ProtoBuf.unittest.Meta
             var fileInfo = FileVersionInfo.GetVersionInfo(outputPath);
 
             var defaultValue = " ";
-            var expectedVersion     = string.IsNullOrEmpty(version)     ? defaultValue : version;
-            var expectedCompanyName = string.IsNullOrEmpty(companyName) ? " "          : companyName;
-            var expectedCopyright   = string.IsNullOrEmpty(copyright)   ? defaultValue : copyright;
-            var expectedTrademark   = string.IsNullOrEmpty(trademark)   ? defaultValue : trademark;
-            var expectedTitle       = string.IsNullOrEmpty(title)       ? defaultValue : title;
-            var expectedProductName = string.IsNullOrEmpty(productName) ? defaultValue : productName;
-            var expectedDescription = string.IsNullOrEmpty(description) ? defaultValue : description;
+            var expectedVersion        = string.IsNullOrEmpty(version)        ? defaultValue : version;
+            var expectedProductVersion = string.IsNullOrEmpty(productVersion) ? defaultValue : productVersion;
+            var expectedCompanyName    = string.IsNullOrEmpty(companyName)    ? " "          : companyName;
+            var expectedCopyright      = string.IsNullOrEmpty(copyright)      ? defaultValue : copyright;
+            var expectedTrademark      = string.IsNullOrEmpty(trademark)      ? defaultValue : trademark;
+            var expectedTitle          = string.IsNullOrEmpty(title)          ? defaultValue : title;
+            var expectedProductName    = string.IsNullOrEmpty(productName)    ? defaultValue : productName;
+            var expectedDescription    = string.IsNullOrEmpty(description)    ? defaultValue : description;
 
-            Assert.Equal(expectedVersion,     fileInfo.FileVersion);
-            Assert.Equal(expectedCompanyName, fileInfo.CompanyName);
-            Assert.Equal(expectedCopyright,   fileInfo.LegalCopyright);
-            Assert.Equal(expectedTrademark,   fileInfo.LegalTrademarks);
-            Assert.Equal(expectedTitle,       fileInfo.FileDescription);
-            Assert.Equal(expectedProductName, fileInfo.ProductName);
-            Assert.Equal(expectedDescription, fileInfo.Comments);
-            Assert.Equal(defaultValue,        fileInfo.ProductVersion);
+            Assert.Equal(expectedVersion,        fileInfo.FileVersion);
+            Assert.Equal(expectedCompanyName,    fileInfo.CompanyName);
+            Assert.Equal(expectedCopyright,      fileInfo.LegalCopyright);
+            Assert.Equal(expectedTrademark,      fileInfo.LegalTrademarks);
+            Assert.Equal(expectedTitle,          fileInfo.FileDescription);
+            Assert.Equal(expectedProductName,    fileInfo.ProductName);
+            Assert.Equal(expectedDescription,    fileInfo.Comments);
+            Assert.Equal(expectedProductVersion, fileInfo.ProductVersion);
         }
     }
 }

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1655,6 +1655,10 @@ namespace ProtoBuf.Meta
             WriteAssemblyInfoAttribute<AssemblyProductAttribute>(options, asm, options.AssemblyProductName);
             WriteAssemblyInfoAttribute<AssemblyTitleAttribute>(options, asm, options.AssemblyTitle);
             WriteAssemblyInfoAttribute<AssemblyTrademarkAttribute>(options, asm, options.AssemblyTrademark);
+
+#if !NETCOREAPP3_1 && !NETSTANDARD2_0
+            asm.DefineVersionInfoResource();
+#endif
         }
 
         private void WriteAssemblyInfoAttribute<TA>(CompilerOptions options, AssemblyBuilder asm, string value)

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1018,6 +1018,10 @@ namespace ProtoBuf.Meta
             /// </summary>
             public int MetaDataVersion { get { return metaDataVersion; } set { metaDataVersion = value; } }
 
+            /// <summary>
+            /// The assembly version to burn into the generated assembly
+            /// </summary>
+            public Version AssemblyVersion { get; set; }
 
             private Accessibility accessibility = Accessibility.Public;
             /// <summary>
@@ -1094,13 +1098,13 @@ namespace ProtoBuf.Meta
             }
 
 #if COREFX
-            AssemblyName an = new AssemblyName();
+            AssemblyName an = new AssemblyName() { Version = options.AssemblyVersion };
             an.Name = assemblyName;
             AssemblyBuilder asm = AssemblyBuilder.DefineDynamicAssembly(an,
                 AssemblyBuilderAccess.Run);
             ModuleBuilder module = asm.DefineDynamicModule(moduleName);
 #else
-            AssemblyName an = new AssemblyName();
+            AssemblyName an = new AssemblyName() { Version = options.AssemblyVersion };
             an.Name = assemblyName;
             AssemblyBuilder asm = AppDomain.CurrentDomain.DefineDynamicAssembly(an,
                 (save ? AssemblyBuilderAccess.RunAndSave : AssemblyBuilderAccess.Run)

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1024,6 +1024,11 @@ namespace ProtoBuf.Meta
             public string AssemblyCompanyName { get; set; }
 
             /// <summary>
+            /// The copyright to burn into the generated assembly
+            /// </summary>
+            public string AssemblyCopyright { get; set; }
+
+            /// <summary>
             /// The assembly version to burn into the generated assembly
             /// </summary>
             public Version AssemblyVersion { get; set; }
@@ -1624,10 +1629,16 @@ namespace ProtoBuf.Meta
 
         private void WriteAssemblyInfoAttributes(CompilerOptions options, AssemblyBuilder asm)
         {
-            var attributeType = typeof(AssemblyCompanyAttribute);
+            WriteAssemblyInfoAttribute<AssemblyCompanyAttribute>(options, asm, options.AssemblyCompanyName);
+            WriteAssemblyInfoAttribute<AssemblyCopyrightAttribute>(options, asm, options.AssemblyCopyright);
+        }
+
+        private void WriteAssemblyInfoAttribute<TA>(CompilerOptions options, AssemblyBuilder asm, string value)
+        {
+            var attributeType = typeof(TA);
             Type[] ctorParameters = { typeof(string) };
             var ctor = attributeType.GetConstructor(ctorParameters);
-            var attribute = new CustomAttributeBuilder(ctor, new object[] { options.AssemblyCompanyName });
+            var attribute = new CustomAttributeBuilder(ctor, new object[] { value });
             asm.SetCustomAttribute(attribute);
         }
 

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1029,6 +1029,26 @@ namespace ProtoBuf.Meta
             public string AssemblyCopyright { get; set; }
 
             /// <summary>
+            /// The description to burn into the generated assembly
+            /// </summary>
+            public string AssemblyDescription { get; set; }
+
+            /// <summary>
+            /// The product name to burn into the generated assembly
+            /// </summary>
+            public string AssemblyProductName { get; set; }
+
+            /// <summary>
+            /// The application title to burn into the generated assembly
+            /// </summary>
+            public string AssemblyTitle { get; set; }
+
+            /// <summary>
+            /// The trademark notice to burn into the generated assembly
+            /// </summary>
+            public string AssemblyTrademark { get; set; }
+
+            /// <summary>
             /// The assembly version to burn into the generated assembly
             /// </summary>
             public Version AssemblyVersion { get; set; }
@@ -1631,6 +1651,10 @@ namespace ProtoBuf.Meta
         {
             WriteAssemblyInfoAttribute<AssemblyCompanyAttribute>(options, asm, options.AssemblyCompanyName);
             WriteAssemblyInfoAttribute<AssemblyCopyrightAttribute>(options, asm, options.AssemblyCopyright);
+            WriteAssemblyInfoAttribute<AssemblyDescriptionAttribute>(options, asm, options.AssemblyDescription);
+            WriteAssemblyInfoAttribute<AssemblyProductAttribute>(options, asm, options.AssemblyProductName);
+            WriteAssemblyInfoAttribute<AssemblyTitleAttribute>(options, asm, options.AssemblyTitle);
+            WriteAssemblyInfoAttribute<AssemblyTrademarkAttribute>(options, asm, options.AssemblyTrademark);
         }
 
         private void WriteAssemblyInfoAttribute<TA>(CompilerOptions options, AssemblyBuilder asm, string value)

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1053,6 +1053,11 @@ namespace ProtoBuf.Meta
             /// </summary>
             public Version AssemblyVersion { get; set; }
 
+            /// <summary>
+            /// The assembly product version to burn into the generated assembly
+            /// </summary>
+            public Version AssemblyProductVersion { get; set; }
+
             private Accessibility accessibility = Accessibility.Public;
             /// <summary>
             /// The acecssibility of the generated serializer
@@ -1655,6 +1660,7 @@ namespace ProtoBuf.Meta
             WriteAssemblyInfoAttribute<AssemblyProductAttribute>(options, asm, options.AssemblyProductName);
             WriteAssemblyInfoAttribute<AssemblyTitleAttribute>(options, asm, options.AssemblyTitle);
             WriteAssemblyInfoAttribute<AssemblyTrademarkAttribute>(options, asm, options.AssemblyTrademark);
+            WriteAssemblyInfoAttribute<AssemblyInformationalVersionAttribute>(options, asm, options.AssemblyProductVersion.ToString());
 
 #if !NETCOREAPP3_1 && !NETSTANDARD2_0
             asm.DefineVersionInfoResource();

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1663,6 +1663,9 @@ namespace ProtoBuf.Meta
 
         private void WriteAssemblyInfoAttribute<TA>(CompilerOptions options, AssemblyBuilder asm, string value)
         {
+            if (string.IsNullOrEmpty(value))
+                return;
+
             var attributeType = typeof(TA);
             Type[] ctorParameters = { typeof(string) };
             var ctor = attributeType.GetConstructor(ctorParameters);

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1654,14 +1654,14 @@ namespace ProtoBuf.Meta
 
         private void WriteAssemblyInfoAttributes(CompilerOptions options, AssemblyBuilder asm)
         {
-            WriteAssemblyInfoAttribute<AssemblyFileVersionAttribute>(options, asm, options.AssemblyVersion.ToString());
+            WriteAssemblyInfoAttribute<AssemblyFileVersionAttribute>(options, asm, options.AssemblyVersion?.ToString());
             WriteAssemblyInfoAttribute<AssemblyCompanyAttribute>(options, asm, options.AssemblyCompanyName);
             WriteAssemblyInfoAttribute<AssemblyCopyrightAttribute>(options, asm, options.AssemblyCopyright);
             WriteAssemblyInfoAttribute<AssemblyDescriptionAttribute>(options, asm, options.AssemblyDescription);
             WriteAssemblyInfoAttribute<AssemblyProductAttribute>(options, asm, options.AssemblyProductName);
             WriteAssemblyInfoAttribute<AssemblyTitleAttribute>(options, asm, options.AssemblyTitle);
             WriteAssemblyInfoAttribute<AssemblyTrademarkAttribute>(options, asm, options.AssemblyTrademark);
-            WriteAssemblyInfoAttribute<AssemblyInformationalVersionAttribute>(options, asm, options.AssemblyProductVersion.ToString());
+            WriteAssemblyInfoAttribute<AssemblyInformationalVersionAttribute>(options, asm, options.AssemblyProductVersion?.ToString());
 
 #if !NETCOREAPP3_1 && !NETSTANDARD2_0
             asm.DefineVersionInfoResource();

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1654,6 +1654,7 @@ namespace ProtoBuf.Meta
 
         private void WriteAssemblyInfoAttributes(CompilerOptions options, AssemblyBuilder asm)
         {
+            WriteAssemblyInfoAttribute<AssemblyFileVersionAttribute>(options, asm, options.AssemblyVersion.ToString());
             WriteAssemblyInfoAttribute<AssemblyCompanyAttribute>(options, asm, options.AssemblyCompanyName);
             WriteAssemblyInfoAttribute<AssemblyCopyrightAttribute>(options, asm, options.AssemblyCopyright);
             WriteAssemblyInfoAttribute<AssemblyDescriptionAttribute>(options, asm, options.AssemblyDescription);

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1019,6 +1019,11 @@ namespace ProtoBuf.Meta
             public int MetaDataVersion { get { return metaDataVersion; } set { metaDataVersion = value; } }
 
             /// <summary>
+            /// The company name to burn into the generated assembly
+            /// </summary>
+            public string AssemblyCompanyName { get; set; }
+
+            /// <summary>
             /// The assembly version to burn into the generated assembly
             /// </summary>
             public Version AssemblyVersion { get; set; }
@@ -1613,6 +1618,17 @@ namespace ProtoBuf.Meta
                     }
                 }
             }
+
+            WriteAssemblyInfoAttributes(options, asm);
+        }
+
+        private void WriteAssemblyInfoAttributes(CompilerOptions options, AssemblyBuilder asm)
+        {
+            var attributeType = typeof(AssemblyCompanyAttribute);
+            Type[] ctorParameters = { typeof(string) };
+            var ctor = attributeType.GetConstructor(ctorParameters);
+            var attribute = new CustomAttributeBuilder(ctor, new object[] { options.AssemblyCompanyName });
+            asm.SetCustomAttribute(attribute);
         }
 
         private static MethodBuilder EmitBoxedSerializer(TypeBuilder type, int i, Type valueType, SerializerPair[] methodPairs, TypeModel model, Compiler.CompilerContext.ILVersion ilVersion, string assemblyName)


### PR DESCRIPTION
Added the AssemblyVersion as discussed in [#849](https://github.com/protobuf-net/protobuf-net/pull/849), plus the additional properties found in the AssemblyInfo class, for complete integration with SBOM services.