### PR TITLE
#1149 Support deprecated options

### DIFF
--- a/src/protobuf-net.Test/Issues/Issue1149.cs
+++ b/src/protobuf-net.Test/Issues/Issue1149.cs
@@ -1,0 +1,83 @@
+using System;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+#pragma warning disable CS0612 // Type or member is obsolete
+    public sealed class Issue1149
+    {
+        [Fact]
+        public void GenerateProtoWithDeprecatedOption()
+        {
+            const string expected = @"syntax = ""proto3"";
+package DefaultPackage;
+
+message SomeClass {
+   option deprecated = true;
+   int32 SomeProperty = 1;
+}
+enum SomeEnum {
+   option deprecated = true;
+   Zero = 0;
+   One = 1;
+   Two = 2;
+}
+message SomeOtherClass {
+   string SomeOtherProperty = 1 [deprecated = true];
+}
+enum SomeOtherEnum {
+   Zero = 0;
+   One = 1;
+   Two = 2;
+   Three = 3 [deprecated = true];
+}
+";
+
+            var actual = Serializer.GetProto(new SchemaGenerationOptions
+            {
+                Syntax = ProtoSyntax.Proto3,
+                Package = "DefaultPackage",
+                Types = { typeof(SomeClass), typeof(SomeOtherClass), typeof(SomeEnum), typeof(SomeOtherEnum) },
+            });
+
+            Assert.Equal(expected, actual);
+        }
+
+        [ProtoContract]
+        [Obsolete]
+        public class SomeClass
+        {
+            [ProtoMember(tag: 1)]
+            public int SomeProperty { get; set; }
+        }
+
+        [ProtoContract]
+        public class SomeOtherClass
+        {
+            [ProtoMember(tag: 1)]
+            [Obsolete]
+            public string SomeOtherProperty { get; set; }
+        }
+
+        [ProtoContract]
+        [Obsolete]
+        public enum SomeEnum
+        {
+            Zero,
+            One,
+            Two,
+        }
+
+        [ProtoContract]
+        public enum SomeOtherEnum
+        {
+            Zero,
+            One,
+            Two,
+            [Obsolete]
+            Three,
+        }
+    }
+#pragma warning restore CS0612 // Type or member is obsolete
+}

--- a/src/protobuf-net/Meta/EnumMember.cs
+++ b/src/protobuf-net/Meta/EnumMember.cs
@@ -21,13 +21,19 @@ namespace ProtoBuf.Meta
         public object Value { get; }
 
         /// <summary>
+        /// Gets the value indicating whether this enum member is obsolete
+        /// </summary>
+        public bool IsObsolete { get; }
+
+        /// <summary>
         /// Create a new named enum value; the value can be of the expected
         /// enum type, or an appropriate boxed enum value
         /// </summary>
-        public EnumMember(object value, string name)
+        public EnumMember(object value, string name, bool isObsolete = false)
         {
             Name = name;
             Value = value;
+            IsObsolete = isObsolete;
         }
 
         internal bool HasValue => Value is not null && !string.IsNullOrWhiteSpace(Name);


### PR DESCRIPTION
- Updated `MetaType` to check if `System.ObsoleteAttribute` exists on type, proprty, or enum member to add deprecated option while generating proto.
- Added unit test to reproduce the issue.

Closes https://github.com/protobuf-net/protobuf-net/issues/1149