### PR TITLE
Fix .proto comment handling (re quotes/apostrophes, in particular)

### DIFF
--- a/src/protobuf-net.Reflection/Token.cs
+++ b/src/protobuf-net.Reflection/Token.cs
@@ -4,27 +4,29 @@ using System;
 
 namespace ProtoBuf.Reflection
 {
-    internal struct Token
+    internal readonly struct Token : IEquatable<Token>
     {
-        public static bool operator ==(Token x, Token y)
+        public static bool operator ==(in Token x, in Token y)
         {
-            return x.Offset == y.Offset && x.File == y.File;
+            return x.TokenIndex == y.TokenIndex && x.File == y.File;
         }
-        public static bool operator !=(Token x, Token y)
+        public static bool operator !=(in Token x, in Token y)
         {
-            return x.Offset != y.Offset || x.File != y.File;
+            return x.TokenIndex != y.TokenIndex || x.File != y.File;
         }
-        public override int GetHashCode() => Offset;
-        public override bool Equals(object obj) => obj is Token token && token.Offset == this.Offset;
-        public bool Equals(Token token) => token.Offset == this.Offset;
-        public int Offset { get; }
+        public override int GetHashCode() => TokenIndex;
+        public override bool Equals(object obj) => obj is Token other && other.TokenIndex == this.TokenIndex && other.File == this.File;
+        public bool Equals(in Token other) => other.TokenIndex == this.TokenIndex && other.File == this.File;
+        bool IEquatable<Token>.Equals(Token other) => Equals(in other);
+
+        public int TokenIndex { get; }
         public int LineNumber { get; }
         public string File { get; }
         public int ColumnNumber { get; }
         public TokenType Type { get; }
         public string Value { get; }
         public string LineContents { get; }
-        internal Token(string value, int lineNumber, int columnNumber, TokenType type, string lineContents, int offset, string file)
+        internal Token(string value, int lineNumber, int columnNumber, TokenType type, string lineContents, int tokenIndex, string file)
         {
             Value = value;
             LineNumber = lineNumber;
@@ -32,7 +34,7 @@ namespace ProtoBuf.Reflection
             File = file;
             Type = type;
             LineContents = lineContents;
-            Offset = offset;
+            TokenIndex = tokenIndex;
         }
         public override string ToString() => $"({LineNumber},{ColumnNumber}) '{Value}'";
 

--- a/src/protobuf-net.Reflection/TokenExtensions.cs
+++ b/src/protobuf-net.Reflection/TokenExtensions.cs
@@ -619,12 +619,9 @@ namespace ProtoBuf.Reflection
                             if (buffer.Length != 0)
                             {
                                 yield return new Token(buffer.ToString(), lineNumber, tokenStart, TokenType.Comment, line, tokenIndex++, file);
+                                buffer.Clear();
                             }
-                            // also yield the terminator
-                            tokenStart += buffer.Length;
-                            yield return new Token("*/", lineNumber, tokenStart, TokenType.Comment, line, tokenIndex++, file);
 
-                            buffer.Clear();
                             commentType = '\0';
                             type = TokenType.None;
                             tokenStart = columnNumber;
@@ -657,10 +654,9 @@ namespace ProtoBuf.Reflection
                             buffer.Append(c);
                         }
                         else if (newType == type && buffer.Length == 1 && lastChar == '/' && c is '/' or '*')
-                        {   // for symbols, only comments are expected together, and they have special handling
-
-                            // we yield the start glyph
-                            yield return new Token(c == '/' ? "//" : "/*", lineNumber, tokenStart, TokenType.Comment, line, tokenIndex++, file);
+                        {
+                            // for symbols, only comments are expected together, and they have special handling
+                            // so: we start a comment region using the '/' or '*' to mark the kind
                             buffer.Clear();
                             tokenStart = columnNumber + 1;
                             commentType = c;

--- a/src/protobuf-net.Reflection/TokenType.cs
+++ b/src/protobuf-net.Reflection/TokenType.cs
@@ -6,6 +6,7 @@
         Whitespace,
         StringLiteral,
         AlphaNumeric,
-        Symbol
+        Symbol,
+        Comment,
     }
 }

--- a/src/protobuf-net.Test/Issues/Issue1010.cs
+++ b/src/protobuf-net.Test/Issues/Issue1010.cs
@@ -1,0 +1,21 @@
+﻿using Google.Protobuf.Reflection;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    public class Issue1010
+    {
+        [Fact]
+        public void Execute()
+        {
+            var schema = @"syntax = ""proto2""; message StackFrame { /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */ required int32 line = 1; /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */ required int32 column = 2; /** An optional end line of the range covered by the stack frame. */ optional int32 endLine = 3; }";
+            var set = new FileDescriptorSet();
+            Assert.True(set.Add("schema.proto", source: new StringReader(schema)));
+            set.Process();
+            Assert.Empty(set.GetErrors());
+            var msg = Assert.Single(Assert.Single(set.Files).MessageTypes);
+            Assert.Equal(3, msg.Fields.Count);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Issues/Issue1010.cs
+++ b/src/protobuf-net.Test/Issues/Issue1010.cs
@@ -40,37 +40,25 @@ message StackFrame {
         [Theory]
         [InlineData("", "")]
         [InlineData("a", "1,1 AlphaNumeric a")]
-        [InlineData("a//", @"1,1 AlphaNumeric a
-1,2 Comment //")]
-        [InlineData("//", "1,1 Comment //")]
-        [InlineData("//a", @"1,1 Comment //
-1,3 Comment a")]
-        [InlineData("//a//b", @"1,1 Comment //
-1,3 Comment a//b")]
+        [InlineData("a//", @"1,1 AlphaNumeric a")]
+        [InlineData("//", "")]
+        [InlineData("//a", @"1,3 Comment a")]
+        [InlineData("//a//b", @"1,3 Comment a//b")]
         [InlineData(@"//
-a", @"1,1 Comment //
-2,1 AlphaNumeric a")]
-        [InlineData(@"/**/", @"1,1 Comment /*
-1,3 Comment */")]
-        [InlineData(@"/*/a", @"1,1 Comment /*
-1,3 Comment /a")]
-        [InlineData(@"/*a*/b", @"1,1 Comment /*
-1,3 Comment a
-1,4 Comment */
+a", @"2,1 AlphaNumeric a")]
+        [InlineData(@"/**/", @"")]
+        [InlineData(@"/*/a", @"1,3 Comment /a")]
+        [InlineData(@"/*a*/b", @"1,3 Comment a
 1,6 AlphaNumeric b")]
-        [InlineData(@"/*/*a*/b", @"1,1 Comment /*
-1,3 Comment /*a
-1,6 Comment */
+        [InlineData(@"/*/*a*/b", @"1,3 Comment /*a
 1,8 AlphaNumeric b")]
         [InlineData(@"/*a
 bcd
 //e
-f*/g", @"1,1 Comment /*
-1,3 Comment a
+f*/g", @"1,3 Comment a
 2,1 Comment bcd
 3,1 Comment //e
 4,1 Comment f
-4,2 Comment */
 4,4 AlphaNumeric g")]
         public void VerifyTokens(string schema, string expected)
         {

--- a/src/protobuf-net.Test/Issues/Issue1010.cs
+++ b/src/protobuf-net.Test/Issues/Issue1010.cs
@@ -1,21 +1,90 @@
 ﻿using Google.Protobuf.Reflection;
+using ProtoBuf.Reflection;
 using System.IO;
+using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ProtoBuf.Test.Issues
 {
     public class Issue1010
     {
-        [Fact]
-        public void Execute()
+        private readonly ITestOutputHelper _log;
+
+        public Issue1010(ITestOutputHelper log)
+            => _log = log;
+
+        [Theory]
+        [InlineData(@"syntax = ""proto2""; message StackFrame { /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */ required int32 line = 1; /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */ required int32 column = 2; /** An optional end line of the range covered by the stack frame. */ optional int32 endLine = 3; }")]
+        [InlineData(@"syntax = ""proto2""; message StackFrame { /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */
+required int32 line = 1; /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */ required int32 column = 2; /** An optional end line of the range covered by the stack frame. */ optional int32 endLine = 3; }")]
+        [InlineData(@"syntax = ""proto2"";
+message StackFrame {
+    /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */
+    required int32 line = 1;
+    /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */
+    required int32 column = 2;
+    /** An optional end line of the range covered by the stack frame. */
+    optional int32 endLine = 3;
+}")]
+        public void Execute(string schema)
         {
-            var schema = @"syntax = ""proto2""; message StackFrame { /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */ required int32 line = 1; /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */ required int32 column = 2; /** An optional end line of the range covered by the stack frame. */ optional int32 endLine = 3; }";
             var set = new FileDescriptorSet();
             Assert.True(set.Add("schema.proto", source: new StringReader(schema)));
             set.Process();
             Assert.Empty(set.GetErrors());
             var msg = Assert.Single(Assert.Single(set.Files).MessageTypes);
             Assert.Equal(3, msg.Fields.Count);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("a", "1,1 AlphaNumeric a")]
+        [InlineData("a//", @"1,1 AlphaNumeric a
+1,2 Comment //")]
+        [InlineData("//", "1,1 Comment //")]
+        [InlineData("//a", @"1,1 Comment //
+1,3 Comment a")]
+        [InlineData("//a//b", @"1,1 Comment //
+1,3 Comment a//b")]
+        [InlineData(@"//
+a", @"1,1 Comment //
+2,1 AlphaNumeric a")]
+        [InlineData(@"/**/", @"1,1 Comment /*
+1,3 Comment */")]
+        [InlineData(@"/*/a", @"1,1 Comment /*
+1,3 Comment /a")]
+        [InlineData(@"/*a*/b", @"1,1 Comment /*
+1,3 Comment a
+1,4 Comment */
+1,6 AlphaNumeric b")]
+        [InlineData(@"/*/*a*/b", @"1,1 Comment /*
+1,3 Comment /*a
+1,6 Comment */
+1,8 AlphaNumeric b")]
+        [InlineData(@"/*a
+bcd
+//e
+f*/g", @"1,1 Comment /*
+1,3 Comment a
+2,1 Comment bcd
+3,1 Comment //e
+4,1 Comment f
+4,2 Comment */
+4,4 AlphaNumeric g")]
+        public void VerifyTokens(string schema, string expected)
+        {
+            // issue 1010 was a failure to correctly tokenize comments; hence we focus on those here
+            using var reader = new StringReader(schema);
+            var sb = new StringBuilder();
+            foreach (var token in reader.Tokenize("schema.proto"))
+            {
+                if (sb.Length > 0) sb.AppendLine();
+                sb.Append(token.LineNumber).Append(',').Append(token.ColumnNumber).Append(' ').Append(token.Type).Append(' ').Append(token.Value);
+            }
+            var actual = sb.ToString();
+            _log.WriteLine(actual);
+            Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
         }
     }
 }


### PR DESCRIPTION
fixes #1010 

the old code using a simple tokenizer that doesn't know about comments - just parses `/*`, `//` and `*/` as "symbol" tokens, then strips comments after the fact by pulling out any tokens after `//` on the same line, or between `/*` and `*/`. That's fine until somebody uses an apostrophe or quote in the comment, where-by the quoted string handling means that the comment terminator can end up *inside a string literal token*. This means that entire chunks of the .proto can be swallowed incorrectly into comments.

Here, we rework things so that comment parsing is handled inside the main tokenizer as a new "comment" token kind, with the comment stripping just being "remove all comment tokens" (we want to preserve them initially for now so we have the capability to add comment metadata later).