### PR TITLE
Date time only

### DIFF
--- a/src/protobuf-net.Core/BclHelpers.cs
+++ b/src/protobuf-net.Core/BclHelpers.cs
@@ -428,6 +428,76 @@ namespace ProtoBuf
         public static Guid ReadGuidString(ref ProtoReader.State state)
             => GuidHelper.Read(ref state); // note that this is forgiving and handles 16/32/36 formats
 
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Parses a DateOnly from a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static DateOnly ReadDateOnly(ProtoReader source)
+        {
+            ProtoReader.State state = source.DefaultState();
+            return ReadDateOnly(ref state);
+        }
+
+        /// <summary>
+        /// Parses a DateOnly from a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static DateOnly ReadDateOnly(ref ProtoReader.State state)
+            => DateOnly.FromDayNumber(state.ReadInt32());
+
+        /// <summary>
+        /// Writes a DateOnly to a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static void WriteDateOnly(DateOnly value, ProtoWriter dest)
+        {
+            ProtoWriter.State state = dest.DefaultState();
+            WriteDateOnly(ref state, value);
+        }
+
+        /// <summary>
+        /// Writes a DateOnly to a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static void WriteDateOnly(ref ProtoWriter.State state, DateOnly value)
+            => state.WriteInt32(value.DayNumber);
+
+        /// <summary>
+        /// Parses a TimeOnly from a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static TimeOnly ReadTimeOnly(ProtoReader source)
+        {
+            ProtoReader.State state = source.DefaultState();
+            return ReadTimeOnly(ref state);
+        }
+
+        /// <summary>
+        /// Parses a TimeOnly from a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static TimeOnly ReadTimeOnly(ref ProtoReader.State state)
+            => new TimeOnly(state.ReadInt64());
+
+        /// <summary>
+        /// Writes a TimeOnly to a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static void WriteTimeOnly(TimeOnly value, ProtoWriter dest)
+        {
+            ProtoWriter.State state = dest.DefaultState();
+            WriteTimeOnly(ref state, value);
+        }
+
+        /// <summary>
+        /// Writes a TimeOnly to a protobuf stream
+        /// </summary>
+        [MethodImpl(ProtoReader.HotPath)]
+        public static void WriteTimeOnly(ref ProtoWriter.State state, TimeOnly value)
+            => state.WriteInt64(value.Ticks);
+#endif
+
 #if FEAT_DYNAMIC_REF
         private const int
             FieldExistingObjectKey = 1,

--- a/src/protobuf-net.Core/Helpers.cs
+++ b/src/protobuf-net.Core/Helpers.cs
@@ -64,6 +64,10 @@ namespace ProtoBuf
             if (type == typeof(Type)) return ProtoTypeCode.Type;
             if (type == typeof(IntPtr)) return ProtoTypeCode.IntPtr;
             if (type == typeof(UIntPtr)) return ProtoTypeCode.UIntPtr;
+#if NET6_0_OR_GREATER
+            if (type == typeof(DateOnly)) return ProtoTypeCode.DateOnly;
+            if (type == typeof(TimeOnly)) return ProtoTypeCode.TimeOnly;
+#endif
 
             return ProtoTypeCode.Unknown;
         }
@@ -187,5 +191,9 @@ namespace ProtoBuf
         ByteReadOnlyMemory = 107,
         IntPtr = 108,
         UIntPtr = 109,
+#if NET6_0_OR_GREATER
+        DateOnly = 110,
+        TimeOnly = 111,
+#endif
     }
 }

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -129,10 +129,16 @@ namespace ProtoBuf.Meta
             switch (Helpers.GetTypeCode(type))
             {
                 case ProtoTypeCode.Int64:
+#if NET6_0_OR_GREATER
+                case ProtoTypeCode.TimeOnly:
+#endif
                 case ProtoTypeCode.UInt64:
                     return format == DataFormat.FixedSize ? WireType.Fixed64 : WireType.Varint;
                 case ProtoTypeCode.Int16:
                 case ProtoTypeCode.Int32:
+#if NET6_0_OR_GREATER
+                case ProtoTypeCode.DateOnly:
+#endif
                 case ProtoTypeCode.UInt16:
                 case ProtoTypeCode.UInt32:
                 case ProtoTypeCode.Boolean:
@@ -158,7 +164,9 @@ namespace ProtoBuf.Meta
             }
             return WireType.None;
         }
