### PR TITLE
Implement [NullWrappedCollection]

### DIFF
--- a/docs/nullwrappers.md
+++ b/docs/nullwrappers.md
@@ -1,6 +1,6 @@
 # Support for `null` values and empty collections
 
-For many commaon scenarios, protobuf-net *just works* with null values; for example:
+For many common scenarios, protobuf-net *just works* with null values; for example:
 
 ``` c#
 [ProtoMember(5)]
@@ -22,7 +22,7 @@ needs to consider multiple things:
 - the later addition of "field presence" to `proto3`
 - the existence of `wrappers.proto`
 
-I'm not going to attempt to cover all of these things in detail! However, we can give a flavor. If we just consider `proto3`, and a
+I'm not going to attempt to cover all of these things in detail! However, we can give a flavour. If we just consider `proto3`, and a
 simple integer:
 
 ``` proto
@@ -163,7 +163,7 @@ class SomeMessage
 
 In the above, we can see that `[NullWrappedValue]` applies to the *values* in a collection; sometimes - much more rarely - we
 wish to apply the same logic to the *collection itself*, to distinguish *null* collections from *empty* collections. Protobuf has
-no way of expressing an empty collection, but we can artifically invent an additional message layer that *has* a collection
+no way of expressing an empty collection, but we can artificially invent an additional message layer that *has* a collection
 
 - for null collections, nothing is written
 - for empty collections, an empty message wrapper is written
