### PR TITLE
fix the protogen pascal rename issue 

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -62,5 +62,6 @@
         <PackageVersion Include="xunit" Version="2.4.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
+        <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
     </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -62,6 +62,6 @@
         <PackageVersion Include="xunit" Version="2.4.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
         <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-        <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
+        <PackageVersion Include="Humanizer.Core" Version="2.14.1"/>
     </ItemGroup>
 </Project>

--- a/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
+++ b/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
@@ -63,4 +63,7 @@
         <EmbeddedResource Include="../protobuf-net.Reflection/protobuf-net/bcl.proto" Link="protobuf-net/bcl.proto" />
         <EmbeddedResource Include="../protobuf-net.Reflection/protobuf-net/protogen.proto" Link="protobuf-net/protogen.proto" />
     </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Humanizer.Core"/>
+	</ItemGroup>
 </Project>

--- a/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
+++ b/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
@@ -70,4 +70,7 @@
     <EmbeddedResource Include="../protobuf-net.Reflection/protobuf-net/bcl.proto" Link="protobuf-net/bcl.proto" />
     <EmbeddedResource Include="../protobuf-net.Reflection/protobuf-net/protogen.proto" Link="protobuf-net/protogen.proto" />
   </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Humanizer.Core"/>
+	</ItemGroup>
 </Project>

--- a/src/protobuf-net.Reflection/NameNormalizer.cs
+++ b/src/protobuf-net.Reflection/NameNormalizer.cs
@@ -3,6 +3,7 @@ using ProtoBuf.Reflection.Internal;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Humanizer;
 
 namespace ProtoBuf.Reflection
 {
@@ -61,21 +62,7 @@ namespace ProtoBuf.Reflection
         /// </summary>
         protected static string AutoCapitalize(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return identifier;
-            // if all upper-case, make proper-case
-            if (Regex.IsMatch(identifier, "^[_A-Z0-9]*$"))
-            {
-                return Regex.Replace(identifier, "(^|_)([A-Z0-9])([A-Z0-9]*)",
-                    match => match.Groups[2].Value.ToUpperInvariant() + match.Groups[3].Value.ToLowerInvariant());
-            }
-            // if all lower-case, make proper case
-            if (Regex.IsMatch(identifier, "^[_a-z0-9]*$"))
-            {
-                return Regex.Replace(identifier, "(^|_)([a-z0-9])([a-z0-9]*)",
-                    match => match.Groups[2].Value.ToUpperInvariant() + match.Groups[3].Value.ToLowerInvariant());
-            }
-            // just remove underscores - leave their chosen casing alone
-            return identifier.Replace("_", "");
+            return identifier.Pascalize();
         }
         /// <summary>
         /// Suggest a name with idiomatic pluralization

--- a/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
+++ b/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
@@ -22,6 +22,6 @@
     <Folder Include="google\type\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core"/>
+    <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
+++ b/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
@@ -21,4 +21,7 @@
   <ItemGroup>
     <Folder Include="google\type\" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Humanizer.Core"/>
+  </ItemGroup>
 </Project>

--- a/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
+++ b/src/protobuf-net.Reflection/protobuf-net.Reflection.csproj
@@ -22,6 +22,6 @@
     <Folder Include="google\type\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
+    <PackageReference Include="Humanizer.Core"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
related to issue #952

when proto message's member name is `testName`
the protogen rename to `testName` not `TestName`

I have already fix this by using a third party libaray [`Humanizer`](https://github.com/Humanizr/Humanizer), only one line code did this fix.
```csharp
protected static string AutoCapitalize(string identifier)
{
    identifier.Pascalize();
}
```