-        /// <summary>        /// Indicates whether a type is known to the model
+
+        /// <summary>
+        /// Indicates whether a type is known to the model
         /// </summary>
         internal virtual bool IsKnownType<T>(CompatibilityLevel ambient)
             => (TypeHelper<T>.IsReferenceType | !TypeHelper<T>.CanBeNull) // don't claim T?

--- a/src/protobuf-net.Test/Serializers/DateOnlyTests.cs
+++ b/src/protobuf-net.Test/Serializers/DateOnlyTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Xunit;
+using ProtoBuf.Meta;
+
+namespace ProtoBuf.unittest.Serializers
+{
+#if NET6_0_OR_GREATER
+    public class DateOnlyTests
+    {
+        public class TypeWithDateOnly
+        {
+            public DateOnly When { get; set; }
+        }
+
+        [Fact]
+        public void TestDateOnlyRuntime()
+        {
+            var model = CreateModel();
+
+            var obj = new TypeWithDateOnly { When = DateOnly.FromDateTime(DateTime.Today) };
+            TypeWithDateOnly clone = (TypeWithDateOnly)model.DeepClone(obj);
+            Assert.Equal(obj.When, clone.When);
+        }
+
+        [Fact]
+        public void TestDateOnlyInPlace()
+        {
+            var model = CreateModel();
+            model.CompileInPlace();
+            var obj = new TypeWithDateOnly { When = DateOnly.FromDateTime(DateTime.Today) };
+
+            TypeWithDateOnly clone = (TypeWithDateOnly)model.DeepClone(obj);
+
+            Assert.Equal(obj.When, clone.When);
+        }
+
+        [Fact]
+        public void TestDateOnlyCanCompileFully()
+        {
+            _ = CreateModel().Compile("TestDateOnlyCanCompileFully", "TestDateOnlyCanCompileFully.dll");
+            PEVerify.Verify("TestDateOnlyCanCompileFully.dll");
+        }
+
+        [Fact]
+        public void TestDateOnlyCompiled()
+        {
+            var model = CreateModel().Compile();
+
+            var obj = new TypeWithDateOnly { When = DateOnly.FromDateTime(DateTime.Today) };
+
+            TypeWithDateOnly clone = (TypeWithDateOnly)model.DeepClone(obj);
+            Assert.Equal(obj.When, clone.When);
+        }
+
+
+        static RuntimeTypeModel CreateModel()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.Add(typeof(TypeWithDateOnly), false)
+                .Add(1, "When");
+            return model;
+        }
+    }
+#endif
+}

--- a/src/protobuf-net.Test/Serializers/TimeOnlyTests.cs
+++ b/src/protobuf-net.Test/Serializers/TimeOnlyTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Xunit;
+using ProtoBuf.Meta;
+
+namespace ProtoBuf.unittest.Serializers
+{
+#if NET6_0_OR_GREATER
+    public class TimeOnlyTests
+    {
+        public class TypeWithTimeOnly
+        {
+            public TimeOnly When { get; set; }
+        }
+
+        [Fact]
+        public void TestTimeOnlyRuntime()
+        {
+            var model = CreateModel();
+
+            var obj = new TypeWithTimeOnly { When = TimeOnly.FromDateTime(DateTime.Today) };
+            TypeWithTimeOnly clone = (TypeWithTimeOnly)model.DeepClone(obj);
+            Assert.Equal(obj.When, clone.When);
+        }
+
+        [Fact]
+        public void TestTimeOnlyInPlace()
+        {
+            var model = CreateModel();
+            model.CompileInPlace();
+            var obj = new TypeWithTimeOnly { When = TimeOnly.FromDateTime(DateTime.Today) };
+
+            TypeWithTimeOnly clone = (TypeWithTimeOnly)model.DeepClone(obj);
+
+            Assert.Equal(obj.When, clone.When);
+        }
+
+        [Fact]
+        public void TestTimeOnlyCanCompileFully()
+        {
+            _ = CreateModel().Compile("TestTimeOnlyCanCompileFully", "TestTimeOnlyCanCompileFully.dll");
+            PEVerify.Verify("TestTimeOnlyCanCompileFully.dll");
+        }
+
+        [Fact]
+        public void TestTimeOnlyCompiled()
+        {
+            var model = CreateModel().Compile();
+
+            var obj = new TypeWithTimeOnly { When = TimeOnly.FromDateTime(DateTime.Today) };
+
+            TypeWithTimeOnly clone = (TypeWithTimeOnly)model.DeepClone(obj);
+            Assert.Equal(obj.When, clone.When);
+        }
+
+
+        static RuntimeTypeModel CreateModel()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.Add(typeof(TypeWithTimeOnly), false)
+                .Add(1, "When");
+            return model;
+        }
+    }
+#endif
+}

