### PR TITLE
V2 - Fix memory leak with ProtoReader context and Added DeserializeWithLengthPrefix methods that support a SerializationContext

### DIFF
--- a/src/protobuf-net/Meta/TypeModel.cs
+++ b/src/protobuf-net/Meta/TypeModel.cs
@@ -304,7 +304,25 @@ namespace ProtoBuf.Meta
         /// <returns>The updated instance; this may be different to the instance argument if
         /// either the original instance was null, or the stream defines a known sub-type of the
         /// original instance.</returns>
-        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, Serializer.TypeResolver resolver, out long bytesRead) => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out bytesRead, out bool haveObject, null);
+        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, Serializer.TypeResolver resolver, out long bytesRead) => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out bytesRead, out bool _, null);
+
+        /// <summary>
+        /// Applies a protocol-buffer stream to an existing instance (or null), using length-prefixed
+        /// data - useful with network IO.
+        /// </summary>
+        /// <param name="type">The type being merged.</param>
+        /// <param name="value">The existing instance to be modified (can be null).</param>
+        /// <param name="source">The binary stream to apply to the instance (cannot be null).</param>
+        /// <param name="style">How to encode the length prefix.</param>
+        /// <param name="expectedField">The tag used as a prefix to each record (only used with base-128 style prefixes).</param>
+        /// <param name="resolver">Used to resolve types on a per-field basis.</param>
+        /// <param name="bytesRead">Returns the number of bytes consumed by this operation (includes length-prefix overheads and any skipped data).</param>
+        /// <param name="context">Additional information about this serialization operation.</param>
+        /// <returns>The updated instance; this may be different to the instance argument if
+        /// either the original instance was null, or the stream defines a known sub-type of the
+        /// original instance.</returns>
+        public object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, Serializer.TypeResolver resolver, out long bytesRead, SerializationContext context)
+            => DeserializeWithLengthPrefix(source, value, type, style, expectedField, resolver, out bytesRead, out bool _, context);
 
         private object DeserializeWithLengthPrefix(Stream source, object value, Type type, PrefixStyle style, int expectedField, Serializer.TypeResolver resolver, out long bytesRead, out bool haveObject, SerializationContext context)
         {

--- a/src/protobuf-net/ProtoReader.cs
+++ b/src/protobuf-net/ProtoReader.cs
@@ -134,6 +134,7 @@ namespace ProtoBuf
                 stringInterner = null;
             }
             if (netCache != null) netCache.Clear();
+            context = null; // fix memory leak.
         }
         internal int TryReadUInt32VariantWithoutMoving(bool trimNegative, out uint value)
         {


### PR DESCRIPTION
Fix for issues https://github.com/protobuf-net/protobuf-net/issues/908 and https://github.com/protobuf-net/protobuf-net/issues/1121