### PR TITLE
fix build SDKs of BuildTools

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -14,7 +14,7 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## unreleased
 
-- fix BuildTools.Legacy - should have been targeting build SDK 3.3.1
+- fix SDKs used by BuildTools[.Legacy]
 
 ## 3.2.8
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -12,7 +12,11 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 - future: protogen support for emitting pre-coded custom serializers
 - future: build-time tooling from code-first (aka "generators")
 
-## pending
+## unreleased
+
+- fix BuildTools.Legacy - should have been targeting build SDK 3.3.1
+
+## 3.2.8
 
 - add support for deserializing into uninitialized `IReadOnlyDictionary<TKey, TValue>` (#1022 by ladeak)
 - fix missing namespace in `[CompatibilityLevel]` in code-gen (#1026)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,9 +18,9 @@
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.1" />
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
         <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
 
         <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="All" />
@@ -30,7 +30,7 @@
         <PackageVersion Include="NodaTime.Serialization.Protobuf" Version="2.0.0" />
 
         <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.2" />
-        <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.0" />
+        <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.8" />
         <PackageVersion Include="protobuf-net.Grpc" Version="1.0.21" />
         <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.1.1" />
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
         <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.1" />
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
         <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>

--- a/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
+++ b/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Pack="false" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Pack="false" PrivateAssets="all" VersionOverride="3.3.1" />
     <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 


### PR DESCRIPTION
- revert BuildTools.Legacy to 3.3.1 (which it was claiming to use)
- revert BuildTools to 4.3.1 for SDK adoption reasons
- also rev tool libvers

fix #1028