### PR TITLE
Sort order of Serializer.GetProto<FooEnum>() as reported in #1102

### DIFF
--- a/docs/contract_first.md
+++ b/docs/contract_first.md
@@ -29,7 +29,7 @@ change the version/contents from the copy baked into the tool. Normally, standar
 
 ## Additional options
 
-Additional configuration options can be specified at attributes against each `<AdditionalFiles>` node, to fine tune your options; this is very similar to the options available with the command-line tools:
+Additional configuration options can be specified as attributes against each `<AdditionalFiles>` node, to fine tune your options; this is very similar to the options available with the command-line tools:
 
 - `ImportPaths` - specifies a comma delimited list of additional import locations; usually this isn't required, as schemas are resolved relative to each file; this is resolved relative to the current file, and
   can indicate "upwards" locations like `../..` - but the actual lookup happens *purely* within the virtual file system of `<AdditionalFiles>` nodes - it does not allow external file access

--- a/src/Examples/EnumTests.cs
+++ b/src/Examples/EnumTests.cs
@@ -69,8 +69,8 @@ message EnumFoo {
 }
 enum blah {
    B = 0;
-   A = -1;
    C = 1;
+   A = -1;
 }
 ", proto, ignoreLineEndingDifferences: true);
         }
@@ -93,8 +93,8 @@ message NonNullValues {
 }
 enum blah {
    B = 0;
-   A = -1;
    C = 1;
+   A = -1;
 }
 ", proto, ignoreLineEndingDifferences: true);
         }
@@ -178,8 +178,8 @@ message NullValues {
 }
 enum blah {
    B = 0;
-   A = -1;
    C = 1;
+   A = -1;
 }
 ", proto, ignoreLineEndingDifferences: true);
         }

--- a/src/Examples/EnumTests.cs
+++ b/src/Examples/EnumTests.cs
@@ -127,8 +127,8 @@ enum OutOfRangeEnum {
    A = 1;
    B = 4;
    C = 2147483647;
-   // D = 2147483648; // note: enums should be valid 32-bit integers
    E = -2147483647;
+   // D = 2147483648; // note: enums should be valid 32-bit integers
    // F = -2147483649; // note: enums should be valid 32-bit integers
 }
 */

--- a/src/protobuf-net.Test/Issues/Issue1102.cs
+++ b/src/protobuf-net.Test/Issues/Issue1102.cs
@@ -26,17 +26,17 @@ enum InRangeEnum {
    ZERO = 0; // proto3 requires a zero value as the first item (it can be named anything)
    A = 1;
    C = 2147483647;
-   B = -4;
    E = -2147483647;
+   B = -4;
 }
 /* for context only
 enum OutOfRangeEnum {
    ZERO = 0; // proto3 requires a zero value as the first item (it can be named anything)
    A = 1;
    C = 2147483647;
+   E = -2147483647;
    B = -4;
    // D = 2147483648; // note: enums should be valid 32-bit integers
-   E = -2147483647;
    // F = -2147483649; // note: enums should be valid 32-bit integers
 }
 */