@@ -181,7 +181,7 @@ class SomeMessage
 ```
 
 As before, a runtime fault is thrown if `[NullWrappedCollection]` is encountered on an unexpected type; `[NullWrappedCollection]` *also*
-supports the same `AsGroup` concept (although it is not expected to be used in many scenarios). Convenienty, `[NullWrappedCollection]`
+supports the same `AsGroup` concept (although it is not expected to be used in many scenarios). Conveniently, `[NullWrappedCollection]`
 can be combined with `[NullWrappedValue]` without difficulty, as they apply at different scopes.
 
 With these features, most common null scenarios can be conveniently and robustly handled.

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -14,6 +14,7 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## unreleased
 
+- implement `[NullWrappedCollection]`, usage [as here](https://protobuf-net.github.io/protobuf-net/nullwrappers#null-collections) (#1044)
 - support `nint` (`IntPtr`) and `nuint` (`UIntPtr`) with layout per `long`/`ulong` (#1043; fixes #1042, fixes grpc 282)
 
 ## 3.2.12

--- a/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
+++ b/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
@@ -46,38 +46,35 @@ namespace ProtoBuf.Internal
                 }
             }
             if (TypeHelper<TKey>.IsReferenceType && TypeHelper<TKey>.ValueChecker.IsNull(key))
-                key = CreateDefault<TKey>(state.Context, _keySerializer);
+                key = CreateDefault<TKey>(state.Context, _keySerializer, _keyFeatures);
             if (TypeHelper<TValue>.IsReferenceType && TypeHelper<TValue>.ValueChecker.IsNull(value))
-                value = CreateDefault<TValue>(state.Context, _valueSerializer);
+                value = CreateDefault<TValue>(state.Context, _valueSerializer, _valueFeatures);
 
             return new KeyValuePair<TKey, TValue>(key, value);
         }
-        static T CreateDefault<T>(ISerializationContext context, ISerializer<T> serializer)
+        static T CreateDefault<T>(ISerializationContext context, ISerializer<T> serializer, SerializerFeatures features)
         {
+            if (features.HasAny(SerializerFeatures.OptionWrappedValue))
+            {   // no field? treat as null
+                return default;
+            }
             if (serializer is not null && serializer.Features.GetCategory() == SerializerFeatures.CategoryMessage)
             {
-                // get the serializer to do the work, by reading an empty state
+                // get the serializer to do the work, by reading an empty payload
                 // (zero bytes is a default object in protobuf)
-                return TryReadEmptyMessage(context, serializer);
-            }
-            return TypeModel.CreateInstance<T>(context, serializer);
-
-            static T TryReadEmptyMessage(ISerializationContext context, ISerializer<T> serializer)
-            {
+                // this is useful in case the type is using a non-trivial constructor
+                // or factory API
                 var state = ProtoReader.State.Create(default(ReadOnlyMemory<byte>), context?.Model, context?.UserState);
                 try
                 {
                     return serializer.Read(ref state, default);
-                }
-                catch
-                {
-                    return TypeModel.CreateInstance<T>(context, serializer);
                 }
                 finally
                 {
                     state.Dispose();
                 }
             }
+            return TypeModel.CreateInstance<T>(context, serializer);
         }
 
         public void Write(ref ProtoWriter.State state, KeyValuePair<TKey, TValue> value)

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -1408,13 +1408,6 @@ namespace ProtoBuf.Meta
                 T obj = default;
                 if (serializer is IFactory<T> factory) obj = factory.Create(context);
 
-                if (obj is null && serializer is not null && serializer.Features.GetCategory() == SerializerFeatures.CategoryMessage)
-                {
-                    // get the serializer to do the work, by reading an empty state
-                    // (zero bytes is a default object in protobuf)
-                    obj = TryReadEmptyMessage(context, serializer);
-                }
-
                 // note we already know this is a ref-type
                 if (obj is null) obj = ActivatorCreate<T>();
                 return obj;
@@ -1422,23 +1415,6 @@ namespace ProtoBuf.Meta
             else
             {
                 return default;
-            }
-
-            static T TryReadEmptyMessage(ISerializationContext context, ISerializer<T> serializer)
-            {
-                var state = ProtoReader.State.Create(default(ReadOnlyMemory<byte>), context?.Model, context?.UserState);
-                try
-                {
-                    return serializer.Read(ref state, default);
-                }
-                catch
-                {
-                    return default;
-                }
-                finally
-                {
-                    state.Dispose();
-                }
             }
         }
 

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -1407,6 +1407,14 @@ namespace ProtoBuf.Meta
                 serializer ??= TypeModel.TryGetSerializer<T>(context?.Model);
                 T obj = default;
                 if (serializer is IFactory<T> factory) obj = factory.Create(context);
+
+                if (obj is null && serializer is not null && serializer.Features.GetCategory() == SerializerFeatures.CategoryMessage)
+                {
+                    // get the serializer to do the work, by reading an empty state
+                    // (zero bytes is a default object in protobuf)
+                    obj = TryReadEmptyMessage(context, serializer);
+                }
+
                 // note we already know this is a ref-type
                 if (obj is null) obj = ActivatorCreate<T>();
                 return obj;
@@ -1414,6 +1422,23 @@ namespace ProtoBuf.Meta
             else
             {
                 return default;
+            }
+
+            static T TryReadEmptyMessage(ISerializationContext context, ISerializer<T> serializer)
+            {
+                var state = ProtoReader.State.Create(default(ReadOnlyMemory<byte>), context?.Model, context?.UserState);
+                try
+                {
+                    return serializer.Read(ref state, default);
+                }
+                catch
+                {
+                    return default;
+                }
+                finally
+                {
+                    state.Dispose();
+                }
             }
         }
 

--- a/src/protobuf-net.Core/NullWrappedValueAttribute.cs
+++ b/src/protobuf-net.Core/NullWrappedValueAttribute.cs
@@ -11,7 +11,7 @@ namespace ProtoBuf
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
     public sealed class NullWrappedValueAttribute : Attribute
     {
-        /// <summary>Indicates that the collection message wrapper shold use group encoding; this is more
+        /// <summary>Indicates that the collection message wrapper should use group encoding; this is more
         /// efficient to write, but may be hard to consume in cross-platform scenarios; this feature is
         /// usually used for compatibility with protobuf-net v2 <c>SupportNull</c> usage</summary>
         public bool AsGroup { get; set; }
@@ -21,9 +21,9 @@ namespace ProtoBuf
     /// see https://protobuf-net.github.io/protobuf-net/nullwrappers for more information.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    internal sealed class NullWrappedCollectionAttribute : Attribute
+    public sealed class NullWrappedCollectionAttribute : Attribute
     {
-        /// <summary>Indicates that the collection message wrapper shold use group encoding; this is more efficient to write, but may be hard to consume in cross-platform scenarios.</summary>
+        /// <summary>Indicates that the collection message wrapper should use group encoding; this is more efficient to write, but may be hard to consume in cross-platform scenarios.</summary>
         public bool AsGroup { get; set; }
     }
 }

--- a/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.BufferWriter.cs
@@ -4,6 +4,7 @@ using ProtoBuf.Serializers;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 
@@ -14,7 +15,7 @@ namespace ProtoBuf
         partial struct State
         {
             /// <summary>
-            /// Create a new ProtoWriter that tagets a buffer writer
+            /// Create a new ProtoWriter that targets a buffer writer
             /// </summary>
             public static State Create(IBufferWriter<byte> writer, TypeModel model, object userState = null)
                 => BufferWriterProtoWriter.CreateBufferWriterProtoWriter(writer, model, userState);
@@ -210,6 +211,78 @@ namespace ProtoBuf
                     case WireType.StartGroup:
                     default:
                         base.WriteMessage<T>(ref state, value, serializer, style, recursionCheck);
+                        return;
+                }
+            }
+
+            internal override void WriteWrappedItem<T>(ref State state, SerializerFeatures features, T value, ISerializer<T> serializer)
+            {
+                switch (WireType)
+                {
+                    case WireType.String:
+                        serializer ??= TypeModel.GetSerializer<T>(Model);
+                        long calculatedLength = MeasureAny<T>(_nullWriter, TypeModel.ListItemTag, features, value, serializer);
+
+                        // write length-prefix as varint
+                        AdvanceAndReset(ImplWriteVarint64(ref state, (ulong)calculatedLength));
+
+                        if (calculatedLength != 0)
+                        {
+                            var oldPos = GetPosition(ref state);
+                            state.WriteAny(TypeModel.ListItemTag, features, value, serializer);
+                            var newPos = GetPosition(ref state);
+
+                            var actualLength = (newPos - oldPos);
+                            if (actualLength != calculatedLength)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException($"Length mismatch; calculated '{calculatedLength}', actual '{actualLength}'");
+                            }
+                        }
+
+                        return;
+                    case WireType.StartGroup:
+                        // forwards-only; can use default implementation
+                        base.WriteWrappedItem<T>(ref state, features, value, serializer);
+                        return;
+                    default:
+                        // if we aren't using length-prefix or group... what are we even?
+                        ThrowHelper.ThrowArgumentOutOfRangeException(nameof(WireType));
+                        return;
+                }
+            }
+
+            internal override void WriteWrappedCollection<TCollection, TItem>(ref State state, SerializerFeatures features, TCollection values, IRepeatedSerializer<TCollection, TItem> serializer, ISerializer<TItem> valueSerializer)
+            {
+                switch (WireType)
+                {
+                    case WireType.String:
+                        valueSerializer ??= TypeModel.GetSerializer<TItem>(Model);
+                        long calculatedLength = MeasureRepeated<TCollection, TItem>(_nullWriter, TypeModel.ListItemTag, features, values, serializer, valueSerializer);
+
+                        // write length-prefix as varint
+                        AdvanceAndReset(ImplWriteVarint64(ref state, (ulong)calculatedLength));
+
+                        if (calculatedLength != 0)
+                        {
+                            var oldPos = GetPosition(ref state);
+                            serializer.WriteRepeated(ref state, TypeModel.ListItemTag, features, values, valueSerializer);
+                            var newPos = GetPosition(ref state);
+
+                            var actualLength = (newPos - oldPos);
+                            if (actualLength != calculatedLength)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException($"Length mismatch; calculated '{calculatedLength}', actual '{actualLength}'");
+                            }
+                        }
+
+                        return;
+                    case WireType.StartGroup:
+                        // forwards-only; can use default implementation
+                        base.WriteWrappedCollection<TCollection, TItem>(ref state, features, values, serializer, valueSerializer);
+                        return;
+                    default:
+                        // if we aren't using length-prefix or group... what are we even?
+                        ThrowHelper.ThrowArgumentOutOfRangeException(nameof(WireType));
                         return;
                 }
             }

--- a/src/protobuf-net.Core/ProtoWriter.Null.cs
+++ b/src/protobuf-net.Core/ProtoWriter.Null.cs
@@ -87,9 +87,15 @@ namespace ProtoBuf
                 var len = MeasureAny<T>(this, TypeModel.ListItemTag, features, value, serializer ?? TypeModel.GetSerializer<T>(Model));
                 AdvanceSubMessage(ref state, len, PrefixStyle.Base128); // only supported styles are group+varint
             }
-            internal override void WriteWrappedCollection<TCollection, TItem>(ref State state, SerializerFeatures features, TCollection values, IRepeatedSerializer<TCollection, TItem> serializer, ISerializer<TItem> valueSerializer)
+            internal override void WriteWrappedCollection<TCollection, TItem>(ref State state, SerializerFeatures features, TCollection values, RepeatedSerializer<TCollection, TItem> serializer, ISerializer<TItem> valueSerializer)
             {
                 var len = MeasureRepeated<TCollection, TItem>(this, TypeModel.ListItemTag, features, values, serializer, valueSerializer ?? TypeModel.GetSerializer<TItem>(Model));
+                AdvanceSubMessage(ref state, len, PrefixStyle.Base128); // only supported styles are group+varint
+            }
+
+            internal override void WriteWrappedMap<TCollection, TKey, TValue>(ref State state, SerializerFeatures features, TCollection values, MapSerializer<TCollection, TKey, TValue> serializer, SerializerFeatures keyFeatures, SerializerFeatures valueFeatures, ISerializer<TKey> keySerializer, ISerializer<TValue> valueSerializer)
+            {
+                var len = MeasureMap<TCollection, TKey, TValue>(this, TypeModel.ListItemTag, features, values, serializer, keyFeatures, valueFeatures, keySerializer, valueSerializer);
                 AdvanceSubMessage(ref state, len, PrefixStyle.Base128); // only supported styles are group+varint
             }
 

--- a/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
+++ b/src/protobuf-net.Core/ProtoWriter.State.WriteMethods.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using ProtoBuf.Serializers;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -340,6 +341,7 @@ namespace ProtoBuf
             [MethodImpl(ProtoReader.HotPath)]
             public void WriteMessage<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>(int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer = null)
             {
+                Debug.Assert(!features.HasAny(SerializerFeatures.OptionWrappedValue), "wrapped value handling has not been processed correctly");
                 if (!(TypeHelper<T>.CanBeNull && TypeHelper<T>.ValueChecker.IsNull(value)))
                 {
                     WriteFieldHeader(fieldNumber, features.IsGroup() ? WireType.StartGroup : WireType.String);
@@ -408,18 +410,19 @@ namespace ProtoBuf
                     return;
                 }
                 WriteFieldHeader(fieldNumber, wrapperFormat);
-#pragma warning disable CS0618 // we don't want to use WriteMessage here; this is a pseudo message layer
-                var tok = StartSubItem(TypeHelper<T>.IsReferenceType & features.ApplyRecursionCheck() ? (object)value : null, PrefixStyle.Base128);
-#pragma warning restore CS0618
+
                 if (!isNull && (fieldPresence || TypeHelper<T>.ValueChecker.HasNonTrivialValue(value)))
                 {   // only write the field if it has a meaningful value (note: we already remove the relevant wrap options,
                     // so: not recursive); if we're using field-presence, we write any non-null value; otherwise,
                     // (think 'wrappers.proto') we only write non-zero values
-                    WriteAny<T>(1, features, value, serializer);
+
+                    Debug.Assert(!features.HasAny(SerializerFeatures.OptionWrappedValue), "should not be wrapped");
+                    GetWriter().WriteWrappedItem<T>(ref this, features, value, serializer);
                 }
-#pragma warning disable CS0618 // we don't want to use WriteMessage here; this is a pseudo message layer
-                EndSubItem(tok);
-#pragma warning restore CS0618
+                else
+                {
+                    GetWriter().WriteEmptyWrappedItem(ref this);
+                }
             }
 
             /// <summary>
@@ -430,7 +433,7 @@ namespace ProtoBuf
                 serializer ??= TypeModel.GetSerializer<T>(Model);
                 features.InheritFrom(serializer.Features);
 
-                if (features.HasAny(SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionWrappedCollection))
+                if (features.HasAny(SerializerFeatures.OptionWrappedValue))
                 {
                     WriteWrapped<T>(fieldNumber, features, value, serializer);
                     return;

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -283,7 +283,6 @@ namespace ProtoBuf
             // var tok = state.StartSubItem(null, PrefixStyle.Base128);
             // state.EndSubItem(tok);
 
-#pragma warning disable CS0618 // StartSubItem/EndSubItem
             switch (WireType)
             {
                 case WireType.String:
@@ -291,12 +290,12 @@ namespace ProtoBuf
                     break;
                 case WireType.StartGroup:
                     state.WriteHeaderCore(state.FieldNumber, WireType.EndGroup);
+                    WireType = WireType.None; // reset
                     break;
                 default:
                     ThrowHelper.ThrowArgumentOutOfRangeException(nameof(WireType));
                     break;
             }
-#pragma warning restore CS0618
         }
 
         internal virtual void WriteWrappedItem<T>(ref State state, SerializerFeatures features, T value, ISerializer<T> serializer)

--- a/src/protobuf-net.Core/ProtoWriter.cs
+++ b/src/protobuf-net.Core/ProtoWriter.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -123,7 +124,7 @@ namespace ProtoBuf
         /// <summary>
         /// Indicates the end of a nested record.
         /// </summary>
-        /// <param name="token">The token obtained from StartubItem.</param>
+        /// <param name="token">The token obtained from StartSubItem.</param>
         /// <param name="writer">The destination.</param>
         [MethodImpl(HotPath)]
         [Obsolete(PreferWriteMessage, false)]
@@ -240,7 +241,7 @@ namespace ProtoBuf
         {
             if (_depth == 0 && _needFlush && ImplDemandFlushOnDispose)
             {
-                ThrowHelper.ThrowInvalidOperationException("Writer was diposed without being flushed; data may be lost - you should ensure that Flush (or Abandon) is called");
+                ThrowHelper.ThrowInvalidOperationException("Writer was disposed without being flushed; data may be lost - you should ensure that Flush (or Abandon) is called");
             }
             recursionStack?.Clear();
             ClearKnownObjects();
@@ -261,6 +262,49 @@ namespace ProtoBuf
             var tok = state.StartSubItem(TypeHelper<T>.IsReferenceType & recursionCheck ? (object)value : null, style);
             (serializer ?? TypeModel.GetSerializer<T>(model)).Write(ref state, value);
             state.EndSubItem(tok, style);
+#pragma warning restore CS0618
+        }
+
+        internal virtual void WriteWrappedCollection<TCollection, TItem>(ref State state, SerializerFeatures features, TCollection values, IRepeatedSerializer<TCollection, TItem> serializer, ISerializer<TItem> valueSerializer)
+        {
+#pragma warning disable CS0618 // StartSubItem/EndSubItem
+            var tok = state.StartSubItem(null);
+            serializer.WriteRepeated(ref state, TypeModel.ListItemTag, features, values, valueSerializer);
+            state.EndSubItem(tok);
+#pragma warning restore CS0618
+        }
+
+        internal void WriteEmptyWrappedItem(ref State state)
+        {
+            // semantically, this is the same as the two lines below; just:
+            // without the indirection and without needing to have
+            // writer-specific implementations (since we can go forwards-only)
+            //
+            // var tok = state.StartSubItem(null, PrefixStyle.Base128);
+            // state.EndSubItem(tok);
+
+#pragma warning disable CS0618 // StartSubItem/EndSubItem
+            switch (WireType)
+            {
+                case WireType.String:
+                    AdvanceAndReset(ImplWriteVarint32(ref state, 0));
+                    break;
+                case WireType.StartGroup:
+                    state.WriteHeaderCore(state.FieldNumber, WireType.EndGroup);
+                    break;
+                default:
+                    ThrowHelper.ThrowArgumentOutOfRangeException(nameof(WireType));
+                    break;
+            }
+#pragma warning restore CS0618
+        }
+
+        internal virtual void WriteWrappedItem<T>(ref State state, SerializerFeatures features, T value, ISerializer<T> serializer)
+        {
+#pragma warning disable CS0618 // we don't want to use WriteMessage here; this is a pseudo message layer
+            var tok = state.StartSubItem(TypeHelper<T>.IsReferenceType & features.ApplyRecursionCheck() ? (object)value : null, PrefixStyle.Base128);
+            state.WriteAny<T>(TypeModel.ListItemTag, features, value, serializer);
+            state.EndSubItem(tok);
 #pragma warning restore CS0618
         }
 
@@ -363,7 +407,7 @@ namespace ProtoBuf
         /// <summary>
         /// Writes any buffered data (if possible) to the underlying stream.
         /// </summary>
-        /// <param name="state">Wwriter state</param>
+        /// <param name="state">writer state</param>
         /// <remarks>It is not always possible to fully flush, since some sequences
         /// may require values to be back-filled into the byte-stream.</remarks>
         private protected abstract bool TryFlush(ref State state);
@@ -532,6 +576,47 @@ namespace ProtoBuf
         public static void WriteType(Type value, ProtoWriter writer)
             => writer.DefaultState().WriteType(value);
 
+        internal static long MeasureRepeated<TCollection, TItem>(NullProtoWriter writer, int fieldNumber, SerializerFeatures features, TCollection values, IRepeatedSerializer<TCollection, TItem> serializer, ISerializer<TItem> valueSerializer)
+        {
+            long length;
+            object obj = default;
+            if (TypeHelper<TCollection>.IsReferenceType)
+            {
+                obj = values;
+                if (obj is null) return 0;
+                if (writer.netCache.TryGetKnownLength(obj, null, out length))
+                    return length;
+            }
+
+            // do the actual work
+            var oldState = writer.ResetWriteState();
+            var nulState = new State(writer);
+            serializer.WriteRepeated(ref nulState, fieldNumber, features, values, valueSerializer);
+            length = nulState.GetPosition();
+            writer.SetWriteState(oldState); // make sure we leave it how we found it
+
+            // cache it if we can
+            if (obj is not null)
+            {   // we know it isn't null; we'd have exited above
+                writer.netCache.SetKnownLength(obj, null, length);
+            }
+            return length;
+        }
+
+        internal static long MeasureAny<T>(NullProtoWriter writer, int fieldNumber, SerializerFeatures features, T value, ISerializer<T> serializer)
+        {
+            // note: not using cache here is intentional, since we're calling from the wrapped-item path; we don't
+            // want to get confused between the wrapped and non-wrapped variants
+
+            var oldState = writer.ResetWriteState();
+            var nulState = new State(writer);
+            nulState.WriteAny<T>(fieldNumber, features, value, serializer);
+            var length = nulState.GetPosition();
+            writer.SetWriteState(oldState); // make sure we leave it how we found it
+
+            return length;
+        }
+
         internal static long Measure<T>(NullProtoWriter writer, T value, ISerializer<T> serializer)
         {
             long length;
@@ -552,7 +637,7 @@ namespace ProtoBuf
             writer.SetWriteState(oldState); // make sure we leave it how we found it
 
             // cache it if we can
-            if (TypeHelper<T>.IsReferenceType)
+            if (obj is not null)
             {   // we know it isn't null; we'd have exited above
                 writer.netCache.SetKnownLength(obj, null, length);
             }

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -295,7 +295,7 @@ namespace ProtoBuf.Serializers
         T ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, T values);
     }
 
-    public interface IRepeatedSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : IRepeatedSerializer<TCollection>
+    internal interface IRepeatedSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : IRepeatedSerializer<TCollection>
     {
         /// <summary>
         /// Serialize a sequence of values to the supplied writer using the specified value-serializer

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -222,7 +222,7 @@ namespace ProtoBuf.Serializers
     }
 
     ///// <summary>
-    ///// Allows a provider to offer indirect access to serivces; note that this is a *secondary* API; the
+    ///// Allows a provider to offer indirect access to services; note that this is a *secondary* API; the
     ///// primary API is for the provider to implement ISerializer-T for the intended T; however, to offer
     ///// indirect access to known serializers, when asked for a type, provide the appropriate ISerializer-T
     ///// for that type. This method can (and often will) return null. The implementation can also return
@@ -293,6 +293,14 @@ namespace ProtoBuf.Serializers
         /// Deserializes a sequence of values from the supplied reader
         /// </summary>
         T ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, T values);
+    }
+
+    public interface IRepeatedSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : IRepeatedSerializer<TCollection>
+    {
+        /// <summary>
+        /// Serialize a sequence of values to the supplied writer using the specified value-serializer
+        /// </summary>
+        void WriteRepeated(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values, ISerializer<TValue> valueSerializer);
     }
 
     /// <summary>

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -295,14 +295,6 @@ namespace ProtoBuf.Serializers
         T ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, T values);
     }
 
-    internal interface IRepeatedSerializer<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TValue> : IRepeatedSerializer<TCollection>
-    {
-        /// <summary>
-        /// Serialize a sequence of values to the supplied writer using the specified value-serializer
-        /// </summary>
-        void WriteRepeated(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values, ISerializer<TValue> valueSerializer);
-    }
-
     /// <summary>
     /// A serializer capable of representing complex objects that may warrant length caching
     /// </summary>

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -121,16 +121,16 @@ namespace ProtoBuf.Serializers
         /// </summary>
         public void WriteRepeated(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values, ISerializer<TItem> serializer = null)
         {
-            serializer ??= TypeModel.GetSerializer<TItem>(state.Model);
-            var serializerFeatures = serializer.Features;
-            if (serializerFeatures.IsRepeated()) TypeModel.ThrowNestedListsNotSupported(typeof(TItem));
-            features.InheritFrom(serializerFeatures);
-
             if (features.HasAny(SerializerFeatures.OptionWrappedCollection))
             {
                 WriteNullWrapped(ref state, fieldNumber, features, values, serializer);
                 return;
             }
+
+            serializer ??= TypeModel.GetSerializer<TItem>(state.Model);
+            var serializerFeatures = serializer.Features;
+            if (serializerFeatures.IsRepeated()) TypeModel.ThrowNestedListsNotSupported(typeof(TItem));
+            features.InheritFrom(serializerFeatures);
 
             int count = TryGetCount(values);
 
@@ -327,15 +327,15 @@ namespace ProtoBuf.Serializers
         /// </summary>
         public TCollection ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, TCollection values, ISerializer<TItem> serializer = null)
         {
-            serializer ??= TypeModel.GetSerializer<TItem>(state.Model);
-            var serializerFeatures = serializer.Features;
-            if (serializerFeatures.IsRepeated()) TypeModel.ThrowNestedListsNotSupported(typeof(TItem));
-            features.InheritFrom(serializerFeatures);
-
             if (features.HasAny(SerializerFeatures.OptionWrappedCollection))
             {
                 return ReadNullWrapped(ref state, features, values, serializer);
             }
+
+            serializer ??= TypeModel.GetSerializer<TItem>(state.Model);
+            var serializerFeatures = serializer.Features;
+            if (serializerFeatures.IsRepeated()) TypeModel.ThrowNestedListsNotSupported(typeof(TItem));
+            features.InheritFrom(serializerFeatures);
 
             if (features.HasAny(SerializerFeatures.OptionWrappedValue))
                 features |= SerializerFeatures.OptionWrappedValueFieldPresence;

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -87,7 +87,7 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Base class for simple collection serializers
     /// </summary>
-    public abstract class RepeatedSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TItem> : IRepeatedSerializer<TCollection, TItem>, IFactory<TCollection>
+    public abstract class RepeatedSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TItem> : ISerializer<TCollection>, IFactory<TCollection>
     {
         TCollection IFactory<TCollection>.Create(ISerializationContext context) => Initialize(default, context);
 
@@ -101,9 +101,6 @@ namespace ProtoBuf.Serializers
 
         void ISerializer<TCollection>.Write(ref ProtoWriter.State state, TCollection value)
             => ThrowHelper.ThrowInvalidOperationException("Should have used " + nameof(IRepeatedSerializer<TCollection>.WriteRepeated));
-
-        void IRepeatedSerializer<TCollection>.WriteRepeated(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values)
-            => WriteRepeated(ref state, fieldNumber, features, values, default);
 
         private void WriteNullWrapped(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values, ISerializer<TItem> serializer)
         {
@@ -295,9 +292,6 @@ namespace ProtoBuf.Serializers
                 return -1;
             }
         }
-
-        TCollection IRepeatedSerializer<TCollection>.ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, TCollection values)
-            => ReadRepeated(ref state, features, values, default);
 
         private TCollection ReadNullWrapped(ref ProtoReader.State state, SerializerFeatures features, TCollection values, ISerializer<TItem> serializer)
         {

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -87,11 +87,15 @@ namespace ProtoBuf.Serializers
     /// <summary>
     /// Base class for simple collection serializers
     /// </summary>
-    public abstract class RepeatedSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TItem> : ISerializer<TCollection>, IFactory<TCollection>
+    public abstract class RepeatedSerializer<TCollection, [DynamicallyAccessedMembers(DynamicAccess.ContractType)] TItem> : IRepeatedSerializer<TCollection>, IFactory<TCollection>
     {
         TCollection IFactory<TCollection>.Create(ISerializationContext context) => Initialize(default, context);
 
         SerializerFeatures ISerializer<TCollection>.Features => SerializerFeatures.CategoryRepeated;
+
+        void IRepeatedSerializer<TCollection>.WriteRepeated(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures features, TCollection values) => WriteRepeated(ref state, fieldNumber, features, values, default);
+
+        TCollection IRepeatedSerializer<TCollection>.ReadRepeated(ref ProtoReader.State state, SerializerFeatures features, TCollection values) => ReadRepeated(ref state, features, values, default);
 
         TCollection ISerializer<TCollection>.Read(ref ProtoReader.State state, TCollection value)
         {

--- a/src/protobuf-net.Test/NullCollections.cs
+++ b/src/protobuf-net.Test/NullCollections.cs
@@ -42,6 +42,42 @@ namespace ProtoBuf.Test
         }
 
         [Theory]
+        [InlineData(typeof(Vanilla), @"syntax = ""proto3"";
+package ProtoBuf.Test;
+
+message Foo {
+   int32 Id = 1;
+}
+message Vanilla {
+   repeated Foo Foos = 4;
+}
+")]
+        [InlineData(typeof(VanillaWrappedValue), @"syntax = ""proto3"";
+package ProtoBuf.Test;
+
+message Foo {
+   int32 Id = 1;
+}
+message WrappedFoo {
+   optional Foo value = 1;
+}
+message VanillaWrappedValue {
+   repeated WrappedFoo Foos = 4;
+}
+")]
+        [InlineData(typeof(VanillaWrappedGroupValue), @"syntax = ""proto3"";
+package ProtoBuf.Test;
+
+message Foo {
+   int32 Id = 1;
+}
+message WrappedAsGroupFoo {
+   optional Foo value = 1;
+}
+message VanillaWrappedGroupValue {
+   repeated group WrappedAsGroupFoo Foos = 4;
+}
+")]
         [InlineData(typeof(ManualWrappedEquivalent), @"syntax = ""proto3"";
 package ProtoBuf.Test;
 
@@ -117,6 +153,20 @@ message WrapperLayer {
 
         [Theory]
         [InlineData(-1, "")]
+        [InlineData(0, "")]
+        [InlineData(1, "22-04-0A-02-08-00")]
+        [InlineData(10, "22-04-0A-02-08-00-22-04-0A-02-08-01-22-00-22-04-0A-02-08-03-22-04-0A-02-08-04-22-00-22-04-0A-02-08-06-22-04-0A-02-08-07-22-00-22-04-0A-02-08-09")]
+        public void TestVanillaWrappedValue(int count, string? hex = null) => Test<VanillaWrappedValue>(count, false, hex, true);
+
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "")]
+        [InlineData(1, "23-0A-02-08-00-24")]
+        [InlineData(10, "23-0A-02-08-00-24-23-0A-02-08-01-24-23-24-23-0A-02-08-03-24-23-0A-02-08-04-24-23-24-23-0A-02-08-06-24-23-0A-02-08-07-24-23-24-23-0A-02-08-09-24")]
+        public void TestVanillaWrappedGroupValue(int count, string? hex = null) => Test<VanillaWrappedGroupValue>(count, false, hex, true);
+
+        [Theory]
+        [InlineData(-1, "")]
         [InlineData(0, "22-00")]
         [InlineData(1, "22-04-0A-02-08-00")]
         [InlineData(10, "22-28-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09")]
@@ -152,7 +202,7 @@ message WrapperLayer {
             Test<T>(model, count, preserveEmpty, expectedHex, true, usesWrappedValues);
             model.CompileInPlace();
             Test<T>(model, count, preserveEmpty, expectedHex, false, usesWrappedValues);
-            Test<T>(PEVerify.CompileAndVerify(model, name), count, preserveEmpty, expectedHex, false, usesWrappedValues);
+            Test<T>(count == 0 ? PEVerify.CompileAndVerify(model, name) : model.Compile(), count, preserveEmpty, expectedHex, false, usesWrappedValues);
         }
 
         private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex, bool usesWrappedValues) where T : class, ITestScenario, new()
@@ -224,6 +274,20 @@ message WrapperLayer {
         public class Vanilla : ITestScenario
         {
             [ProtoMember(4)]
+            public List<Foo?>? Foos { get; set; }
+        }
+
+        [ProtoContract]
+        public class VanillaWrappedValue : ITestScenario
+        {
+            [ProtoMember(4), NullWrappedValue]
+            public List<Foo?>? Foos { get; set; }
+        }
+
+        [ProtoContract]
+        public class VanillaWrappedGroupValue : ITestScenario
+        {
+            [ProtoMember(4), NullWrappedValue(AsGroup = true)]
             public List<Foo?>? Foos { get; set; }
         }
 

--- a/src/protobuf-net.Test/NullCollections.cs
+++ b/src/protobuf-net.Test/NullCollections.cs
@@ -1,0 +1,111 @@
+﻿using ProtoBuf.Meta;
+using ProtoBuf.unittest;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace ProtoBuf.Test
+{
+    public class NullCollections
+    {
+        public ITestOutputHelper Log { get; }
+
+        public NullCollections(ITestOutputHelper log)
+            => Log = log;
+
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "22-00")] // guess, something like
+        [InlineData(1, "22-04-0A-02-08-00")] // guess, something like
+        [InlineData(10)]
+        public void TestWithNullWrappedCollection(int count, string? hex = null) => Test<WithNullWrappedCollection>(count, true, hex);
+
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "")]
+        [InlineData(1, "22-02-08-00")]
+        [InlineData(10, "22-02-08-00-22-02-08-01-22-02-08-02-22-02-08-03-22-02-08-04-22-02-08-05-22-02-08-06-22-02-08-07-22-02-08-08-22-02-08-09")]
+        public void TestVanilla(int count, string? hex = null) => Test<Vanilla>(count, false, hex);
+
+        private void Test<T>(int count, bool withAttrib, string? expectedHex) where T : class, ITestScenario, new()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            model.Add<T>();
+            Test<T>(model, count, withAttrib, expectedHex);
+            model.CompileInPlace();
+            Test<T>(model, count, withAttrib, expectedHex);
+            Test<T>(PEVerify.CompileAndVerify(model), count, withAttrib, expectedHex);
+        }
+
+        private void Test<T>(TypeModel model, int count, bool withAttrib, string? expectedHex) where T : class, ITestScenario, new()
+        {
+            T obj = new();
+            if (count >= 0)
+            {
+                var list = obj.Foos = new List<Foo>();
+                for (int i = 0; i < count; i++)
+                {
+                    list.Add(new(i));
+                }
+            }
+            using var ms = new MemoryStream();
+            model.Serialize<T>(ms, obj);
+            if (!ms.TryGetBuffer(out var buffer)) buffer = new(ms.ToArray());
+            var hex = BitConverter.ToString(buffer.Array!, buffer.Offset, buffer.Count);
+            Log.WriteLine(hex);
+
+            if (expectedHex is not null) Assert.Equal(expectedHex, hex);
+
+            ms.Position = 0;
+            var clone = model.Deserialize<T>(ms);
+
+            if (count < 0 || (count == 0 && !withAttrib))
+            {
+                Assert.Null(clone.Foos);
+            }
+            else
+            {
+                var list = clone.Foos;
+                Assert.NotNull(list);
+                Assert.Equal(count, list.Count);
+                for (int i = 0; i < count; i++)
+                {
+                    Assert.Equal(i, list[i].Id);
+                }
+            }
+        }
+
+
+
+
+        [ProtoContract]
+        public class Vanilla : ITestScenario
+        {
+            [ProtoMember(4)]
+            public List<Foo>? Foos { get; set; }
+        }
+
+        [ProtoContract]
+        public class WithNullWrappedCollection : ITestScenario
+        {
+            [ProtoMember(4), NullWrappedCollection]
+            public List<Foo>? Foos { get; set; }
+        }
+
+        public interface ITestScenario
+        {
+            List<Foo>? Foos { get; set; }
+        }
+
+        public readonly struct Foo
+        {
+            public Foo(int id) => Id = id; 
+            public int Id { get; }
+        }
+    }
+}

--- a/src/protobuf-net.Test/NullCollections.cs
+++ b/src/protobuf-net.Test/NullCollections.cs
@@ -19,9 +19,9 @@ namespace ProtoBuf.Test
 
         [Theory]
         [InlineData(-1, "")]
-        [InlineData(0, "22-00")] // guess, something like
-        [InlineData(1, "22-04-0A-02-08-00")] // guess, something like
-        [InlineData(10)]
+        [InlineData(0, "22-00")]
+        [InlineData(1, "22-04-0A-02-08-00")]
+        [InlineData(10, "22-28-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09")]
         public void TestWithNullWrappedCollection(int count, string? hex = null) => Test<WithNullWrappedCollection>(count, true, hex);
 
         [Theory]
@@ -31,18 +31,25 @@ namespace ProtoBuf.Test
         [InlineData(10, "22-02-08-00-22-02-08-01-22-02-08-02-22-02-08-03-22-02-08-04-22-02-08-05-22-02-08-06-22-02-08-07-22-02-08-08-22-02-08-09")]
         public void TestVanilla(int count, string? hex = null) => Test<Vanilla>(count, false, hex);
 
-        private void Test<T>(int count, bool withAttrib, string? expectedHex) where T : class, ITestScenario, new()
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "22-00")]
+        [InlineData(1, "22-04-0A-02-08-00")]
+        [InlineData(10, "22-28-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09")]
+        public void TestManualWrappedEquivalent(int count, string? hex = null) => Test<ManualWrappedEquivalent>(count, true, hex);
+
+        private void Test<T>(int count, bool preserveEmpty, string? expectedHex) where T : class, ITestScenario, new()
         {
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
             model.Add<T>();
-            Test<T>(model, count, withAttrib, expectedHex);
+            Test<T>(model, count, preserveEmpty, expectedHex);
             model.CompileInPlace();
-            Test<T>(model, count, withAttrib, expectedHex);
-            Test<T>(PEVerify.CompileAndVerify(model), count, withAttrib, expectedHex);
+            Test<T>(model, count, preserveEmpty, expectedHex);
+            Test<T>(PEVerify.CompileAndVerify(model), count, preserveEmpty, expectedHex);
         }
 
-        private void Test<T>(TypeModel model, int count, bool withAttrib, string? expectedHex) where T : class, ITestScenario, new()
+        private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex) where T : class, ITestScenario, new()
         {
             T obj = new();
             if (count >= 0)
@@ -64,7 +71,7 @@ namespace ProtoBuf.Test
             ms.Position = 0;
             var clone = model.Deserialize<T>(ms);
 
-            if (count < 0 || (count == 0 && !withAttrib))
+            if (count < 0 || (count == 0 && !preserveEmpty))
             {
                 Assert.Null(clone.Foos);
             }
@@ -88,6 +95,42 @@ namespace ProtoBuf.Test
         {
             [ProtoMember(4)]
             public List<Foo>? Foos { get; set; }
+        }
+
+        [ProtoContract]
+        public class ManualWrappedEquivalent : ITestScenario
+        {
+            [ProtoContract]
+            public class WrapperLayer
+            {
+                public WrapperLayer() => Foos = new();
+                public WrapperLayer(List<Foo> foos) => Foos = foos;
+
+                [ProtoMember(1)]
+                public List<Foo> Foos { get; set; }
+            }
+
+            [ProtoMember(4)]
+            public WrapperLayer? Wrapper {get;set;}
+            List<Foo>? ITestScenario.Foos
+            {
+                get => Wrapper?.Foos;
+                set
+                {
+                    if (value is null)
+                    {
+                        Wrapper = null;
+                    }
+                    else if (Wrapper is null)
+                    {
+                        Wrapper = new(value);
+                    }
+                    else
+                    {
+                        Wrapper.Foos = value;
+                    }
+                }
+            }
         }
 
         [ProtoContract]

--- a/src/protobuf-net.Test/NullCollections.cs
+++ b/src/protobuf-net.Test/NullCollections.cs
@@ -3,6 +3,7 @@ using ProtoBuf.unittest;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Abstractions;
 using static ProtoBuf.Test.BufferWriteCountTests;
@@ -97,15 +98,15 @@ message WrapperLayer {
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
         [InlineData(1, "22-06-0A-04-0A-02-08-00")]
-        [InlineData(10, "22-3C-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09")]
-        public void TestWithNullWrappedCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedCollection_WrappedValues>(count, true, hex);
+        [InlineData(10, "22-30-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-00-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-00-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-00-0A-04-0A-02-08-09")]
+        public void TestWithNullWrappedCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedCollection_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
         [InlineData(1, "23-0A-04-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09-24")]
-        public void TestWithNullWrappedGroupCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedGroupCollection_WrappedValues>(count, true, hex);
+        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-00-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-00-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-00-0A-04-0A-02-08-09-24")]
+        public void TestWithNullWrappedGroupCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedGroupCollection_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
@@ -132,37 +133,38 @@ message WrapperLayer {
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
         [InlineData(1, "22-06-0A-04-0A-02-08-00")]
-        [InlineData(10, "22-3C-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09")]
-        public void TestManualWrappedEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedEquivalent_WrappedValues>(count, true, hex);
+        [InlineData(10, "22-30-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-00-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-00-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-00-0A-04-0A-02-08-09")]
+        public void TestManualWrappedEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedEquivalent_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
         [InlineData(1, "23-0A-04-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09-24")]
-        public void TestManualWrappedGroupEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent_WrappedValues>(count, true, hex);
+        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-00-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-00-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-00-0A-04-0A-02-08-09-24")]
+        public void TestManualWrappedGroupEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent_WrappedValues>(count, true, hex, true);
 
 
-        private void Test<T>(int count, bool preserveEmpty, string? expectedHex) where T : class, ITestScenario, new()
+        private void Test<T>(int count, bool preserveEmpty, string? expectedHex, bool usesWrappedValues = false, [CallerMemberName] string name = "") where T : class, ITestScenario, new()
         {
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
             model.Add<T>();
-            Test<T>(model, count, preserveEmpty, expectedHex, true);
+            Test<T>(model, count, preserveEmpty, expectedHex, true, usesWrappedValues);
             model.CompileInPlace();
-            Test<T>(model, count, preserveEmpty, expectedHex, false);
-            Test<T>(PEVerify.CompileAndVerify(model), count, preserveEmpty, expectedHex, false);
+            Test<T>(model, count, preserveEmpty, expectedHex, false, usesWrappedValues);
+            Test<T>(PEVerify.CompileAndVerify(model, name), count, preserveEmpty, expectedHex, false, usesWrappedValues);
         }
 
-        private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex) where T : class, ITestScenario, new()
+        private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex, bool usesWrappedValues) where T : class, ITestScenario, new()
         {
+            bool ShouldBeNull(int index) => usesWrappedValues && (index % 3) == 2;
             T obj = new();
             if (count >= 0)
             {
-                var list = obj.Foos = new List<Foo>();
+                var list = obj.Foos = new List<Foo?>();
                 for (int i = 0; i < count; i++)
                 {
-                    list.Add(new(i));
+                    list.Add(ShouldBeNull(i) ? null : new(i));
                 }
             }
             using var ms = new MemoryStream();
@@ -188,7 +190,16 @@ message WrapperLayer {
                 Assert.Equal(count, list.Count);
                 for (int i = 0; i < count; i++)
                 {
-                    Assert.Equal(i, list[i].Id);
+                    var listItem = list[i];
+                    if (ShouldBeNull(i))
+                    {
+                        Assert.Null(listItem);
+                    }
+                    else
+                    {
+                        Assert.NotNull(listItem);
+                        Assert.Equal(i, listItem.Id);
+                    }
                 }
             }
 
@@ -213,7 +224,7 @@ message WrapperLayer {
         public class Vanilla : ITestScenario
         {
             [ProtoMember(4)]
-            public List<Foo>? Foos { get; set; }
+            public List<Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
@@ -223,15 +234,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(List<Foo?> foos) => Foos = foos;
 
                 [ProtoMember(1)]
-                public List<Foo> Foos { get; set; }
+                public List<Foo?> Foos { get; set; }
             }
 
             [ProtoMember(4)]
             public WrapperLayer? Wrapper {get;set;}
-            List<Foo>? ITestScenario.Foos
+            List<Foo?>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -259,15 +270,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(List<Foo?> foos) => Foos = foos;
 
                 [ProtoMember(1), NullWrappedValue]
-                public List<Foo> Foos { get; set; }
+                public List<Foo?> Foos { get; set; }
             }
 
             [ProtoMember(4)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            List<Foo?>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -295,15 +306,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(List<Foo?> foos) => Foos = foos;
 
                 [ProtoMember(1)]
-                public List<Foo> Foos { get; set; }
+                public List<Foo?> Foos { get; set; }
             }
 
             [ProtoMember(4, DataFormat = DataFormat.Group)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            List<Foo?>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -331,15 +342,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(List<Foo?> foos) => Foos = foos;
 
                 [ProtoMember(1), NullWrappedValue]
-                public List<Foo> Foos { get; set; }
+                public List<Foo?> Foos { get; set; }
             }
 
             [ProtoMember(4, DataFormat = DataFormat.Group)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            List<Foo?>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -372,33 +383,33 @@ message WrapperLayer {
         public class WithNullWrappedCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection]
-            public List<Foo>? Foos { get; set; }
+            public List<Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true)]
-            public List<Foo>? Foos { get; set; }
+            public List<Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection, NullWrappedValue]
-            public List<Foo>? Foos { get; set; }
+            public List<Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true), NullWrappedValue]
-            public List<Foo>? Foos { get; set; }
+            public List<Foo?>? Foos { get; set; }
         }
 
         public interface ITestScenario
         {
-            List<Foo>? Foos { get; set; }
+            List<Foo?>? Foos { get; set; }
         }
 
         public sealed class Foo

--- a/src/protobuf-net.Test/NullMaps.cs
+++ b/src/protobuf-net.Test/NullMaps.cs
@@ -11,11 +11,11 @@ using static ProtoBuf.Test.BufferWriteCountTests;
 
 namespace ProtoBuf.Test
 {
-    public class NullCollections
+    public class NullMaps
     {
         public ITestOutputHelper Log { get; }
 
-        public NullCollections(ITestOutputHelper log)
+        public NullMaps(ITestOutputHelper log)
             => Log = log;
 
         [Fact]
@@ -51,7 +51,7 @@ message ManualWrappedEquivalent {
    WrapperLayer Wrapper = 4;
 }
 message WrapperLayer {
-   repeated Foo Foos = 1;
+   map<int32,Foo> Foos = 1;
 }
 ")]
         [InlineData(typeof(ManualWrappedGroupEquivalent), @"syntax = ""proto3"";
@@ -64,7 +64,7 @@ message ManualWrappedGroupEquivalent {
    group WrapperLayer Wrapper = 4;
 }
 message WrapperLayer {
-   repeated Foo Foos = 1;
+   map<int32,Foo> Foos = 1;
 }
 ")]
         public void SchemaGenerationSucceeds(Type type, string expected)
@@ -82,15 +82,15 @@ message WrapperLayer {
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
-        [InlineData(1, "22-04-0A-02-08-00")]
-        [InlineData(10, "22-28-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09")]
+        [InlineData(1, "22-06-0A-04-12-02-08-00")]
+        [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
         public void TestWithNullWrappedCollection(int count, string? hex = null) => Test<WithNullWrappedCollection>(count, true, hex);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
-        [InlineData(1, "23-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09-24")]
+        [InlineData(1, "23-0A-04-12-02-08-00-24")]
+        [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
         public void TestWithNullWrappedGroupCollection(int count, string? hex = null) => Test<WithNullWrappedGroupCollection>(count, true, hex);
 
         [Theory]
@@ -98,60 +98,73 @@ message WrapperLayer {
         [InlineData(0, "22-00")]
         [InlineData(1, "22-06-0A-04-0A-02-08-00")]
         [InlineData(10, "22-3C-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09")]
-        public void TestWithNullWrappedCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedCollection_WrappedValues>(count, true, hex);
+        public void TestWithNullWrappedCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedCollection_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
         [InlineData(1, "23-0A-04-0A-02-08-00-24")]
         [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09-24")]
-        public void TestWithNullWrappedGroupCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedGroupCollection_WrappedValues>(count, true, hex);
+        public void TestWithNullWrappedGroupCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedGroupCollection_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "")]
-        [InlineData(1, "22-02-08-00")]
-        [InlineData(10, "22-02-08-00-22-02-08-01-22-02-08-02-22-02-08-03-22-02-08-04-22-02-08-05-22-02-08-06-22-02-08-07-22-02-08-08-22-02-08-09")]
+        [InlineData(1, "22-04-12-02-08-00")]
+        [InlineData(10, "22-04-12-02-08-00-22-06-08-01-12-02-08-01-22-06-08-02-12-02-08-02-22-06-08-03-12-02-08-03-22-06-08-04-12-02-08-04-22-06-08-05-12-02-08-05-22-06-08-06-12-02-08-06-22-06-08-07-12-02-08-07-22-06-08-08-12-02-08-08-22-06-08-09-12-02-08-09")]
         public void TestVanilla(int count, string? hex = null) => Test<Vanilla>(count, false, hex);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
-        [InlineData(1, "22-04-0A-02-08-00")]
-        [InlineData(10, "22-28-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09")]
+        [InlineData(1, "22-06-0A-04-12-02-08-00")]
+        [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
         public void TestManualWrappedEquivalent(int count, string? hex = null) => Test<ManualWrappedEquivalent>(count, true, hex);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
-        [InlineData(1, "23-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-02-08-00-0A-02-08-01-0A-02-08-02-0A-02-08-03-0A-02-08-04-0A-02-08-05-0A-02-08-06-0A-02-08-07-0A-02-08-08-0A-02-08-09-24")]
+        [InlineData(1, "23-0A-04-12-02-08-00-24")]
+        [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
         public void TestManualWrappedGroupEquivalent(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent>(count, true, hex);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
-        [InlineData(1, "22-06-0A-04-0A-02-08-00")]
-        [InlineData(10, "22-3C-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09")]
-        public void TestManualWrappedEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedEquivalent_WrappedValues>(count, true, hex);
+        [InlineData(1, "22-06-0A-04-12-02-08-00")]
+        [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
+        public void TestManualWrappedEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedEquivalent_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
-        [InlineData(1, "23-0A-04-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09-24")]
-        public void TestManualWrappedGroupEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent_WrappedValues>(count, true, hex);
+        [InlineData(1, "23-0A-04-12-02-08-00-24")]
+        [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
+        public void TestManualWrappedGroupEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent_WrappedValues>(count, true, hex, true);
 
 
-        private void Test<T>(int count, bool preserveEmpty, string? expectedHex) where T : class, ITestScenario, new()
+        private void Test<T>(int count, bool preserveEmpty, string? expectedHex, bool usesWrappedValues = false) where T : class, ITestScenario, new()
         {
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
             model.Add<T>();
-            Test<T>(model, count, preserveEmpty, expectedHex, true);
-            model.CompileInPlace();
-            Test<T>(model, count, preserveEmpty, expectedHex, false);
-            Test<T>(PEVerify.CompileAndVerify(model), count, preserveEmpty, expectedHex, false);
+            if (usesWrappedValues)
+            {
+                var ex = Assert.Throws<NotSupportedException>(() => RunTests());
+                Assert.Equal("Wrapped values in maps are not currently supported", ex.Message);
+            }
+            else
+            {
+                RunTests();
+            }
+
+            void RunTests()
+            {
+                Test<T>(model, count, preserveEmpty, expectedHex, true);
+                model.CompileInPlace();
+                Test<T>(model, count, preserveEmpty, expectedHex, false);
+                Test<T>(PEVerify.CompileAndVerify(model), count, preserveEmpty, expectedHex, false);
+            }
         }
 
         private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex) where T : class, ITestScenario, new()
@@ -159,10 +172,10 @@ message WrapperLayer {
             T obj = new();
             if (count >= 0)
             {
-                var list = obj.Foos = new List<Foo>();
+                var list = obj.Foos = new Dictionary<int, Foo>();
                 for (int i = 0; i < count; i++)
                 {
-                    list.Add(new(i));
+                    list.Add(i, new(i));
                 }
             }
             using var ms = new MemoryStream();
@@ -213,7 +226,7 @@ message WrapperLayer {
         public class Vanilla : ITestScenario
         {
             [ProtoMember(4)]
-            public List<Foo>? Foos { get; set; }
+            public Dictionary<int, Foo>? Foos { get; set; }
         }
 
         [ProtoContract]
@@ -223,15 +236,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(Dictionary<int, Foo> foos) => Foos = foos;
 
                 [ProtoMember(1)]
-                public List<Foo> Foos { get; set; }
+                public Dictionary<int, Foo> Foos { get; set; }
             }
 
             [ProtoMember(4)]
             public WrapperLayer? Wrapper {get;set;}
-            List<Foo>? ITestScenario.Foos
+            Dictionary<int, Foo>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -259,15 +272,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(Dictionary<int, Foo> foos) => Foos = foos;
 
                 [ProtoMember(1), NullWrappedValue]
-                public List<Foo> Foos { get; set; }
+                public Dictionary<int, Foo> Foos { get; set; }
             }
 
             [ProtoMember(4)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            Dictionary<int, Foo>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -295,15 +308,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(Dictionary<int, Foo> foos) => Foos = foos;
 
                 [ProtoMember(1)]
-                public List<Foo> Foos { get; set; }
+                public Dictionary<int, Foo> Foos { get; set; }
             }
 
             [ProtoMember(4, DataFormat = DataFormat.Group)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            Dictionary<int, Foo>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -331,15 +344,15 @@ message WrapperLayer {
             public class WrapperLayer
             {
                 public WrapperLayer() => Foos = new();
-                public WrapperLayer(List<Foo> foos) => Foos = foos;
+                public WrapperLayer(Dictionary<int, Foo> foos) => Foos = foos;
 
                 [ProtoMember(1), NullWrappedValue]
-                public List<Foo> Foos { get; set; }
+                public Dictionary<int, Foo> Foos { get; set; }
             }
 
             [ProtoMember(4, DataFormat = DataFormat.Group)]
             public WrapperLayer? Wrapper { get; set; }
-            List<Foo>? ITestScenario.Foos
+            Dictionary<int, Foo>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
                 set
@@ -372,33 +385,33 @@ message WrapperLayer {
         public class WithNullWrappedCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection]
-            public List<Foo>? Foos { get; set; }
+            public Dictionary<int, Foo>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true)]
-            public List<Foo>? Foos { get; set; }
+            public Dictionary<int, Foo>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection, NullWrappedValue]
-            public List<Foo>? Foos { get; set; }
+            public Dictionary<int, Foo>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true), NullWrappedValue]
-            public List<Foo>? Foos { get; set; }
+            public Dictionary<int, Foo>? Foos { get; set; }
         }
 
         public interface ITestScenario
         {
-            List<Foo>? Foos { get; set; }
+            Dictionary<int, Foo>? Foos { get; set; }
         }
 
         public sealed class Foo

--- a/src/protobuf-net.Test/NullMaps.cs
+++ b/src/protobuf-net.Test/NullMaps.cs
@@ -3,6 +3,7 @@ using ProtoBuf.unittest;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Xunit;
 using Xunit.Abstractions;
 using static ProtoBuf.Test.BufferWriteCountTests;
@@ -30,17 +31,31 @@ namespace ProtoBuf.Test
 
         [Theory]
         [InlineData(typeof(WithNullWrappedCollection))]
+        [InlineData(typeof(WithNullWrappedCollection_WrappedValues))]
         [InlineData(typeof(WithNullWrappedGroupCollection))]
+        [InlineData(typeof(WithNullWrappedGroupCollection_WrappedValues))]
+        [InlineData(typeof(VanillaNullValues))]
+        [InlineData(typeof(VanillaNullGroupedValues))]
         public void SchemaGenerationFails_NotCurrentlySupported(Type type)
         {
             // this should look comparable to the ones below in SchemaGenerationSucceeds
             var model = RuntimeTypeModel.Create();
             model.Add(type);
-            var ex = Assert.Throws<NotSupportedException>(() => model.GetSchema(type, ProtoSyntax.Proto3));
-            Assert.Equal("Schema generation for null-wrapped collections is not currently implemented; poke @mgravell with a big stick if you need this!", ex.Message);
+            var ex = Assert.Throws<NotSupportedException>(() => Log?.WriteLine(model.GetSchema(type, ProtoSyntax.Proto3)));
+            Assert.Equal("Schema generation for null-wrapped maps and maps with null-wrapped values is not currently implemented; poke @mgravell with a big stick if you need this!", ex.Message);
         }
 
         [Theory]
+        [InlineData(typeof(Vanilla), @"syntax = ""proto3"";
+package ProtoBuf.Test;
+
+message Foo {
+   int32 Id = 1;
+}
+message Vanilla {
+   map<int32,Foo> Foos = 4;
+}
+")]
         [InlineData(typeof(ManualWrappedEquivalent), @"syntax = ""proto3"";
 package ProtoBuf.Test;
 
@@ -83,6 +98,7 @@ message WrapperLayer {
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
         [InlineData(1, "22-06-0A-04-12-02-08-00")]
+        [InlineData(3, "22-16-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02")]
         [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
         public void TestWithNullWrappedCollection(int count, string? hex = null) => Test<WithNullWrappedCollection>(count, true, hex);
 
@@ -90,92 +106,249 @@ message WrapperLayer {
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
         [InlineData(1, "23-0A-04-12-02-08-00-24")]
+        [InlineData(3, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-24")]
         [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
         public void TestWithNullWrappedGroupCollection(int count, string? hex = null) => Test<WithNullWrappedGroupCollection>(count, true, hex);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
-        [InlineData(1, "22-06-0A-04-0A-02-08-00")]
-        [InlineData(10, "22-3C-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09")]
+        [InlineData(1, "22-08-0A-06-12-04-0A-02-08-00")]
+        [InlineData(3, "22-16-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02")]
+        [InlineData(10, "22-50-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-0A-08-08-03-12-04-0A-02-08-03-0A-08-08-04-12-04-0A-02-08-04-0A-02-08-05-0A-08-08-06-12-04-0A-02-08-06-0A-08-08-07-12-04-0A-02-08-07-0A-02-08-08-0A-08-08-09-12-04-0A-02-08-09")]
         public void TestWithNullWrappedCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedCollection_WrappedValues>(count, true, hex, true);
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
-        [InlineData(1, "23-0A-04-0A-02-08-00-24")]
-        [InlineData(10, "23-0A-04-0A-02-08-00-0A-04-0A-02-08-01-0A-04-0A-02-08-02-0A-04-0A-02-08-03-0A-04-0A-02-08-04-0A-04-0A-02-08-05-0A-04-0A-02-08-06-0A-04-0A-02-08-07-0A-04-0A-02-08-08-0A-04-0A-02-08-09-24")]
+        [InlineData(1, "23-0A-06-12-04-0A-02-08-00-24")]
+        [InlineData(3, "23-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-24")]
+        [InlineData(10, "23-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-0A-08-08-03-12-04-0A-02-08-03-0A-08-08-04-12-04-0A-02-08-04-0A-02-08-05-0A-08-08-06-12-04-0A-02-08-06-0A-08-08-07-12-04-0A-02-08-07-0A-02-08-08-0A-08-08-09-12-04-0A-02-08-09-24")]
         public void TestWithNullWrappedGroupCollection_WrappedValues(int count, string? hex = null) => Test<WithNullWrappedGroupCollection_WrappedValues>(count, true, hex, true);
 
+        /* Vanilla, 3
+Field #4: 22 String Length = 4, Hex = 04, UTF8 = ""
+    As sub-object :
+    Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 0, Hex = 00
+Field #4: 22 String Length = 6, Hex = 06, UTF8 = ""
+    As sub-object :
+    Field #1: 08 Varint Value = 1, Hex = 01
+    Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 1, Hex = 01
+Field #4: 22 String Length = 6, Hex = 06, UTF8 = ""
+    As sub-object :
+    Field #1: 08 Varint Value = 2, Hex = 02
+    Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 2, Hex = 02
+*/
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "")]
         [InlineData(1, "22-04-12-02-08-00")]
+        [InlineData(3, "22-04-12-02-08-00-22-06-08-01-12-02-08-01-22-06-08-02-12-02-08-02")]
         [InlineData(10, "22-04-12-02-08-00-22-06-08-01-12-02-08-01-22-06-08-02-12-02-08-02-22-06-08-03-12-02-08-03-22-06-08-04-12-02-08-04-22-06-08-05-12-02-08-05-22-06-08-06-12-02-08-06-22-06-08-07-12-02-08-07-22-06-08-08-12-02-08-08-22-06-08-09-12-02-08-09")]
         public void TestVanilla(int count, string? hex = null) => Test<Vanilla>(count, false, hex);
 
+        /* TestVanillaNullValues, 3
+Field #4: 22 String Length = 6, Hex = 06, UTF8 = " "
+    As sub-object :
+    Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+        As sub-object :
+        Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 0, Hex = 00
+Field #4: 22 String Length = 8, Hex = 08, UTF8 = " "
+    As sub-object :
+    Field #1: 08 Varint Value = 1, Hex = 01
+    Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+        As sub-object :
+        Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 1, Hex = 01
+Field #4: 22 String Length = 2, Hex = 02, UTF8 = ""
+    As sub-object :
+    Field #1: 08 Varint Value = 2, Hex = 02
+*/
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "")]
+        [InlineData(1, "22-06-12-04-0A-02-08-00")]
+        [InlineData(3, "22-06-12-04-0A-02-08-00-22-08-08-01-12-04-0A-02-08-01-22-02-08-02")]
+        [InlineData(10, "22-06-12-04-0A-02-08-00-22-08-08-01-12-04-0A-02-08-01-22-02-08-02-22-08-08-03-12-04-0A-02-08-03-22-08-08-04-12-04-0A-02-08-04-22-02-08-05-22-08-08-06-12-04-0A-02-08-06-22-08-08-07-12-04-0A-02-08-07-22-02-08-08-22-08-08-09-12-04-0A-02-08-09")]
+        public void TestVanillaNullValues(int count, string? hex = null) => Test<VanillaNullValues>(count, false, hex, true);
+
+        /* TestVanillaNullGroupedValues, 3
+Field #4: 22 String Length = 6, Hex = 06, UTF8 = " "
+    As sub-object :
+    Field #2: 13 StartGroup
+        Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 0, Hex = 00
+Field #4: 22 String Length = 8, Hex = 08, UTF8 = " "
+    As sub-object :
+    Field #1: 08 Varint Value = 1, Hex = 01
+    Field #2: 13 StartGroup
+        Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 1, Hex = 01
+Field #4: 22 String Length = 2, Hex = 02, UTF8 = ""
+    As sub-object :
+    Field #1: 08 Varint Value = 2, Hex = 02
+*/
+        [Theory]
+        [InlineData(-1, "")]
+        [InlineData(0, "")]
+        [InlineData(1, "22-06-13-0A-02-08-00-14")]
+        [InlineData(3, "22-06-13-0A-02-08-00-14-22-08-08-01-13-0A-02-08-01-14-22-02-08-02")]
+        [InlineData(10, "22-06-13-0A-02-08-00-14-22-08-08-01-13-0A-02-08-01-14-22-02-08-02-22-08-08-03-13-0A-02-08-03-14-22-08-08-04-13-0A-02-08-04-14-22-02-08-05-22-08-08-06-13-0A-02-08-06-14-22-08-08-07-13-0A-02-08-07-14-22-02-08-08-22-08-08-09-13-0A-02-08-09-14")]
+        public void TestVanillaNullGroupedValues(int count, string? hex = null) => Test<VanillaNullGroupedValues>(count, false, hex, true);
+
+        /* TestManualWrappedEquivalent, 3
+Field #4: 22 String Length = 22, Hex = 16, UTF8 = "    ..." (total 22 chars)
+    As sub-object :
+    Field #1: 0A String Length = 4, Hex = 04, UTF8 = ""
+        As sub-object :
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 0, Hex = 00
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 1, Hex = 01
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 1, Hex = 01
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 2, Hex = 02
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 2, Hex = 02
+ */
+
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
         [InlineData(1, "22-06-0A-04-12-02-08-00")]
+        [InlineData(3, "22-16-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02")]
         [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
         public void TestManualWrappedEquivalent(int count, string? hex = null) => Test<ManualWrappedEquivalent>(count, true, hex);
 
+
+        /* TestManualWrappedGroupEquivalent, 3
+Field #4: 23 StartGroup
+    Field #1: 0A String Length = 4, Hex = 04, UTF8 = ""
+        As sub-object :
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 0, Hex = 00
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 1, Hex = 01
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 1, Hex = 01
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 2, Hex = 02
+        Field #2: 12 String Length = 2, Hex = 02, UTF8 = ""
+            As sub-object :
+            Field #1: 08 Varint Value = 2, Hex = 02
+*/
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
         [InlineData(1, "23-0A-04-12-02-08-00-24")]
+        [InlineData(3, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-24")]
         [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
         public void TestManualWrappedGroupEquivalent(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent>(count, true, hex);
+
+        /* TestManualWrappedEquivalent_WrappedValues, 3
+Field #4: 22 String Length = 22, Hex = 16, UTF8 = "     ..." (total 22 chars)
+    As sub-object :
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = " "
+        As sub-object :
+        Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+            As sub-object :
+            Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+                As sub-object :
+                Field #1: 08 Varint Value = 0, Hex = 00
+    Field #1: 0A String Length = 8, Hex = 08, UTF8 = " "
+    As sub-object :
+        Field #1: 08 Varint Value = 1, Hex = 01
+        Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+            As sub-object :
+            Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+                As sub-object :
+                Field #1: 08 Varint Value = 1, Hex = 01
+    Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 2, Hex = 02
+*/
 
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "22-00")]
-        [InlineData(1, "22-06-0A-04-12-02-08-00")]
-        [InlineData(10, "22-4E-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09")]
+        [InlineData(1, "22-08-0A-06-12-04-0A-02-08-00")]
+        [InlineData(3, "22-16-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02")]
+        [InlineData(10, "22-50-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-0A-08-08-03-12-04-0A-02-08-03-0A-08-08-04-12-04-0A-02-08-04-0A-02-08-05-0A-08-08-06-12-04-0A-02-08-06-0A-08-08-07-12-04-0A-02-08-07-0A-02-08-08-0A-08-08-09-12-04-0A-02-08-09")]
         public void TestManualWrappedEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedEquivalent_WrappedValues>(count, true, hex, true);
 
+        /* TestManualWrappedGroupEquivalent_WrappedValues, 3
+Field #4: 23 StartGroup
+    Field #1: 0A String Length = 6, Hex = 06, UTF8 = " "
+        As sub-object :
+        Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+            As sub-object :
+            Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+                As sub-object :
+                Field #1: 08 Varint Value = 0, Hex = 00
+    Field #1: 0A String Length = 8, Hex = 08, UTF8 = " "
+        As sub-object :
+        Field #1: 08 Varint Value = 1, Hex = 01
+        Field #2: 12 String Length = 4, Hex = 04, UTF8 = " "
+            As sub-object :
+            Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+                As sub-object :
+                Field #1: 08 Varint Value = 1, Hex = 01
+    Field #1: 0A String Length = 2, Hex = 02, UTF8 = ""
+        As sub-object :
+        Field #1: 08 Varint Value = 2, Hex = 02
+*/
         [Theory]
         [InlineData(-1, "")]
         [InlineData(0, "23-24")]
-        [InlineData(1, "23-0A-04-12-02-08-00-24")]
-        [InlineData(10, "23-0A-04-12-02-08-00-0A-06-08-01-12-02-08-01-0A-06-08-02-12-02-08-02-0A-06-08-03-12-02-08-03-0A-06-08-04-12-02-08-04-0A-06-08-05-12-02-08-05-0A-06-08-06-12-02-08-06-0A-06-08-07-12-02-08-07-0A-06-08-08-12-02-08-08-0A-06-08-09-12-02-08-09-24")]
+        [InlineData(1, "23-0A-06-12-04-0A-02-08-00-24")]
+        [InlineData(3, "23-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-24")]
+        [InlineData(10, "23-0A-06-12-04-0A-02-08-00-0A-08-08-01-12-04-0A-02-08-01-0A-02-08-02-0A-08-08-03-12-04-0A-02-08-03-0A-08-08-04-12-04-0A-02-08-04-0A-02-08-05-0A-08-08-06-12-04-0A-02-08-06-0A-08-08-07-12-04-0A-02-08-07-0A-02-08-08-0A-08-08-09-12-04-0A-02-08-09-24")]
         public void TestManualWrappedGroupEquivalent_WrappedValues(int count, string? hex = null) => Test<ManualWrappedGroupEquivalent_WrappedValues>(count, true, hex, true);
 
 
-        private void Test<T>(int count, bool preserveEmpty, string? expectedHex, bool usesWrappedValues = false) where T : class, ITestScenario, new()
+        private void Test<T>(int count, bool preserveEmpty, string? expectedHex, bool usesWrappedValues = false, [CallerMemberName] string name = "") where T : class, ITestScenario, new()
         {
             var model = RuntimeTypeModel.Create();
             model.AutoCompile = false;
             model.Add<T>();
-            if (usesWrappedValues)
-            {
-                var ex = Assert.Throws<NotSupportedException>(() => RunTests());
-                Assert.Equal("Wrapped values in maps are not currently supported", ex.Message);
-            }
-            else
-            {
-                RunTests();
-            }
 
-            void RunTests()
-            {
-                Test<T>(model, count, preserveEmpty, expectedHex, true);
-                model.CompileInPlace();
-                Test<T>(model, count, preserveEmpty, expectedHex, false);
-                Test<T>(PEVerify.CompileAndVerify(model), count, preserveEmpty, expectedHex, false);
-            }
+            Test<T>(model, count, preserveEmpty, expectedHex, true, usesWrappedValues);
+            model.CompileInPlace();
+            Test<T>(model, count, preserveEmpty, expectedHex, false, usesWrappedValues);
+            Test<T>(PEVerify.CompileAndVerify(model, name), count, preserveEmpty, expectedHex, false, usesWrappedValues);
         }
 
-        private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex) where T : class, ITestScenario, new()
+        private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex, bool usesWrappedValues) where T : class, ITestScenario, new()
         {
+            bool ShouldBeNull(int index) => usesWrappedValues && (index % 3) == 2;
             T obj = new();
             if (count >= 0)
             {
-                var list = obj.Foos = new Dictionary<int, Foo>();
+                var list = obj.Foos = new Dictionary<int, Foo?>();
                 for (int i = 0; i < count; i++)
                 {
-                    list.Add(i, new(i));
+                    list.Add(i, ShouldBeNull(i) ? null : new(i));
                 }
             }
             using var ms = new MemoryStream();
@@ -201,7 +374,16 @@ message WrapperLayer {
                 Assert.Equal(count, list.Count);
                 for (int i = 0; i < count; i++)
                 {
-                    Assert.Equal(i, list[i].Id);
+                    var listItem = list[i];
+                    if (ShouldBeNull(i))
+                    {
+                        Assert.Null(listItem);
+                    }
+                    else
+                    {
+                        Assert.NotNull(listItem);
+                        Assert.Equal(i, listItem.Id);
+                    }
                 }
             }
 
@@ -230,6 +412,20 @@ message WrapperLayer {
         }
 
         [ProtoContract]
+        public class VanillaNullValues : ITestScenario
+        {
+            [ProtoMember(4), NullWrappedValue]
+            public Dictionary<int, Foo>? Foos { get; set; }
+        }
+
+        [ProtoContract]
+        public class VanillaNullGroupedValues : ITestScenario
+        {
+            [ProtoMember(4), NullWrappedValue(AsGroup = true)]
+            public Dictionary<int, Foo>? Foos { get; set; }
+        }
+
+        [ProtoContract]
         public class ManualWrappedEquivalent : ITestScenario
         {
             [ProtoContract]
@@ -243,7 +439,7 @@ message WrapperLayer {
             }
 
             [ProtoMember(4)]
-            public WrapperLayer? Wrapper {get;set;}
+            public WrapperLayer? Wrapper { get; set; }
             Dictionary<int, Foo>? ITestScenario.Foos
             {
                 get => Wrapper?.Foos;
@@ -385,38 +581,38 @@ message WrapperLayer {
         public class WithNullWrappedCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection]
-            public Dictionary<int, Foo>? Foos { get; set; }
+            public Dictionary<int, Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true)]
-            public Dictionary<int, Foo>? Foos { get; set; }
+            public Dictionary<int, Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection, NullWrappedValue]
-            public Dictionary<int, Foo>? Foos { get; set; }
+            public Dictionary<int, Foo?>? Foos { get; set; }
         }
 
         [ProtoContract]
         public class WithNullWrappedGroupCollection_WrappedValues : ITestScenario
         {
             [ProtoMember(4), NullWrappedCollection(AsGroup = true), NullWrappedValue]
-            public Dictionary<int, Foo>? Foos { get; set; }
+            public Dictionary<int, Foo?>? Foos { get; set; }
         }
 
         public interface ITestScenario
         {
-            Dictionary<int, Foo>? Foos { get; set; }
+            Dictionary<int, Foo?>? Foos { get; set; }
         }
 
         public sealed class Foo
         {
-            public Foo(int id) => Id = id; 
+            public Foo(int id) => Id = id;
             public int Id { get; }
         }
     }

--- a/src/protobuf-net.Test/NullMaps.cs
+++ b/src/protobuf-net.Test/NullMaps.cs
@@ -336,7 +336,7 @@ Field #4: 23 StartGroup
             Test<T>(model, count, preserveEmpty, expectedHex, true, usesWrappedValues);
             model.CompileInPlace();
             Test<T>(model, count, preserveEmpty, expectedHex, false, usesWrappedValues);
-            Test<T>(PEVerify.CompileAndVerify(model, name), count, preserveEmpty, expectedHex, false, usesWrappedValues);
+            Test<T>(count == 0 ? PEVerify.CompileAndVerify(model, name) : model.Compile(), count, preserveEmpty, expectedHex, false, usesWrappedValues);
         }
 
         private void Test<T>(TypeModel model, int count, bool preserveEmpty, string? expectedHex, bool logHex, bool usesWrappedValues) where T : class, ITestScenario, new()

--- a/src/protobuf-net.Test/NullWrappedValueTests.cs
+++ b/src/protobuf-net.Test/NullWrappedValueTests.cs
@@ -1,7 +1,6 @@
 ﻿using ProtoBuf.Meta;
 using ProtoBuf.unittest;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;

--- a/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TupleSerializer.cs
@@ -47,7 +47,7 @@ namespace ProtoBuf.Internal.Serializers
                 }
                 else if (repeated.IsMap)
                 {
-                    serializer = ValueMember.CreateMap(repeated, model, DataFormat.Default, compatibilityLevel, DataFormat.Default, DataFormat.Default, asReference, false, true, false, i + 1);
+                    serializer = ValueMember.CreateMap(repeated, model, DataFormat.Default, compatibilityLevel, DataFormat.Default, DataFormat.Default, asReference, false, true, false, i + 1, null);
                 }
                 else
                 {

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -2106,6 +2106,10 @@ namespace ProtoBuf.Meta
                     bool hasOption = false;
                     if (member.IsMap)
                     {
+                        if (member.NullWrappedCollection)
+                        {
+                            throw new NotSupportedException("Schema generation for null-wrapped collections is not currently implemented; poke @mgravell with a big stick if you need this!");
+                        }
                         repeated = model.TryGetRepeatedProvider(member.MemberType);
                         repeated.ResolveMapTypes(out var keyType, out var valueType);
 

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -210,7 +210,7 @@ namespace ProtoBuf.Meta
             }
         }
         /// <summary>
-        /// Assigns the callbacks to use during serialiation/deserialization.
+        /// Assigns the callbacks to use during serialization/deserialization.
         /// </summary>
         /// <param name="beforeSerialize">The method (or null) called before serialization begins.</param>
         /// <param name="afterSerialize">The method (or null) called when serialization is complete.</param>
@@ -421,7 +421,7 @@ namespace ProtoBuf.Meta
             Type = type;
             if (type.IsArray)
             {
-                // we'all allow add, to allow proxy generation, but
+                // we'll allow add, to allow proxy generation, but
                 // don't play with it too much!
                 SetFlag(TypeOptions.Frozen, true, false);
             }
@@ -626,7 +626,7 @@ namespace ProtoBuf.Meta
         [Flags]
         internal enum AttributeFamily
         {
-            None = 0, ProtoBuf = 1, DataContractSerialier = 2, XmlSerializer = 4, AutoTuple = 8
+            None = 0, ProtoBuf = 1, DataContractSerializer = 2, XmlSerializer = 4, AutoTuple = 8
         }
         private static Type GetBaseType(MetaType type)
         {
@@ -959,7 +959,7 @@ namespace ProtoBuf.Meta
                     case "System.Runtime.Serialization.DataContractAttribute":
                         if (!model.AutoAddProtoContractTypesOnly)
                         {
-                            family |= AttributeFamily.DataContractSerialier;
+                            family |= AttributeFamily.DataContractSerializer;
                         }
                         break;
                 }
@@ -1167,7 +1167,7 @@ namespace ProtoBuf.Meta
                 }
             }
 
-            if (!ignore && !done && HasFamily(family, AttributeFamily.DataContractSerialier))
+            if (!ignore && !done && HasFamily(family, AttributeFamily.DataContractSerializer))
             {
                 attrib = GetAttribute(attribs, "System.Runtime.Serialization.DataMemberAttribute");
                 if (attrib is not null)
@@ -2133,6 +2133,11 @@ namespace ProtoBuf.Meta
 
                         void WriteValueMember(string schemaModelTypeName, bool hasGroupModifier = false)
                         {
+                            if (member.NullWrappedCollection)
+                            {
+                                throw new NotSupportedException("Schema generation for null-wrapped collections is not currently implemented; poke @mgravell with a big stick if you need this!");
+                            }
+
                             string ordinality = member.ItemType is not null ? "repeated " : (syntax == ProtoSyntax.Proto2 ? (member.IsRequired ? "required " : "optional ") : "");
                             NewLine(builder, indent + 1).Append(ordinality);
 

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -2106,9 +2106,9 @@ namespace ProtoBuf.Meta
                     bool hasOption = false;
                     if (member.IsMap)
                     {
-                        if (member.NullWrappedCollection)
+                        if (member.NullWrappedCollection || member.NullWrappedValue)
                         {
-                            throw new NotSupportedException("Schema generation for null-wrapped collections is not currently implemented; poke @mgravell with a big stick if you need this!");
+                            throw new NotSupportedException("Schema generation for null-wrapped maps and maps with null-wrapped values is not currently implemented; poke @mgravell with a big stick if you need this!");
                         }
                         repeated = model.TryGetRepeatedProvider(member.MemberType);
                         repeated.ResolveMapTypes(out var keyType, out var valueType);

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -504,12 +504,11 @@ namespace ProtoBuf.Meta
                 }
                 else
                 {
-
+                    if (NullWrappedCollection) ThrowHelper.ThrowNotSupportedException($"{nameof(NullWrappedCollection)} can only be used with collection types");
                     ser = TryGetCoreSerializer(model, DataFormat, CompatibilityLevel, MemberType, out WireType wireType, AsReference, DynamicType, OverwriteList, allowComplexTypes: true);
                     if (ser is null) ThrowHelper.NoSerializerDefined(MemberType);
                     if (NullWrappedValue)
                     {
-                        if (NullWrappedCollection) ThrowHelper.ThrowNotSupportedException($"{nameof(NullWrappedCollection)} can only be used with collection types");
                         var valueFeatures = SerializerFeatures.OptionWrappedValue;
                         if (NullWrappedValueGroup) valueFeatures |= SerializerFeatures.OptionWrappedValueGroup;
                         if (MemberType.IsValueType && Nullable.GetUnderlyingType(MemberType) is null) ThrowHelper.ThrowNotSupportedException($"{nameof(NullWrappedValue)} cannot be used with non-nullable values");

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -442,13 +442,14 @@ namespace ProtoBuf.Meta
             if (overwriteList) features |= SerializerFeatures.OptionClearCollection;
 
             member?.ComposeListFeatures(ref features);
-            if (features.HasAny(SerializerFeatures.OptionWrappedValue))
-            {
-                ThrowHelper.ThrowNotSupportedException("Wrapped values in maps are not currently supported");
-            }
+
+            // transfer OptionWrappedValue and OptionWrappedValueGroup from the serializer features to the value features
+            var valueFeatures = valueWireType.AsFeatures();
+            valueFeatures |= features & (SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionWrappedValueGroup);
+            features &= ~(SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionWrappedValueGroup);
 
             return MapDecorator.Create(repeated, keyType, valueType, fieldNumber, features,
-                keyWireType.AsFeatures(), keyCompatibilityLevel, keyFormat, valueWireType.AsFeatures(), valueCompatibilityLevel, valueFormat);
+                keyWireType.AsFeatures(), keyCompatibilityLevel, keyFormat, valueFeatures, valueCompatibilityLevel, valueFormat);
         }
 
         void ComposeListFeatures(ref SerializerFeatures listFeatures)


### PR DESCRIPTION
usage is as per https://protobuf-net.github.io/protobuf-net/nullwrappers and in particular https://protobuf-net.github.io/protobuf-net/nullwrappers#null-collections

key pieces:

- un-hide `[NullWrappedCollection]`
- implement at the repeated-serializer layer
- tests
  - [x] lists, with without groups, with and without wrapped inner values
  - [x] maps, with without groups (without wrapped inner values only)
- detect `[NullWrappedCollection]` in `GetSchema(...)`/`GetProto(...)` and throw; not implemented yet (throwing is better than returning an incorrect schema)
- fix an issue with `[NullWrappedValue]` when used with buffer-writer
- fix an issue with null values in dictionaries that don't have basic construction (tuples, factories, etc)