--- a/src/protobuf-net/Internal/Serializers/DateOnlySerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/DateOnlySerializer.cs
@@ -6,7 +6,7 @@ namespace ProtoBuf.Internal.Serializers
 #if NET6_0_OR_GREATER
     internal sealed class DateOnlySerializer : IRuntimeProtoSerializerNode
     {
-        bool IRuntimeProtoSerializerNode.IsScalar => true;
+        bool IRuntimeProtoSerializerNode.IsScalar => false;
         private DateOnlySerializer() { }
         internal static readonly DateOnlySerializer Instance = new DateOnlySerializer();
 
@@ -21,21 +21,21 @@ namespace ProtoBuf.Internal.Serializers
         public object Read(ref ProtoReader.State state, object value)
         {
             Debug.Assert(value is null); // since replaces
-            return DateOnly.FromDayNumber(state.ReadInt32());
+            return BclHelpers.ReadDateOnly(ref state);
         }
 
         public void Write(ref ProtoWriter.State state, object value)
         {
-            state.WriteInt32(((DateOnly)value).DayNumber);
+            BclHelpers.WriteDateOnly(ref state, (DateOnly)value);
         }
 
         void IRuntimeProtoSerializerNode.EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
         {
-            ctx.EmitStateBasedWrite(nameof(ProtoWriter.State.WriteInt32), valueFrom);
+            ctx.EmitStateBasedWrite(nameof(BclHelpers.WriteDateOnly), valueFrom, typeof(BclHelpers));
         }
         void IRuntimeProtoSerializerNode.EmitRead(Compiler.CompilerContext ctx, Compiler.Local entity)
         {
-            ctx.EmitStateBasedRead(nameof(ProtoReader.State.ReadInt32), ExpectedType);
+            ctx.EmitStateBasedRead(typeof(BclHelpers), nameof(BclHelpers.ReadDateOnly), ExpectedType);
         }
     }
 #endif

--- a/src/protobuf-net/Internal/Serializers/DateOnlySerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/DateOnlySerializer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ProtoBuf.Internal.Serializers
+{
+#if NET6_0_OR_GREATER
+    internal sealed class DateOnlySerializer : IRuntimeProtoSerializerNode
+    {
+        bool IRuntimeProtoSerializerNode.IsScalar => true;
+        private DateOnlySerializer() { }
+        internal static readonly DateOnlySerializer Instance = new DateOnlySerializer();
+
+        private static readonly Type expectedType = typeof(DateOnly);
+
+        public Type ExpectedType => expectedType;
+
+        bool IRuntimeProtoSerializerNode.RequiresOldValue => false;
+
+        bool IRuntimeProtoSerializerNode.ReturnsValue => true;
+
+        public object Read(ref ProtoReader.State state, object value)
+        {
+            Debug.Assert(value is null); // since replaces
+            return DateOnly.FromDayNumber(state.ReadInt32());
+        }
+
+        public void Write(ref ProtoWriter.State state, object value)
+        {
+            state.WriteInt32(((DateOnly)value).DayNumber);
+        }
+
+        void IRuntimeProtoSerializerNode.EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            ctx.EmitStateBasedWrite(nameof(ProtoWriter.State.WriteInt32), valueFrom);
+        }
+        void IRuntimeProtoSerializerNode.EmitRead(Compiler.CompilerContext ctx, Compiler.Local entity)
+        {
+            ctx.EmitStateBasedRead(nameof(ProtoReader.State.ReadInt32), ExpectedType);
+        }
+    }
+#endif
+}

