### PR TITLE
DeserializeWithLengthPrefix() returning a generic object with Type arg

### DIFF
--- a/src/protobuf-net/Serializer.cs
+++ b/src/protobuf-net/Serializer.cs
@@ -203,6 +203,33 @@ namespace ProtoBuf
         /// Creates a new instance from a protocol-buffer stream that has a length-prefix
         /// on data (to assist with network IO).
         /// </summary>
+        /// <param name="type">The runtime type to be deserialized.</param>
+        /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
+        /// <param name="style">How to encode the length prefix.</param>
+        /// <returns>A new, initialized instance, as a generic object.</returns>
+        public static object DeserializeWithLengthPrefix([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source, PrefixStyle style)
+        {
+            return DeserializeWithLengthPrefix(type, source, style, 0);
+        }
+
+        /// <summary>
+        /// Creates a new instance from a protocol-buffer stream that has a length-prefix
+        /// on data (to assist with network IO).
+        /// </summary>
+        /// <param name="type">The runtime type to be deserialized.</param>
+        /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
+        /// <param name="style">How to encode the length prefix.</param>
+        /// <param name="fieldNumber">The expected tag of the item (only used with base-128 prefix style).</param>
+        /// <returns>A new, initialized instance, as a generic object.</returns>
+        public static object DeserializeWithLengthPrefix([DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, Stream source, PrefixStyle style, int fieldNumber)
+        {
+            return RuntimeTypeModel.Default.DeserializeWithLengthPrefix(source, null, type, style, fieldNumber);
+        }
+
+        /// <summary>
+        /// Creates a new instance from a protocol-buffer stream that has a length-prefix
+        /// on data (to assist with network IO).
+        /// </summary>
         /// <typeparam name="T">The type to be created.</typeparam>
         /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
         /// <param name="style">How to encode the length prefix.</param>


### PR DESCRIPTION
This PR adds 2 DeserializeWithLengthPrefix method overloads to ProtoBuf.Serializer, with Type as first argument.

The new methods returns an object instead of &lt;T>.

Sometimes developers do not have the generic T type argument, but instead they have a Type. Having this PR merged, will give developers the possibility to deserialize in those cases too.