### PR TITLE
Support serializing ISet<T> and IReadOnlySet<T>

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -14,6 +14,8 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## unreleased
 
+- support of deserializing `ISet<T>` and `IReadOnlySet<T>` (ladeak)
+
 ## 3.2.30
 
 - support `DateOnly` and `TimeOnly` (#1100 by @mgravell, fixes #977)

--- a/src/Examples/SetTests.cs
+++ b/src/Examples/SetTests.cs
@@ -1,0 +1,378 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ProtoBuf;
+using Xunit;
+
+namespace Examples
+{
+    public class HashSetSerializerTests
+    {
+        [ProtoContract]
+        class HashSetData<T>
+        {
+            [ProtoMember(1)]
+            public HashSet<T> Data { get; set; }
+        }
+
+        [ProtoContract]
+        class NotEmptyHashSetData
+        {
+            public NotEmptyHashSetData() => Data = new HashSet<int>(new[] { 1 });
+
+            public NotEmptyHashSetData(HashSet<int> data) => Data = data;
+
+            [ProtoMember(1)]
+            public HashSet<int> Data { get; }
+        }
+
+        [Fact]
+        public void TestEmptyNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            var input = new HashSetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Null(clone.Data);
+        }
+
+        [Fact]
+        public void TestNullNestedSetWithStrings()
+        {
+            var input = new HashSetData<string>() { Data = null };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Equal(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            set.Add("hello");
+            set.Add("world");
+            var input = new HashSetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithInt32()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(3);
+            set.Add(3);
+            var input = new HashSetData<int>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void RoundtripHashSet()
+        {
+            HashSet<int> lookup = new HashSet<int>(new[] { 1, 2, 3 });
+
+            var clone = Serializer.DeepClone(lookup);
+
+            AssertEqual(lookup, clone);
+        }
+
+        [Fact]
+        public void TestNonEmptySetStrings()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(2);
+            var input = new NotEmptyHashSetData(set);
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestDefaultCtorValueOverwritten()
+        {
+            var set = new HashSet<int>();
+            set.Add(3);
+            var input = new NotEmptyHashSetData(set);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            Assert.Contains(new NotEmptyHashSetData().Data.Single(), clone.Data);
+            Assert.Contains(3, clone.Data);
+        }
+
+        static void AssertEqual<T>(
+            HashSet<T> expected,
+            HashSet<T> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            foreach (var value in expected)
+                Assert.Contains(value, actual);
+        }
+    }
+
+    public class SetSerializerTests
+    {
+        [ProtoContract]
+        class SetData<T>
+        {
+            [ProtoMember(1)]
+            public ISet<T> Data { get; set; }
+        }
+
+        [ProtoContract]
+        class NotEmptySetData
+        {
+            public NotEmptySetData() => Data = new HashSet<int>(new[] { 1 });
+
+            public NotEmptySetData(ISet<int> data) => Data = data;
+
+            [ProtoMember(1)]
+            public ISet<int> Data { get; }
+        }
+
+        [Fact]
+        public void TestEmptyNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            var input = new SetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Null(clone.Data);
+        }
+
+        [Fact]
+        public void TestNullNestedSetWithStrings()
+        {
+            var input = new SetData<string>() { Data = null };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Equal(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            set.Add("hello");
+            set.Add("world");
+            var input = new SetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithInt32()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(3);
+            set.Add(3);
+            var input = new SetData<int>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void RoundtripSet()
+        {
+            ISet<int> lookup = new HashSet<int>(new[] { 1, 2, 3 });
+
+            var clone = Serializer.DeepClone(lookup);
+
+            AssertEqual(lookup, clone);
+        }
+
+        [Fact]
+        public void TestNonEmptySetStrings()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(2);
+            var input = new NotEmptySetData(set);
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestDefaultCtorValueOverwritten()
+        {
+            var set = new HashSet<int>();
+            set.Add(3);
+            var input = new NotEmptySetData(set);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            Assert.True(clone.Data.Contains(new NotEmptySetData().Data.Single()));
+            Assert.True(clone.Data.Contains(3));
+        }
+
+        static void AssertEqual<T>(
+            ISet<T> expected,
+            ISet<T> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            foreach (var value in expected)
+                Assert.True(actual.Contains(value));
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    public class ReadOnlySetSerializerTests
+    {
+        [ProtoContract]
+        class ReadOnlySetData<T>
+        {
+            [ProtoMember(1)]
+            public IReadOnlySet<T> Data { get; init; }
+        }
+
+        [ProtoContract]
+        class NotEmptyReadOnlySetData
+        {
+            public NotEmptyReadOnlySetData()
+            {
+                Data = new HashSet<int>(new[] { 1 });
+            }
+
+            public NotEmptyReadOnlySetData(IReadOnlySet<int> data)
+            {
+                Data = data;
+            }
+
+            [ProtoMember(1)]
+            public IReadOnlySet<int> Data { get; }
+        }
+
+        [Fact]
+        public void TestEmptyNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            var input = new ReadOnlySetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Null(clone.Data);
+        }
+
+        [Fact]
+        public void TestNullNestedSetWithStrings()
+        {
+            var input = new ReadOnlySetData<string>() { Data = null };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            Assert.Equal(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithStrings()
+        {
+            var set = new HashSet<string>();
+            set.Add("hello");
+            set.Add("world");
+            var input = new ReadOnlySetData<string>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestNestedSetWithInt32()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(3);
+            set.Add(3);
+            var input = new ReadOnlySetData<int>() { Data = set };
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void RoundtripReadOnlySet()
+        {
+            IReadOnlySet<int> lookup = new HashSet<int>(new[] { 1, 2, 3 });
+
+            var clone = Serializer.DeepClone(lookup);
+
+            AssertEqual(lookup, clone);
+        }
+
+        [Fact]
+        public void TestNonEmptySetStrings()
+        {
+            var set = new HashSet<int>();
+            set.Add(1);
+            set.Add(2);
+            set.Add(2);
+            var input = new NotEmptyReadOnlySetData(set);
+
+            var clone = Serializer.DeepClone(input);
+
+            Assert.NotSame(input, clone);
+            AssertEqual(input.Data, clone.Data);
+        }
+
+        [Fact]
+        public void TestDefaultCtorValueOverwritten()
+        {
+            var set = new HashSet<int>();
+            set.Add(3);
+            var input = new NotEmptyReadOnlySetData(set);
+
+            var clone = Serializer.DeepClone(input);
+            Assert.NotSame(input, clone);
+            Assert.True(clone.Data.Contains(new NotEmptyReadOnlySetData().Data.Single()));
+            Assert.True(clone.Data.Contains(3));
+        }
+
+        static void AssertEqual<T>(
+            IReadOnlySet<T> expected,
+            IReadOnlySet<T> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            foreach (var value in expected)
+                Assert.True(actual.Contains(value));
+        }
+    }
+#endif
+}

--- a/src/protobuf-net.Test/Serializers/Collections.cs
+++ b/src/protobuf-net.Test/Serializers/Collections.cs
@@ -24,7 +24,7 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(IEnumerable<int>), typeof(EnumerableSerializer<IEnumerable<int>, IEnumerable<int>, int>))]
         [InlineData(typeof(IList<int>), typeof(EnumerableSerializer<IList<int>, IList<int>, int>))]
         [InlineData(typeof(Dictionary<int, string>), typeof(DictionarySerializer<int, string>))]
-        [InlineData(typeof(IDictionary<int, string>), typeof(DictionarySerializer<IDictionary<int,string>,int, string>))]
+        [InlineData(typeof(IDictionary<int, string>), typeof(DictionarySerializer<IDictionary<int, string>, int, string>))]
         [InlineData(typeof(IReadOnlyDictionary<int, string>), typeof(DictionaryOfIReadOnlyDictionarySerializer<int, string>))]
         [InlineData(typeof(ImmutableArray<int>), typeof(ImmutableArraySerializer<int>))]
         [InlineData(typeof(ImmutableDictionary<int, string>), typeof(ImmutableDictionarySerializer<int, string>))]
@@ -32,8 +32,8 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(IImmutableDictionary<int, string>), typeof(ImmutableIDictionarySerializer<int, string>))]
         [InlineData(typeof(Queue<int>), typeof(QueueSerializer<Queue<int>, int>))]
         [InlineData(typeof(Stack<int>), typeof(StackSerializer<Stack<int>, int>))]
-        [InlineData(typeof(CustomGenericCollection<int>), typeof(EnumerableSerializer<CustomGenericCollection<int>, CustomGenericCollection<int>,int>))]
-        [InlineData(typeof(CustomNonGenericCollection), typeof(EnumerableSerializer<CustomNonGenericCollection,CustomNonGenericCollection,bool>))]
+        [InlineData(typeof(CustomGenericCollection<int>), typeof(EnumerableSerializer<CustomGenericCollection<int>, CustomGenericCollection<int>, int>))]
+        [InlineData(typeof(CustomNonGenericCollection), typeof(EnumerableSerializer<CustomNonGenericCollection, CustomNonGenericCollection, bool>))]
         [InlineData(typeof(IReadOnlyCollection<string>), typeof(EnumerableSerializer<IReadOnlyCollection<string>, IReadOnlyCollection<string>, string>))]
         [InlineData(typeof(CustomNonGenericReadOnlyCollection), typeof(EnumerableSerializer<CustomNonGenericReadOnlyCollection, CustomNonGenericReadOnlyCollection, string>))]
         [InlineData(typeof(CustomGenericReadOnlyCollection<string>), typeof(EnumerableSerializer<CustomGenericReadOnlyCollection<string>, CustomGenericReadOnlyCollection<string>, string>))]
@@ -58,6 +58,11 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(Dictionary<int, int[]>), typeof(DictionarySerializer<int, int[]>))]
         [InlineData(typeof(Dictionary<int[], int[]>), typeof(DictionarySerializer<int[], int[]>))]
 
+        [InlineData(typeof(HashSet<int>), typeof(SetSerializer<HashSet<int>, int>))]
+        [InlineData(typeof(ISet<int>), typeof(SetSerializer<ISet<int>, int>))]
+#if NET6_0_OR_GREATER
+        [InlineData(typeof(IReadOnlySet<int>), typeof(ReadOnlySetSerializer<int>))]
+#endif
         public void TestWhatProviderWeGet(Type type, Type expected)
         {
             var provider = RepeatedSerializers.TryGetRepeatedProvider(type);
@@ -155,7 +160,8 @@ namespace ProtoBuf.Serializers
         public class CustomGenericCollection<T> : IList<T>
         {
             #region nope
-            T IList<T>.this[int index] {
+            T IList<T>.this[int index]
+            {
                 get => throw new NotImplementedException();
                 set => throw new NotImplementedException();
             }

--- a/src/protobuf-net/Serializers/RepeatedSerializers.cs
+++ b/src/protobuf-net/Serializers/RepeatedSerializers.cs
@@ -96,6 +96,11 @@ namespace ProtoBuf.Serializers
             Add(typeof(IReadOnlyDictionary<,>), (root, current, targs) => Resolve(typeof(MapSerializer), nameof(MapSerializer.CreateIReadOnlyDictionary), targs));
             Add(typeof(Queue<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateQueue), new[] { root, targs[0] }), false);
             Add(typeof(Stack<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateStack), new[] { root, targs[0] }), false);
+            Add(typeof(HashSet<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateSet), new[] { root, targs[0] }));
+            Add(typeof(ISet<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateSet), new[] { root, targs[0] }));
+#if NET6_0_OR_GREATER
+            Add(typeof(IReadOnlySet<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateReadOnySet), new[] { targs[0] }));
+#endif
 
             // fallbacks, these should be at the end
             Add(typeof(IEnumerable<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateEnumerable), new[] { root, targs[0] }), false);


### PR DESCRIPTION
Serializers that can handle `ISet<T>` and `IReadOnlySet<T>`.
Implementation is similar to `Dictionaries<TKey, TValue>` and its corresponding readonly and read-write interfaces.
As `IReadOnlySet<T>` is a new construct it is protected with `#if` for the given target framework.


Closes #197