--- a/src/protobuf-net/Internal/Serializers/DefaultValueDecorator.cs
+++ b/src/protobuf-net/Internal/Serializers/DefaultValueDecorator.cs
@@ -241,6 +241,17 @@ namespace ProtoBuf.Internal.Serializers
                         EmitBeq(ctx, label, typeof(ulong));
                         break;
                     }
+#if NET6_0_OR_GREATER
+                case ProtoTypeCode.DateOnly:
+                    {
+                        ctx.LoadValue(((DateOnly)defaultValue).DayNumber);
+                        ctx.EmitCall(typeof(DateOnly).GetMethod("FromDayNumber"));
+
+                        EmitBeq(ctx, label, expected);
+                        break;
+                    }
+                //TODO: support TimeOnly
+#endif
                 default:
                     throw new NotSupportedException("Type cannot be represented as a default value: " + expected.FullName);
             }

--- a/src/protobuf-net/Internal/Serializers/TimeOnlySerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TimeOnlySerializer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ProtoBuf.Internal.Serializers
+{
+#if NET6_0_OR_GREATER
+    internal sealed class TimeOnlySerializer : IRuntimeProtoSerializerNode
+    {
+        bool IRuntimeProtoSerializerNode.IsScalar => true;
+        private TimeOnlySerializer() { }
+        internal static readonly TimeOnlySerializer Instance = new TimeOnlySerializer();
+
+        private static readonly Type expectedType = typeof(TimeOnly);
+
+        public Type ExpectedType => expectedType;
+
+        bool IRuntimeProtoSerializerNode.RequiresOldValue => false;
+
+        bool IRuntimeProtoSerializerNode.ReturnsValue => true;
+
+        public object Read(ref ProtoReader.State state, object value)
+        {
+            Debug.Assert(value is null); // since replaces
+            return new TimeOnly(state.ReadInt64());
+        }
+
+        public void Write(ref ProtoWriter.State state, object value)
+        {
+            state.WriteInt64(((TimeOnly)value).Ticks);
+        }
+
+        void IRuntimeProtoSerializerNode.EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
+        {
+            ctx.EmitStateBasedWrite(nameof(ProtoWriter.State.WriteInt64), valueFrom);
+        }
+        void IRuntimeProtoSerializerNode.EmitRead(Compiler.CompilerContext ctx, Compiler.Local entity)
+        {
+            ctx.EmitStateBasedRead(nameof(ProtoReader.State.ReadInt64), ExpectedType);
+        }
+    }
+#endif
+}

--- a/src/protobuf-net/Internal/Serializers/TimeOnlySerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/TimeOnlySerializer.cs
@@ -6,7 +6,7 @@ namespace ProtoBuf.Internal.Serializers
 #if NET6_0_OR_GREATER
     internal sealed class TimeOnlySerializer : IRuntimeProtoSerializerNode
     {
-        bool IRuntimeProtoSerializerNode.IsScalar => true;
+        bool IRuntimeProtoSerializerNode.IsScalar => false;
         private TimeOnlySerializer() { }
         internal static readonly TimeOnlySerializer Instance = new TimeOnlySerializer();
 
@@ -21,21 +21,21 @@ namespace ProtoBuf.Internal.Serializers
         public object Read(ref ProtoReader.State state, object value)
         {
             Debug.Assert(value is null); // since replaces
-            return new TimeOnly(state.ReadInt64());
+            return BclHelpers.ReadTimeOnly(ref state);
         }
 
         public void Write(ref ProtoWriter.State state, object value)
         {
-            state.WriteInt64(((TimeOnly)value).Ticks);
+            BclHelpers.WriteTimeOnly(ref state, (TimeOnly)value);
         }
 
         void IRuntimeProtoSerializerNode.EmitWrite(Compiler.CompilerContext ctx, Compiler.Local valueFrom)
         {
-            ctx.EmitStateBasedWrite(nameof(ProtoWriter.State.WriteInt64), valueFrom);
+            ctx.EmitStateBasedWrite(nameof(BclHelpers.WriteTimeOnly), valueFrom, typeof(BclHelpers));
         }
         void IRuntimeProtoSerializerNode.EmitRead(Compiler.CompilerContext ctx, Compiler.Local entity)
         {
-            ctx.EmitStateBasedRead(nameof(ProtoReader.State.ReadInt64), ExpectedType);
+            ctx.EmitStateBasedRead(typeof(BclHelpers), nameof(BclHelpers.ReadTimeOnly), ExpectedType);
         }
     }
 #endif

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -2366,6 +2366,10 @@ namespace ProtoBuf.Meta
                     case ProtoTypeCode.Byte: return ((byte)value) == 0;
                     case ProtoTypeCode.Char: return ((char)value) == '\0';
                     case ProtoTypeCode.DateTime: return ((DateTime)value) == default;