--- a/src/protobuf-net.Test/Issues/Issue1102.cs
+++ b/src/protobuf-net.Test/Issues/Issue1102.cs
@@ -1,0 +1,120 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+#if !NET7_0_OR_GREATER
+    public class Issue1102
+    {
+        [Fact]
+        public void TestEnumOrderInProtoMatchesDefinitionOrder()
+        {
+            var letters = new string[] { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"};
+
+            MemberInfo[] foundList = typeof(FooEnum).GetMembers(BindingFlags.Public | BindingFlags.Static);
+
+            Assert.Equal(letters.Length, foundList.Length);
+
+            for (var i = 0; i < foundList.Length; i++)
+            {
+                var field = (FieldInfo)foundList[i];
+                Assert.Equal(letters[i], field.Name);
+            }
+
+            var proto = Serializer.GetProto<FooEnum>();
+
+            Assert.Equal(ExpectedOutput, proto, ignoreLineEndingDifferences: true);
+        }
+
+        private static string ExpectedOutput = @"syntax = ""proto3"";
+package ProtoBuf.Test.Issues;
+
+enum FooEnum {
+   A = 0;
+   B = 1;
+   C = 2;
+   D = 3;
+   E = 4;
+   F = 5;
+   G = 6;
+   H = 7;
+   I = 8;
+   J = 9;
+   K = 10;
+   L = 11;
+   M = 12;
+   N = 13;
+   O = 14;
+   P = 15;
+   Q = 16;
+   R = 17;
+   S = 18;
+   T = 19;
+   U = 20;
+   V = 21;
+   W = 22;
+   X = 23;
+   Y = 24;
+   Z = 25;
+}
+";
+
+        [ProtoContract]
+        public enum FooEnum
+        {
+            [ProtoEnum]
+            A,
+            [ProtoEnum]
+            B,
+            [ProtoEnum]
+            C,
+            [ProtoEnum]
+            D,
+            [ProtoEnum]
+            E,
+            [ProtoEnum]
+            F,
+            [ProtoEnum]
+            G,
+            [ProtoEnum]
+            H,
+            [ProtoEnum]
+            I,
+            [ProtoEnum]
+            J,
+            [ProtoEnum]
+            K,
+            [ProtoEnum]
+            L,
+            [ProtoEnum]
+            M,
+            [ProtoEnum]
+            N,
+            [ProtoEnum]
+            O,
+            [ProtoEnum]
+            P,
+            [ProtoEnum]
+            Q,
+            [ProtoEnum]
+            R,
+            [ProtoEnum]
+            S,
+            [ProtoEnum]
+            T,
+            [ProtoEnum]
+            U,
+            [ProtoEnum]
+            V,
+            [ProtoEnum]
+            W,
+            [ProtoEnum]
+            X,
+            [ProtoEnum]
+            Y,
+            [ProtoEnum]
+            Z
+        }
+    }
+#endif
+}

--- a/src/protobuf-net.Test/Issues/Issue1102.cs
+++ b/src/protobuf-net.Test/Issues/Issue1102.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace ProtoBuf.Test.Issues
 {
-#if !NET7_0_OR_GREATER
     public class Issue1102
     {
         [Fact]
@@ -116,5 +115,4 @@ enum FooEnum {
             Z
         }
     }
-#endif
 }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -125,17 +125,15 @@ namespace ProtoBuf.Meta
             var thisValue = TryGetInt32();
             var otherValue = other.TryGetInt32();
 
-            if (!thisValue.HasValue || !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue && !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue) return 1;
+            if (!otherValue.HasValue) return -1;
 
-            if (thisValue.Value < 0 && otherValue.Value < 0)
-            { 
-                return otherValue.Value.CompareTo(thisValue.Value);
-            }
-            if (thisValue.Value < 0)
+            if (thisValue.Value < 0 && otherValue.Value >= 0)
             {
                 return 1;
             }
-            if (otherValue.Value < 0)
+            if (otherValue.Value < 0 && thisValue.Value >= 0)
             {
                 return -1;
             }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -125,9 +125,17 @@ namespace ProtoBuf.Meta
             var thisValue = TryGetInt32();
             var otherValue = other.TryGetInt32();
 
-            if (!thisValue.HasValue && !otherValue.HasValue) return 0;
-            if (!thisValue.HasValue && otherValue.HasValue) return -1;
-            if (thisValue.HasValue && !otherValue.HasValue) return 1;
+            if (!thisValue.HasValue || !otherValue.HasValue) return 0;
+
+            if (thisValue.Value < 0 && otherValue.Value < 0)
+            { 
+                return otherValue.Value.CompareTo(thisValue.Value);
+            }
+            if ((thisValue.Value < 0 && otherValue.Value >= 0) || (thisValue.Value >= 0 && otherValue.Value < 0))
+            {
+                return 1;
+            }
+
             return thisValue.Value.CompareTo(otherValue.Value);
         }
     }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -131,9 +131,13 @@ namespace ProtoBuf.Meta
             { 
                 return otherValue.Value.CompareTo(thisValue.Value);
             }
