### PR TITLE
Cleanup package dependencies

### DIFF
--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CS1591;CA1822</NoWarn>
     <DefineConstants>$(DefineConstants);NEW_API</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)'=='net472'">$(DefineConstants);WRITE_DLL</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='net8.0'">$(DefineConstants);INTRINSICS</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)'!='net472'">$(DefineConstants);INTRINSICS</DefineConstants>
     <RootNamespace>Benchmark</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/BuildToolsUnitTests/BuildToolsUnitTests.csproj
+++ b/src/BuildToolsUnitTests/BuildToolsUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>BuildToolsUnitTests</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Nullable>enable</Nullable>

--- a/src/protobuf-net.AspNetCore/protobuf-net.AspNetCore.csproj
+++ b/src/protobuf-net.AspNetCore/protobuf-net.AspNetCore.csproj
@@ -12,6 +12,5 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\protobuf-net\protobuf-net.csproj" />
-    <PackageReference Include="System.IO.Pipelines" />
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.Core/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net.Core/Properties/AssemblyInfo.cs
@@ -36,6 +36,12 @@ using System.Runtime.CompilerServices;
     + "0815a096e4483605139a32a76ec2fef196507487329c12047bf6a68bca8ee9354155f4d01daf6e"
     + "ec5ff6bc")]
 
-#if PLAT_SKIP_LOCALS_INIT
 [module: SkipLocalsInit]
+
+#if !NET8_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Module, Inherited = false)]
+    internal sealed class SkipLocalsInitAttribute : Attribute;
+}
 #endif

--- a/src/protobuf-net.Core/protobuf-net.Core.csproj
+++ b/src/protobuf-net.Core/protobuf-net.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="System.Memory" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net7.0'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <!-- we use the AddRange span API from v7 -->
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
@@ -23,8 +23,8 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
     <DefineConstants>$(DefineConstants);PLAT_ISREF;PLAT_SPAN_OVERLOADS;PLAT_CONCURRENT_CLEAR</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <DefineConstants>$(DefineConstants);PLAT_ISREF;PLAT_SPAN_OVERLOADS;PLAT_INTRINSICS;PLAT_AGGRESSIVE_OPTIMIZE;PLAT_CONCURRENT_CLEAR;PLAT_SKIP_LOCALS_INIT;PLAT_UTF8_STRING;PLAT_DYNAMIC_ACCESS_ATTR</DefineConstants>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <DefineConstants>$(DefineConstants);PLAT_ISREF;PLAT_SPAN_OVERLOADS;PLAT_INTRINSICS;PLAT_AGGRESSIVE_OPTIMIZE;PLAT_CONCURRENT_CLEAR;PLAT_UTF8_STRING;PLAT_DYNAMIC_ACCESS_ATTR</DefineConstants>
   </PropertyGroup>
 
 <!--
@@ -35,7 +35,6 @@ PLAT_INTRINSICS           : make use of CPU intrinsics
 PLAT_AGGRESSIVE_OPTIMIZE  : use MethodImplOptions.AggressiveOptimization appropriate
 FEAT_DYNAMIC_REF          : whether the dynamic type / reference-tracking features are enabled
 PLAT_CONCURRENT_CLEAR     : whether the concurrent collections have the necessary Clear method
-PLAT_SKIP_LOCALS_INIT     : whether we can avoid ".locals init"
 PLAT_DYNAMIC_ACCESS_ATTR  : whether the runtime defines DynamicallyAccessedMembersAttribute et al
 TRACK_USAGE               : count writer activity to check disposal/re-use is correct
 -->

--- a/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
+++ b/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.FSharp</RootNamespace>
   </PropertyGroup>
 

--- a/src/protobuf-net.MessagePipes/protobuf-net.MessagePipes.csproj
+++ b/src/protobuf-net.MessagePipes/protobuf-net.MessagePipes.csproj
@@ -12,12 +12,15 @@
 
   <ItemGroup>
     <PackageReference Include="Pipelines.Sockets.Unofficial" />
-    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
     <PackageReference Include="System.IO.Pipelines" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.ServiceModel/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net.ServiceModel/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿
 using System.Runtime.CompilerServices;
 
-#if PLAT_SKIP_LOCALS_INIT
 [module: SkipLocalsInit]
-#endif

--- a/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
+++ b/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
@@ -14,10 +14,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
     <DefineConstants>$(DefineConstants);FEAT_SERVICECONFIGMODEL</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <DefineConstants>$(DefineConstants);PLAT_SKIP_LOCALS_INIT</DefineConstants>
-  </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Configuration" />

--- a/src/protobuf-net/Compiler/CompilerContextScope.cs
+++ b/src/protobuf-net/Compiler/CompilerContextScope.cs
@@ -148,7 +148,7 @@ namespace ProtoBuf.Compiler
                     il.Emit(OpCodes.Ret);
                 }
 
-#if PLAT_NO_EMITDLL
+#if NETSTANDARD2_0
                 Type finalType = type.CreateTypeInfo().AsType();
 #else
                 Type finalType = type.CreateType();

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1386,7 +1386,7 @@ namespace ProtoBuf.Meta
             WriteSerializers(scope, serviceType);
             WriteEnumsAndProxies(serviceType);
 
-#if PLAT_NO_EMITDLL
+#if NETSTANDARD2_0
             var finalServiceType = serviceType.CreateTypeInfo().AsType();
 #else
             var finalServiceType = serviceType.CreateType();
@@ -1397,7 +1397,7 @@ namespace ProtoBuf.Meta
 
             WriteConstructorsAndOverrides(modelType, finalServiceType);
 
-#if PLAT_NO_EMITDLL
+#if NETSTANDARD2_0
             Type finalType = modelType.CreateTypeInfo().AsType();
 #else
             Type finalType = modelType.CreateType();

--- a/src/protobuf-net/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net/Properties/AssemblyInfo.cs
@@ -60,6 +60,4 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(CompatibilityLevelAttribute))]
 [assembly: TypeForwardedTo(typeof(ProtoSyntax))]
 
-#if PLAT_SKIP_LOCALS_INIT
 [module: SkipLocalsInit]
-#endif

--- a/src/protobuf-net/protobuf-net.csproj
+++ b/src/protobuf-net/protobuf-net.csproj
@@ -10,14 +10,8 @@
   </PropertyGroup>
   
   <!-- define configuration per-platform -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net462'">
     <DefineConstants>$(DefineConstants);PLAT_NO_EMITDLL</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <DefineConstants>$(DefineConstants);PLAT_NO_EMITDLL</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <DefineConstants>$(DefineConstants);PLAT_NO_EMITDLL;PLAT_SKIP_LOCALS_INIT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
- Cleanup package dependencies.
- Enable `SkipLocalsInit` on all platforms.
- Update a few `TargetFramework` values.