### PR TITLE
Include protobuf-net.FSharp in publishing

### DIFF
--- a/Build.csproj
+++ b/Build.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="src\protobuf-net.AspNetCore\*.csproj" />
     <ProjectReference Include="src\protobuf-net.BuildTools\*.csproj" />
     <ProjectReference Include="src\protobuf-net.BuildTools.Legacy\*.csproj" />
+    <ProjectReference Include="src\protobuf-net.FSharp\*.csproj" />
     <ProjectReference Include="src\protogen\*.csproj" />
   </ItemGroup>
   <ItemGroup Condition="$(Packing) != 'true'">


### PR DESCRIPTION
It looks like this is all that is required to produce a new NuGet package and publish the FSharp bits.