### PR TITLE
Fix-10777 DataContractAnalyzer crashes on partial classes

### DIFF
--- a/src/BuildToolsUnitTests/AnalyzerTestBase.cs
+++ b/src/BuildToolsUnitTests/AnalyzerTestBase.cs
@@ -65,6 +65,18 @@ namespace BuildToolsUnitTests
             return diagnostics;
         }
 
+        protected async Task<ICollection<Diagnostic>> AnalyzeMultiFileAsync(List<string> sourceCode, [CallerMemberName] string? callerMemberName = null, bool ignoreCompatibilityLevelAdvice = true, bool ignorePreferAsyncAdvice = true)
+        {
+            return await AnalyzeAsync(project =>
+            {
+                for (int i = 0; i < sourceCode.Count; i++)
+                {
+                    project = project.AddDocument($"{callerMemberName}_{i}_.cs", sourceCode[i]).Project;
+                }
+                return project;
+            }, callerMemberName, ignoreCompatibilityLevelAdvice, ignorePreferAsyncAdvice);
+        }
+
         protected async Task<(Project Project, Compilation Compilation)> ObtainProjectAndCompilationAsync(Func<Project, Project>? projectModifier = null, [CallerMemberName] string? callerMemberName = null)
         {
             _ = callerMemberName;

--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using ProtoBuf.BuildTools.Analyzers;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -64,6 +65,34 @@ public class Foo
 }}");
             Assert.Empty(diagnostics);
         }
+
+        [Fact]
+        public async Task DoesntReportOnPartialClassDefinition()
+        {
+            var diagnostics = await AnalyzeMultiFileAsync(
+                new List<string> {
+@"
+using ProtoBuf;
+[ProtoContract(SkipConstructor = true)]
+public partial class Foo
+{
+    [ProtoMember(2)]
+    [System.ComponentModel.DefaultValue(3)]
+    public int Bar {get;set;} =3;
+} ",
+//next file
+@"
+public partial class Foo
+{
+    public Foo(int bar){
+        Bar = bar;
+    }
+    public Foo (){}
+} "});
+            Assert.Empty(diagnostics);
+        }
+
+
 
         [Theory]
         [InlineData(0)]

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -372,7 +372,7 @@ namespace ProtoBuf.BuildTools.Internal
             }
             
             // calculating the member initial value using semantic model 
-            var semanticModel = context.SemanticModel;
+            var semanticModel = context.Compilation.GetSemanticModel(memberNode.SyntaxTree);
             var constantValue = semanticModel.GetConstantValue(initialValueSyntaxNode!);
             if (!constantValue.HasValue || constantValue.Value is null)
             {


### PR DESCRIPTION
Fix for #1077 DataContractAnalyzer crashes on some partial classes definitions.