### PR TITLE
Don't use [SkipLocalsInit] on ns2.*

### DIFF
--- a/src/protobuf-net.Core/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net.Core/Properties/AssemblyInfo.cs
@@ -36,9 +36,11 @@ using System.Runtime.CompilerServices;
     + "0815a096e4483605139a32a76ec2fef196507487329c12047bf6a68bca8ee9354155f4d01daf6e"
     + "ec5ff6bc")]
 
+#if !NETSTANDARD2_0_OR_GREATER // see #1214
 [module: SkipLocalsInit]
+#endif
 
-#if !NET8_0_OR_GREATER
+#if !NET8_0_OR_GREATER && !NETSTANDARD2_0_OR_GREATER
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Module, Inherited = false)]

--- a/src/protobuf-net.ServiceModel/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net.ServiceModel/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
 ﻿
 using System.Runtime.CompilerServices;
 
+#if !NETSTANDARD2_0_OR_GREATER // see #1214
 [module: SkipLocalsInit]
+#endif

--- a/src/protobuf-net/Properties/AssemblyInfo.cs
+++ b/src/protobuf-net/Properties/AssemblyInfo.cs
@@ -60,4 +60,6 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(CompatibilityLevelAttribute))]
 [assembly: TypeForwardedTo(typeof(ProtoSyntax))]
 
+#if !NETSTANDARD2_0_OR_GREATER // see #1214
 [module: SkipLocalsInit]
+#endif


### PR DESCRIPTION
fixes #1214