### PR TITLE
Null dereference in error message when stub is null

### DIFF
--- a/src/protobuf-net/Internal/Serializers/RepeatedDecorator.cs
+++ b/src/protobuf-net/Internal/Serializers/RepeatedDecorator.cs
@@ -10,7 +10,7 @@ namespace ProtoBuf.Internal.Serializers
     {
         public static IRuntimeProtoSerializerNode Create(RepeatedSerializerStub stub, int fieldNumber, SerializerFeatures features, CompatibilityLevel compatibilityLevel, DataFormat dataFormat)
         {
-            if (stub is null) ThrowHelper.ThrowArgumentNullException(nameof(stub), $"No suitable repeated serializer resolved for {stub.ForType.NormalizeName()}");
+            if (stub is null) ThrowHelper.ThrowArgumentNullException(nameof(stub), $"No suitable repeated serializer resolved for stub");
             _ = stub.Serializer; // primes and validates
             return (IRuntimeProtoSerializerNode)Activator.CreateInstance(typeof(RepeatedDecorator<,>).MakeGenericType(stub.ForType, stub.ItemType),
                 new object[] { fieldNumber, features, compatibilityLevel, dataFormat, stub });


### PR DESCRIPTION
In the following code, there's a potential null dereference when constructing the message for ThrowArgumentNullException:
`if (stub is null) ThrowHelper.ThrowArgumentNullException(nameof(stub), $"No suitable repeated serializer resolved for {stub.ForType.NormalizeName()}");`
Code: https://github.com/protobuf-net/protobuf-net/blob/3.2.52/src/protobuf-net/Internal/Serializers/RepeatedDecorator.cs#L13


When **stub** is **null**, the code tries to access **stub**.ForType to include in the message, which will cause a null dereference exception before the ThrowArgumentNullException would be executed.