-            if ((thisValue.Value < 0 && otherValue.Value >= 0) || (thisValue.Value >= 0 && otherValue.Value < 0))
+            if (thisValue.Value < 0)
             {
                 return 1;
+            }
+            if (otherValue.Value < 0)
+            {
+                return -1;
             }
 
             return thisValue.Value.CompareTo(otherValue.Value);

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -125,7 +125,9 @@ namespace ProtoBuf.Meta
             var thisValue = TryGetInt32();
             var otherValue = other.TryGetInt32();
 
-            if(!thisValue.HasValue && !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue && !otherValue.HasValue) return 0;
+            if (!thisValue.HasValue && otherValue.HasValue) return -1;
+            if (thisValue.HasValue && !otherValue.HasValue) return 1;
             return thisValue.Value.CompareTo(otherValue.Value);
         }
     }

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -8,7 +8,7 @@ namespace ProtoBuf.Meta
     /// Describes a named constant integer, i.e. an enum value
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
-    public readonly struct EnumMember : IEquatable<EnumMember>
+    public readonly struct EnumMember : IEquatable<EnumMember>, IComparable<EnumMember>
     {
         /// <summary>
         /// Gets the declared name of this enum member
@@ -118,6 +118,15 @@ namespace ProtoBuf.Meta
         {
             if (string.IsNullOrWhiteSpace(Name))
                 ThrowHelper.ThrowInvalidOperationException("All enum declarations must have valid names");
+        }
+
+        public int CompareTo(EnumMember other)
+        {
+            var thisValue = TryGetInt32();
+            var otherValue = other.TryGetInt32();
+
+            if(!thisValue.HasValue && !otherValue.HasValue) return 0;
+            return thisValue.Value.CompareTo(otherValue.Value);
         }
     }
 }

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1720,7 +1720,7 @@ namespace ProtoBuf.Meta
         public EnumMember[] GetEnumValues()
         {
             if (!HasEnums) return Array.Empty<EnumMember>();
-            // todo: there might be a need to sort enums based on proto version...
+
             var arr = Enums.ToArray();
             Array.Sort(arr);
             return arr;
@@ -2028,9 +2028,7 @@ namespace ProtoBuf.Meta
             }
             else if (Type.IsEnum)
             {
-                // todo: potentially pass in syntax here or use a factory to create a comparer?
                 var enums = GetEnumValues();
-
 
                 bool allValid = IsValidEnum(enums);
                 if (!allValid) NewLine(builder, indent).Append("/* for context only");

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1720,7 +1720,7 @@ namespace ProtoBuf.Meta
         public EnumMember[] GetEnumValues()
         {
             if (!HasEnums) return Array.Empty<EnumMember>();
-
+            // todo: there might be a need to sort enums based on proto version...
             var arr = Enums.ToArray();
             Array.Sort(arr);
             return arr;
@@ -2028,6 +2028,7 @@ namespace ProtoBuf.Meta
             }
             else if (Type.IsEnum)
             {
+                // todo: potentially pass in syntax here or use a factory to create a comparer?
                 var enums = GetEnumValues();
 
 

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1720,7 +1720,12 @@ namespace ProtoBuf.Meta
         public EnumMember[] GetEnumValues()
         {
             if (!HasEnums) return Array.Empty<EnumMember>();
-            return Enums.ToArray();
+
+            var arr = Enums.ToArray();
+#if !NET7_0_OR_GREATER
+            Array.Sort(arr);
+#endif
+            return arr;
         }
 
         /// <summary>

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1722,9 +1722,7 @@ namespace ProtoBuf.Meta
             if (!HasEnums) return Array.Empty<EnumMember>();
 
             var arr = Enums.ToArray();
-#if !NET7_0_OR_GREATER
             Array.Sort(arr);
-#endif
             return arr;
         }
 


### PR DESCRIPTION
Hi @mgravell, addition of value sorting logic for enums in answer to https://github.com/protobuf-net/protobuf-net/issues/1102. Also, an extremely minor spelling change for contract_first.md.

The changes will result in an EnumMember array being sorted by value; from 0 to int max and then negative int max to -1. If HasValue returns false (or the value is outside the range of an int; which returns false) the comparison returns zero so that order is unchanged; the values are later removed/commented via existing logic.