### PR TITLE
Add SubtypesCount public get-only property to the MetaType object

### DIFF
--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -197,6 +197,11 @@ namespace ProtoBuf.Meta
         public bool HasSubtypes => _subTypes is not null && _subTypes.Count != 0;
 
         /// <summary>
+        /// Returns the number of defined subtypes on the current type
+        /// </summary>
+        public int SubtypesCount => _subTypes?.Count ?? 0;
+
+        /// <summary>
         /// Returns the set of callbacks defined for this type
         /// </summary>
         public CallbackSet Callbacks => callbacks ??= new CallbackSet(this);


### PR DESCRIPTION
Hello there.

While I was implementing a way for automatic model building for protobuf-net, I've ran into a need to apply lots `AddSubType()` in my type hierarchy, and since the most elegant way to add a subtype (the method of which requires us to provide a field number) is as follows:

```cs
baseType.AddSubType(baseType.GetSubtypes().Length + 1, type)
```

Then it becomes obvious that calling `GetSubtypes()` (and it also sorts its array under the hood) only to get total count so that a field number could be sequentially provided is not an ideal way of doing so.

While I would still prefer **not** counting the subtypes myself, I see an easy way out — a get-only property on the `MetaType`, which is lightweight and provides the user with the defined subtypes count.