### PR TITLE
Allows the [Description] feature to be added, with comments when gene…

### DIFF
--- a/src/protobuf-net.Core/Meta/Service.cs
+++ b/src/protobuf-net.Core/Meta/Service.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ProtoBuf.Meta
 {
@@ -11,6 +12,11 @@ namespace ProtoBuf.Meta
         /// The name of the service.
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the service.
+        /// </summary>
+        public string Description { get; set; }
 
         /// <summary>
         /// The methods available on the service.

--- a/src/protobuf-net.Core/Meta/ServiceMethod.cs
+++ b/src/protobuf-net.Core/Meta/ServiceMethod.cs
@@ -13,6 +13,11 @@ namespace ProtoBuf.Meta
         public string Name { get; set; }
 
         /// <summary>
+        /// The description of the method.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
         /// The type sent by the client.
         /// </summary>
         public Type InputType { get; set; } = typeof(Empty);

--- a/src/protobuf-net.Test/ServiceSchemas.cs
+++ b/src/protobuf-net.Test/ServiceSchemas.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using Xunit;
 using Xunit.Abstractions;
@@ -62,6 +63,64 @@ service myService {
    rpc unary (.google.protobuf.Empty) returns (.google.protobuf.Timestamp);
    rpc clientStreaming (stream Foo) returns (Foo);
    rpc serverStreaming (.google.protobuf.Duration) returns (stream Foo);
+   rpc fullDuplex (stream Foo) returns (stream Foo);
+}
+", schema, ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public void GenerateDescriptionServiceSchema()
+        {
+            var service = new Service
+            {
+                Name = "myService",
+                Description = "myService",
+                Methods =
+                {
+                    new ServiceMethod { Name = "unary", Description = "unary", InputType = typeof(Empty), OutputType = typeof(Timestamp) },
+                    new ServiceMethod { Name = "clientStreaming", Description = "clientStreaming", InputType = typeof(Foo), OutputType =typeof(Foo), ClientStreaming = true },
+                    new ServiceMethod { Name = "serverStreaming", Description = "serverStreaming", InputType = typeof(Duration), OutputType =typeof(Foo), ServerStreaming = true },
+                    new ServiceMethod { Name = "fullDuplex", Description = "fullDuplex", InputType = typeof(Foo), OutputType = typeof(Foo), ClientStreaming = true, ServerStreaming = true },
+                }
+            };
+
+            var schema = RuntimeTypeModel.Default.GetSchema(
+                new SchemaGenerationOptions
+                {
+                    Syntax = ProtoSyntax.Proto3,
+                    Flags = SchemaGenerationFlags.PreserveSubType,
+                    Package = "mypackage",
+                    Services = { service }
+                }
+            );
+            Log(schema);
+            Assert.Equal(@"syntax = ""proto3"";
+package mypackage;
+import ""google/protobuf/duration.proto"";
+import ""google/protobuf/empty.proto"";
+import ""google/protobuf/timestamp.proto"";
+import ""protobuf-net/protogen.proto""; // custom protobuf-net options
+
+message Bar {
+   string Value = 1;
+}
+message Foo {
+   .google.protobuf.Timestamp When = 1;
+   string Id = 2; // default value could not be applied: 00000000-0000-0000-0000-000000000000
+   oneof subtype {
+      option (.protobuf_net.oneofopt).isSubType = true;
+      Bar Bar = 42;
+   }
+}
+// myService
+service myService {
+   // unary
+   rpc unary (.google.protobuf.Empty) returns (.google.protobuf.Timestamp);
+   // clientStreaming
+   rpc clientStreaming (stream Foo) returns (Foo);
+   // serverStreaming
+   rpc serverStreaming (.google.protobuf.Duration) returns (stream Foo);
+   // fullDuplex
    rpc fullDuplex (stream Foo) returns (stream Foo);
 }
 ", schema, ignoreLineEndingDifferences: true);
@@ -133,6 +192,98 @@ service ConferencesService {
 
             [DataMember(Order = 2)]
             public string Title { get; set; }
+        }
+
+        [Fact]
+        public void GenerateDescriptionMessageScheema()
+        {
+            var service = new Service
+            {
+                Name = "BookService",
+                Description = "BookService",
+                Methods =
+                {
+                    new ServiceMethod { Name = "GetBookInfo", Description= "GetBookInfo", InputType = typeof(Empty), OutputType = typeof(BookDescription) },
+                    new ServiceMethod { Name = "GetBookTypes", Description= "GetBookTypes", InputType = typeof(Empty), OutputType = typeof(BookTypeDescription) }
+                }
+            };
+
+            var schema = RuntimeTypeModel.Default.GetSchema(
+                new SchemaGenerationOptions
+                {
+                    Syntax = ProtoSyntax.Proto3,
+                    Package = "protobuf_net.Grpc.Reflection.Test",
+                    Services = { service },
+                    Types = { typeof(BookType) }
+                }
+            );
+            Log(schema);
+            Assert.Equal(@"syntax = ""proto3"";
+package protobuf_net.Grpc.Reflection.Test;
+import ""google/protobuf/empty.proto"";
+
+// BookDescription
+message BookDescription {
+   // ID
+   int32 ID = 1;
+   // Title
+   string Title = 2;
+}
+// BookType
+enum BookType {
+   Biology = 0;
+   Chemistry = 1;
+}
+// BookDescription
+message BookTypeDescription {
+}
+// BookService
+service BookService {
+   // GetBookInfo
+   rpc GetBookInfo (.google.protobuf.Empty) returns (BookDescription);
+   // GetBookTypes
+   rpc GetBookTypes (.google.protobuf.Empty) returns (BookTypeDescription);
+}
+", schema, ignoreLineEndingDifferences: true);
+        }
+
+        [Description("BookDescription")]
+        [DataContract]
+        public class BookDescription
+        {
+            [Description("ID")]
+            [DataMember(Order = 1)]
+            public int ID { get; set; }
+
+            [Description("Title")]
+            [DataMember(Order = 2)]
+            public string Title { get; set; }
+
+            [Description("Tags")]
+            public Dictionary<int, string> Tags { get; set; }
+
+            [Description("PriceChanges")]
+            public int[] PriceChanges { get; set; }
+            [Description("Type")]
+            public BookType Type { get; set; }
+        }
+        [Description("BookDescription")]
+        [DataContract]
+        public class BookTypeDescription
+        {
+            [Description("Type")]
+            public BookType Type { get; set; }
+        }
+
+        [Description("BookType")]
+        [DataContract]
+        public enum BookType
+        {
+            [Description("Biology")]
+            Biology,
+
+            [Description("Biology")]
+            Chemistry
         }
     }
 }

--- a/src/protobuf-net.Test/ServiceSchemas.cs
+++ b/src/protobuf-net.Test/ServiceSchemas.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf.Meta;
+using ProtoBuf.Meta;
 using ProtoBuf.WellKnownTypes;
 using System;
 using System.Collections;
@@ -228,6 +228,11 @@ message BookDescription {
    int32 ID = 1;
    // Title
    string Title = 2;
+   map<int32,string> Tags = 3;
+   // PriceChanges
+   repeated int32 PriceChanges = 4 [packed = false];
+   // Type
+   BookType Type = 5;
 }
 // BookType
 enum BookType {
@@ -236,6 +241,8 @@ enum BookType {
 }
 // BookDescription
 message BookTypeDescription {
+   // Type
+   BookType Type = 1;
 }
 // BookService
 service BookService {
@@ -260,18 +267,24 @@ service BookService {
             public string Title { get; set; }
 
             [Description("Tags")]
+            [DataMember(Order = 3)]
             public Dictionary<int, string> Tags { get; set; }
 
             [Description("PriceChanges")]
+            [DataMember(Order = 4)]
             public int[] PriceChanges { get; set; }
+
             [Description("Type")]
+            [DataMember(Order = 5)]
             public BookType Type { get; set; }
         }
+
         [Description("BookDescription")]
         [DataContract]
         public class BookTypeDescription
         {
             [Description("Type")]
+            [DataMember(Order = 1)]
             public BookType Type { get; set; }
         }
 
@@ -279,9 +292,11 @@ service BookService {
         [DataContract]
         public enum BookType
         {
+            [DataMember(Order = 1)]
             [Description("Biology")]
             Biology,
 
+            [DataMember(Order = 2)]
             [Description("Biology")]
             Chemistry
         }


### PR DESCRIPTION
For model class:

```csharp
        [Description("BookDescription")]
        [DataContract]
        public class BookDescription
        {
            [Description("ID")]
            [DataMember(Order = 1)]
            public int ID { get; set; }

            [Description("Title")]
            [DataMember(Order = 2)]
            public string Title { get; set; }

            [Description("Tags")]
            public Dictionary<int, string> Tags { get; set; }

            [Description("PriceChanges")]
            public int[] PriceChanges { get; set; }
            [Description("Type")]
            public BookType Type { get; set; }
        }
```
Build example:
```csharp
syntax = ""proto3"";
package protobuf_net.Grpc.Reflection.Test;
import ""google/protobuf/empty.proto"";

// BookDescription
message BookDescription {
   // ID
   int32 ID = 1;
   // Title
   string Title = 2;
}
// BookType
enum BookType {
   Biology = 0;
   Chemistry = 1;
}
// BookDescription
message BookTypeDescription {
}
// BookService
service BookService {
   // GetBookInfo
   rpc GetBookInfo (.google.protobuf.Empty) returns (BookDescription);
   // GetBookTypes
   rpc GetBookTypes (.google.protobuf.Empty) returns (BookTypeDescription);
}
```