### PR TITLE
Deserializing into an uninitialized IReadOnlyDictionary causes an InvalidCastException

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -12,6 +12,10 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 - future: protogen support for emitting pre-coded custom serializers
 - future: build-time tooling from code-first (aka "generators")
 
+## pending
+
+- Deserializing into uninitialized `IReadOnlyDictionary<TKey, TValue>` (#1022)
+
 ## 3.2.0
 
 - implement `[NullWrappedValue]` (compile-time annotation for `ValueMember.SupportNull`, see 3.1.26)

--- a/src/Examples/DictionaryTests.cs
+++ b/src/Examples/DictionaryTests.cs
@@ -83,7 +83,7 @@ namespace Examples.Dictionary
             };
 
             var clone = Serializer.DeepClone(lookup);
-            
+
             AssertEqual(lookup, clone);
         }
         static void AssertEqual<TKey, TValue>(
@@ -99,7 +99,128 @@ namespace Examples.Dictionary
             }
         }
     }
-    
+
+    public class IReadOnlyDictionaryTests
+    {
+        [ProtoContract]
+        class ReadOnlyDictionaryData<T>
+        {
+            public ReadOnlyDictionaryData() {}
+
+            public ReadOnlyDictionaryData(Dictionary<int, T> data)
+            {
+                Data = data;
+            }
+
+            [ProtoMember(1)]
+            public IReadOnlyDictionary<int, T> Data { get; }
+        }
+
+        [ProtoContract]
+        class NonEmptyReadOnlyDictionaryData
+        {
+            public NonEmptyReadOnlyDictionaryData()
+            {
+                var temp = new Dictionary<int, string>();
+                temp[2] = "something";
+                Data = temp;
+            }
+
+            public NonEmptyReadOnlyDictionaryData(Dictionary<int, string> data)
+            {
+                Data = data;
+            }
+
+            [ProtoMember(1)]
+            public IReadOnlyDictionary<int, string> Data { get; }
+        }
+
+        [Fact]
+        public void TestNestedDictionaryWithStrings()
+        {
+            var obj = new Dictionary<int, string>();
+            obj[0] = "abc";
+            obj[4] = "def";
+            obj[7] = "abc";
+            var input = new ReadOnlyDictionaryData<string>(obj);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedDictionaryWithSimpleData()
+        {
+            var obj = new Dictionary<int, SimpleData>();
+            obj[0] = new SimpleData(5);
+            obj[4] = new SimpleData(72);
+            obj[7] = new SimpleData(72);
+            var input = new ReadOnlyDictionaryData<SimpleData>(obj);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void RoundtripDictionary()
+        {
+            IReadOnlyDictionary<int, string> lookup = new Dictionary<int, string>
+            {
+                [0] = "abc",
+                [4] = "def",
+                [7] = "abc"
+            };
+
+            var clone = Serializer.DeepClone(lookup);
+
+            AssertEqual(lookup, clone);
+        }
+
+        [Fact]
+        public void TestNonEmptyDictionaryStrings()
+        {
+            var obj = new Dictionary<int, string>();
+            obj[0] = "abc";
+            obj[1] = "def";
+            var input = new NonEmptyReadOnlyDictionaryData(obj);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            Assert.Equal(input.Data[0], clone.Data[0]);
+            Assert.Equal(input.Data[1], clone.Data[1]);
+            Assert.Equal("something", clone.Data[2]);
+        }
+
+        [Fact]
+        public void TestNonEmptyDictionaryOverwriteStrings()
+        {
+            var obj = new Dictionary<int, string>();
+            obj[0] = "abc";
+            obj[2] = "def";
+            var input = new NonEmptyReadOnlyDictionaryData(obj);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            Assert.Equal(input.Data[0], clone.Data[0]);
+            Assert.Equal("def", clone.Data[2]);
+        }
+
+        static void AssertEqual<TKey, TValue>(
+            IReadOnlyDictionary<TKey, TValue> expected,
+            IReadOnlyDictionary<TKey, TValue> actual)
+        {
+            Assert.NotSame(expected, actual);
+            Assert.Equal(expected.Count, actual.Count);
+            foreach (var pair in expected)
+            {
+                Assert.True(actual.TryGetValue(pair.Key, out TValue value));
+                Assert.Equal(pair.Value, value);
+            }
+        }
+    }
+
     public class EmptyDictionaryTests
     {
         [Fact]

--- a/src/Examples/DictionaryTests.cs
+++ b/src/Examples/DictionaryTests.cs
@@ -100,7 +100,7 @@ namespace Examples.Dictionary
         }
     }
 
-    public class IReadOnlyDictionaryTests
+    public class DictionaryOfIReadOnlyDictionarySerializerTests
     {
         [ProtoContract]
         class ReadOnlyDictionaryData<T>
@@ -140,7 +140,7 @@ namespace Examples.Dictionary
         {
             var obj = new Dictionary<int, string>();
             obj[0] = "abc";
-            obj[4] = "def";
+            obj[1] = "def";
             obj[7] = "abc";
             var input = new ReadOnlyDictionaryData<string>(obj);
 

--- a/src/protobuf-net.Test/Serializers/Collections.cs
+++ b/src/protobuf-net.Test/Serializers/Collections.cs
@@ -25,7 +25,7 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(IList<int>), typeof(EnumerableSerializer<IList<int>, IList<int>, int>))]
         [InlineData(typeof(Dictionary<int, string>), typeof(DictionarySerializer<int, string>))]
         [InlineData(typeof(IDictionary<int, string>), typeof(DictionarySerializer<IDictionary<int,string>,int, string>))]
-        [InlineData(typeof(IReadOnlyDictionary<int, string>), typeof(IReadOnlyDictionarySerializer<int, string>))]
+        [InlineData(typeof(IReadOnlyDictionary<int, string>), typeof(DictionaryOfIReadOnlyDictionarySerializer<int, string>))]
         [InlineData(typeof(ImmutableArray<int>), typeof(ImmutableArraySerializer<int>))]
         [InlineData(typeof(ImmutableDictionary<int, string>), typeof(ImmutableDictionarySerializer<int, string>))]
         [InlineData(typeof(ImmutableSortedDictionary<int, string>), typeof(ImmutableSortedDictionarySerializer<int, string>))]

--- a/src/protobuf-net.Test/Serializers/Collections.cs
+++ b/src/protobuf-net.Test/Serializers/Collections.cs
@@ -25,6 +25,7 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(IList<int>), typeof(EnumerableSerializer<IList<int>, IList<int>, int>))]
         [InlineData(typeof(Dictionary<int, string>), typeof(DictionarySerializer<int, string>))]
         [InlineData(typeof(IDictionary<int, string>), typeof(DictionarySerializer<IDictionary<int,string>,int, string>))]
