### PR TITLE
Sort order of Serializer.GetProto<FooEnum>() as reported in #1102

### DIFF
--- a/docs/contract_first.md
+++ b/docs/contract_first.md
@@ -29,7 +29,7 @@ change the version/contents from the copy baked into the tool. Normally, standar
 
 ## Additional options
 
-Additional configuration options can be specified at attributes against each `<AdditionalFiles>` node, to fine tune your options; this is very similar to the options available with the command-line tools:
+Additional configuration options can be specified as attributes against each `<AdditionalFiles>` node, to fine tune your options; this is very similar to the options available with the command-line tools:
 
 - `ImportPaths` - specifies a comma delimited list of additional import locations; usually this isn't required, as schemas are resolved relative to each file; this is resolved relative to the current file, and
   can indicate "upwards" locations like `../..` - but the actual lookup happens *purely* within the virtual file system of `<AdditionalFiles>` nodes - it does not allow external file access

--- a/src/protobuf-net.Test/Issues/Issue1102.cs
+++ b/src/protobuf-net.Test/Issues/Issue1102.cs
@@ -1,0 +1,120 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+#if !NET7_0_OR_GREATER
+    public class Issue1102
+    {
+        [Fact]
+        public void TestEnumOrderInProtoMatchesDefinitionOrder()
+        {
+            var letters = new string[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"};
+
+            MemberInfo[] foundList = typeof(FooEnum).GetMembers(BindingFlags.Public | BindingFlags.Static);
+
+            Assert.Equal(letters.Length, foundList.Length);
+
+            for (var i = 0; i < foundList.Length; i++)
+            {
+                var field = (FieldInfo)foundList[i];
+                Assert.Equal(letters[i], field.Name);
+            }
+
+            var proto = Serializer.GetProto<FooEnum>();
+
+            Assert.Equal(ExpectedOutput, proto, ignoreLineEndingDifferences: true);
+        }
+
+        private static string ExpectedOutput = @"syntax = ""proto3"";
+package ProtoBuf.Test.Issues;
+
+enum FooEnum {
+   A = 0;
+   B = 1;
+   C = 2;
+   D = 3;
+   E = 4;
+   F = 5;
+   G = 6;
+   H = 7;
+   I = 8;
+   J = 9;
+   K = 10;
+   L = 11;
+   M = 12;
+   N = 13;
+   O = 14;
+   P = 15;
+   Q = 16;
+   R = 17;
+   S = 18;
+   T = 19;
+   U = 20;
+   V = 21;
+   W = 22;
+   X = 23;
+   Y = 24;
+   Z = 25;
+}
+";
+
+        [ProtoContract]
+        public enum FooEnum
+        {
+            [ProtoEnum]
+            A,
+            [ProtoEnum]
+            B,
+            [ProtoEnum]
+            C,
+            [ProtoEnum]
+            D,
+            [ProtoEnum]
+            E,
+            [ProtoEnum]
+            F,
+            [ProtoEnum]
+            G,
+            [ProtoEnum]
+            H,
+            [ProtoEnum]
+            I,
+            [ProtoEnum]
+            J,
+            [ProtoEnum]
+            K,
+            [ProtoEnum]
+            L,
+            [ProtoEnum]
+            M,
+            [ProtoEnum]
+            N,
+            [ProtoEnum]
+            O,
+            [ProtoEnum]
+            P,
+            [ProtoEnum]
+            Q,
+            [ProtoEnum]
+            R,
+            [ProtoEnum]
+            S,
+            [ProtoEnum]
+            T,
+            [ProtoEnum]
+            U,
+            [ProtoEnum]
+            V,
+            [ProtoEnum]
+            W,
+            [ProtoEnum]
+            X,
+            [ProtoEnum]
+            Y,
+            [ProtoEnum]
+            Z
+        }
+    }
+#endif
+}

--- a/src/protobuf-net.Test/Issues/Issue1102.cs
+++ b/src/protobuf-net.Test/Issues/Issue1102.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace ProtoBuf.Test.Issues
 {
-#if !NET7_0_OR_GREATER
     public class Issue1102
     {
         [Fact]
@@ -116,5 +115,4 @@ enum FooEnum {
             Z
         }
     }
-#endif
 }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -125,7 +125,9 @@ namespace ProtoBuf.Meta
             var thisValue = TryGetInt32();
             var otherValue = other.TryGetInt32();
 
-            if(!thisValue.HasValue && !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue && !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue && otherValue.HasValue) return -1;
+            if (thisValue.HasValue && !otherValue.HasValue) return 1;
             return thisValue.Value.CompareTo(otherValue.Value);
         }
     }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -8,7 +8,7 @@ namespace ProtoBuf.Meta
     /// Describes a named constant integer, i.e. an enum value
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    public readonly struct EnumMember : IEquatable<EnumMember>
+    public readonly struct EnumMember : IEquatable<EnumMember>, IComparable<EnumMember>
     {
         /// <summary>
         /// Gets the declared name of this enum member
@@ -118,6 +118,15 @@ namespace ProtoBuf.Meta
         {
             if (string.IsNullOrWhiteSpace(Name))
                 ThrowHelper.ThrowInvalidOperationException("All enum declarations must have valid names");
+        }
+
+        public int CompareTo(EnumMember other)
+        {
+            var thisValue = TryGetInt32();
+            var otherValue = other.TryGetInt32();
+
+            if(!thisValue.HasValue && !otherValue.HasValue) return 0;
+            return thisValue.Value.CompareTo(otherValue.Value);
         }
     }
 }

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1720,7 +1720,12 @@ namespace ProtoBuf.Meta
         public EnumMember[] GetEnumValues()
         {
             if (!HasEnums) return Array.Empty<EnumMember>();
-            return Enums.ToArray();
+
+            var arr = Enums.ToArray();
+#if !NET7_0_OR_GREATER
+            Array.Sort(arr);
+#endif
+            return arr;
         }
 
         /// <summary>

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1722,9 +1722,7 @@ namespace ProtoBuf.Meta
             if (!HasEnums) return Array.Empty<EnumMember>();
 
             var arr = Enums.ToArray();
-#if !NET7_0_OR_GREATER
             Array.Sort(arr);
-#endif
             return arr;
         }
 


### PR DESCRIPTION
Hi @mgravell, addition of value sorting logic for enums in answer to https://github.com/protobuf-net/protobuf-net/issues/1102. Also, an extremely minor spelling change for contract_first.md.