+#if NET6_0_OR_GREATER
+                    case ProtoTypeCode.DateOnly: return ((DateOnly)value) == default;
+                    case ProtoTypeCode.TimeOnly: return ((TimeOnly)value) == default;
+#endif
                     case ProtoTypeCode.Decimal: return ((decimal)value) == 0M;
                     case ProtoTypeCode.Double: return ((double)value) == 0;
                     case ProtoTypeCode.Int16: return ((short)value) == 0;

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1980,6 +1980,9 @@ namespace ProtoBuf.Meta
                         };
                     case ProtoTypeCode.SByte:
                     case ProtoTypeCode.Int16:
+#if NET6_0_OR_GREATER
+                    case ProtoTypeCode.DateOnly:
+#endif
                     case ProtoTypeCode.Int32:
                         return dataFormat switch
                         {
@@ -1995,6 +1998,9 @@ namespace ProtoBuf.Meta
                             _ => "uint64",
                         };
                     case ProtoTypeCode.Int64:
+#if NET6_0_OR_GREATER
+                    case ProtoTypeCode.TimeOnly:
+#endif
                     case ProtoTypeCode.IntPtr:
                         return dataFormat switch
                         {

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -200,6 +200,10 @@ namespace ProtoBuf.Meta
                         if (s.Length == 1) return s[0];
                         throw new FormatException("Single character expected: \"" + s + "\"");
                     case ProtoTypeCode.DateTime: return DateTime.Parse(s, CultureInfo.InvariantCulture);
+#if NET6_0_OR_GREATER
+                    case ProtoTypeCode.DateOnly: return DateOnly.Parse(s, CultureInfo.InvariantCulture);
+                    case ProtoTypeCode.TimeOnly: return TimeOnly.Parse(s, CultureInfo.InvariantCulture);
+#endif
                     case ProtoTypeCode.Decimal: return decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture);
                     case ProtoTypeCode.Double: return double.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture);
                     case ProtoTypeCode.Int16: return short.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture);
@@ -708,6 +712,14 @@ namespace ProtoBuf.Meta
                 case ProtoTypeCode.UIntPtr:
                     defaultWireType = GetIntWireType(dataFormat, 64);
                     return UIntPtrSerializer.Instance;
+#if NET6_0_OR_GREATER
+                case ProtoTypeCode.DateOnly:
+                    defaultWireType = GetIntWireType(dataFormat, 32);
+                    return DateOnlySerializer.Instance;
+                case ProtoTypeCode.TimeOnly:
+                    defaultWireType = GetIntWireType(dataFormat, 64);
+                    return TimeOnlySerializer.Instance;
+#endif
             }
             IRuntimeProtoSerializerNode parseable = model.AllowParseableTypes ? ParseableSerializer.TryCreate(type) : null;
             if (parseable is object)


### PR DESCRIPTION
Add support for the DateOnly and TimeOnly types.
DateOnly is serialized to int. TimeOnly is serialized to long.