+        [InlineData(typeof(IReadOnlyDictionary<int, string>), typeof(IReadOnlyDictionarySerializer<int, string>))]
         [InlineData(typeof(ImmutableArray<int>), typeof(ImmutableArraySerializer<int>))]
         [InlineData(typeof(ImmutableDictionary<int, string>), typeof(ImmutableDictionarySerializer<int, string>))]
         [InlineData(typeof(ImmutableSortedDictionary<int, string>), typeof(ImmutableSortedDictionarySerializer<int, string>))]

--- a/src/protobuf-net/Serializers/RepeatedSerializers.cs
+++ b/src/protobuf-net/Serializers/RepeatedSerializers.cs
@@ -93,6 +93,7 @@ namespace ProtoBuf.Serializers
             // pretty normal stuff
             Add(typeof(Dictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), root == current ? targs : new[] { root, targs[0], targs[1] }), false);
             Add(typeof(IDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), new[] { root, targs[0], targs[1] }), false);
+            Add(typeof(IReadOnlyDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateIReadOnlyDictionary), new[] { root, targs[0], targs[1] }), false);
             Add(typeof(Queue<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateQueue), new[] { root, targs[0] }), false);
             Add(typeof(Stack<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateStack), new[] { root, targs[0] }), false);
 

--- a/src/protobuf-net/Serializers/RepeatedSerializers.cs
+++ b/src/protobuf-net/Serializers/RepeatedSerializers.cs
@@ -93,7 +93,7 @@ namespace ProtoBuf.Serializers
             // pretty normal stuff
             Add(typeof(Dictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), root == current ? targs : new[] { root, targs[0], targs[1] }), false);
             Add(typeof(IDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateDictionary), new[] { root, targs[0], targs[1] }), false);
-            Add(typeof(IReadOnlyDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateIReadOnlyDictionary), new[] { root, targs[0], targs[1] }), false);
+            Add(typeof(IReadOnlyDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateIReadOnlyDictionary), targs));
             Add(typeof(Queue<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateQueue), new[] { root, targs[0] }), false);
             Add(typeof(Stack<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateStack), new[] { root, targs[0] }), false);
 


### PR DESCRIPTION
- Adding a new RepeatedSearializer for IReadOnlyDictionary<T> which uses a Dictionary as a backing type. This incurs a copy of items when the underyling data structure is not a Dictionary.
- It does not consider ImmutableDictionary or other types as underlying type.
- Extending collections tests and DictionaryTests

Questions:
If you have a suggestion, I would be happy to add further tests, but I have not found a more appropriate place to do so.
Should we consider ImmutableDictionary as the underlying type?


Implements #720 