### PR TITLE
fix(ImmutableArray serializer): Serializing uninitialized ImmutableArray throws NullReferenceException

### DIFF
--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf.Internal;
+using ProtoBuf.Internal;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -80,7 +80,7 @@ namespace ProtoBuf.Serializers
 #endif
         );
 
-        protected override int TryGetCount(ImmutableArray<T> values) => (values.IsDefault || values.IsEmpty) ? 0 : values.Length;
+        protected override int TryGetCount(ImmutableArray<T> values) => values.IsDefaultOrEmpty ? 0 : values.Length;
 
         internal override long Measure(ImmutableArray<T> values, IMeasuringSerializer<T> serializer, ISerializationContext context, WireType wireType)
         {

--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.Immutable.cs
@@ -80,7 +80,7 @@ namespace ProtoBuf.Serializers
 #endif
         );
 
-        protected override int TryGetCount(ImmutableArray<T> values) => values.IsEmpty ? 0 : values.Length;
+        protected override int TryGetCount(ImmutableArray<T> values) => (values.IsDefault || values.IsEmpty) ? 0 : values.Length;
 
         internal override long Measure(ImmutableArray<T> values, IMeasuringSerializer<T> serializer, ISerializationContext context, WireType wireType)
         {

--- a/src/protobuf-net.Test/Issues/Immutables.cs
+++ b/src/protobuf-net.Test/Issues/Immutables.cs
@@ -46,6 +46,26 @@ namespace ProtoBuf.Issues
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public void CanSerializeUninitializedImmutableArray(bool autoCompile)
+        {
+            var testClass = new UninitializedImmutableArrayTestClass();
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = autoCompile;
+
+            UninitializedImmutableArrayTestClass testClassClone;
+            using (var ms = new MemoryStream())
+            {
+                model.Serialize(ms, testClass);
+                ms.Position = 0;
+                testClassClone = model.Deserialize<UninitializedImmutableArrayTestClass>(ms);
+            }
+
+            Assert.Equal(testClass.Array, testClassClone.Array);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void CanDeserialiseImmutableList(bool autoCompile)
         {
             var testClass = new ImmutableListTestClass(ImmutableList.Create("a", "b", "c"));
@@ -172,6 +192,13 @@ namespace ProtoBuf.Issues
 
             [ProtoMember(1)]
             public ImmutableArray<string> Array {get;}
+        }
+
+        [ProtoContract]
+        public class UninitializedImmutableArrayTestClass
+        {
+            [ProtoMember(1)]
+            public ImmutableArray<int> Array { get; }
         }
 
         [ProtoContract(SkipConstructor = true)]


### PR DESCRIPTION
With this change, an uninitialized ImmutableArray serializes the same as an empty array - nothing is written.

This doesn't fix #1181, but I discovered it while investigating #1181.
