### PR TITLE
Add public GetSurrogateOwnerType API for stub-surrogate round-trip

### DIFF
--- a/src/protobuf-net.Test/Issues/EyeshotEntityDataRefTests.cs
+++ b/src/protobuf-net.Test/Issues/EyeshotEntityDataRefTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using ProtoBuf;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    /// <summary>
+    /// Reproduces Eyeshot SerializeEntityToEntityData: shared-instance preservation across
+    /// nested Model.Serialize/Deserialize calls, with a custom ReferenceId field and
+    /// a thread-local cache that dedups via RefId (Dictionary Equals/GetHashCode overrides).
+    ///
+    /// v2 (Eyeshot 2025) passed. v3 inheritance+surrogate chain must preserve this.
+    ///
+    /// Scenario:
+    ///   Collection [0]=arc_full, [1]=composite_full
+    ///   composite.EntityData = arc  (embedded as nested bytes wrapping a STUB EntitySurrogate
+    ///                                 that carries only the ReferenceId)
+    /// Expected: deserialized composite.EntityData must ReferenceEquals deserialized [0].
+    /// </summary>
+    public class EyeshotEntityDataRefTests
+    {
+        #region Cache (mirrors Eyeshot SerializerCache, simplified)
+
+        internal interface ISurrogateWithRefId
+        {
+            int ReferenceId { get; set; }
+        }
+
+        internal sealed class Cache
+        {
+            private readonly ConditionalWeakTable<object, ISurrogateWithRefId> _writing = new();
+            private readonly Dictionary<ISurrogateWithRefId, object> _reading = new();
+            private int _counter = 1;
+
+            public void Reset()
+            {
+                _counter = 1;
+                _reading.Clear();
+            }
+
+            public void AddWrite(object key, ISurrogateWithRefId value)
+            {
+                if (value.ReferenceId == -1) value.ReferenceId = _counter++;
+                _writing.Add(key, value);
+            }
+
+            public void AddRead(ISurrogateWithRefId key, object value)
+            {
+                if (key.ReferenceId == -1) key.ReferenceId = _counter++;
+                _reading.Add(key, value);
+            }
+
+            public ISurrogateWithRefId GetWrite(object key)
+                => _writing.TryGetValue(key, out var v) ? v : null;
+
+            public object GetRead(ISurrogateWithRefId key)
+                => _reading.TryGetValue(key, out var v) ? v : null;
+        }
+
+        private static readonly Cache s_cache = new();
+
+        #endregion
+
+        #region Domain
+
+        public abstract class Entity
+        {
+            public object EntityData;
+        }
+
+        public class Arc : Entity
+        {
+            public double Radius;
+        }
+
+        public class Composite : Entity
+        {
+            public string Name;
+        }
+
+        #endregion
+
+        #region Surrogate
+
+        // ProtoObject-like wrapper to carry Entity.EntityData across the wire as a raw-byte blob.
+        [ProtoContract]
+        public sealed class ProtoObject
+        {
+            public ProtoObject() { }
+            public ProtoObject(object obj) { Object = obj; }
+            public object Object;
+
+            [ProtoMember(1)] internal byte[] _object;
+        }
+
+        public sealed class ProtoObjectSurrogate
+        {
+            [ProtoMember(1)] internal byte[] _object;
+
+            public static implicit operator ProtoObjectSurrogate(ProtoObject src)
+            {
+                if (src == null) return null;
+                var s = new ProtoObjectSurrogate();
+                if (src.Object != null)
+                {
+                    using var ms = new MemoryStream();
+                    var model = CurrentModel;
+                    var type = src.Object.GetType();
+                    model.SerializeWithLengthPrefix(ms, type.AssemblyQualifiedName, typeof(string), PrefixStyle.Base128, 1);
+                    model.Serialize(ms, src.Object);
+                    s._object = ms.ToArray();
+                }
+                return s;
+            }
+
+            public static implicit operator ProtoObject(ProtoObjectSurrogate s)
+            {
+                if (s == null) return null;
+                var p = new ProtoObject();
+                if (s._object != null)
+                {
+                    using var ms = new MemoryStream(s._object);
+                    var model = CurrentModel;
+                    var typeName = (string)model.DeserializeWithLengthPrefix(ms, null, typeof(string), PrefixStyle.Base128, 1);
+                    var type = Type.GetType(typeName);
+                    p.Object = model.Deserialize(ms, null, type);
+                }
+                return p;
+            }
+        }
+
+        public class EntitySurrogate : ISurrogateWithRefId
+        {
+            public EntitySurrogate() { ReferenceId = -1; }
+            public EntitySurrogate(int refId) { ReferenceId = refId; }
+
+            public int ReferenceId { get; set; } = -1;
+            public ProtoObject EntityData;
+
+            public override bool Equals(object obj)
+                => (ReferenceId > 0 && obj is ISurrogateWithRefId o && o.ReferenceId == ReferenceId);
+
+            public override int GetHashCode() => ReferenceId > 0 ? ReferenceId : base.GetHashCode();
+
+            public static implicit operator EntitySurrogate(Entity source)
+            {
+                if (source == null) return null;
+                if (s_cache.GetWrite(source) is EntitySurrogate cached)
+                    return new EntitySurrogate(cached.ReferenceId); // stub: RefId only
+
+                EntitySurrogate s = source switch
+                {
+                    Arc a => new ArcSurrogate { Radius = a.Radius },
+                    Composite c => new CompositeSurrogate { Name = c.Name },
+                    _ => throw new NotSupportedException()
+                };
+                if (source.EntityData != null)
+                    s.EntityData = new ProtoObject(source.EntityData);
+
+                s_cache.AddWrite(source, s);
+                return s;
+            }
+
+            public static implicit operator Entity(EntitySurrogate s)
+            {
+                if (s == null) return null;
+                if (s_cache.GetRead(s) is Entity cached) return cached;
+
+                Entity e = s switch
+                {
+                    ArcSurrogate a => new Arc { Radius = a.Radius },
+                    CompositeSurrogate c => new Composite { Name = c.Name },
+                    _ => null
+                };
+                if (e == null) return null; // stub read but not yet materialized -> should have been cache hit
+
+                s_cache.AddRead(s, e);
+                if (s.EntityData != null) e.EntityData = s.EntityData.Object;
+                return e;
+            }
+        }
+
+        public class ArcSurrogate : EntitySurrogate
+        {
+            public double Radius;
+        }
+
+        public class CompositeSurrogate : EntitySurrogate
+        {
+            public string Name;
+        }
+
+        #endregion
+
+        [ThreadStatic] private static RuntimeTypeModel _currentModel;
+        private static RuntimeTypeModel CurrentModel => _currentModel;
+
+        private static RuntimeTypeModel BuildModel()
+        {
+            var m = RuntimeTypeModel.Create();
+
+            m.Add(typeof(ProtoObject), false).SetSurrogate(typeof(ProtoObjectSurrogate));
+            m[typeof(ProtoObjectSurrogate)].Add(1, "_object").UseConstructor = false;
+
+            var ent = m.Add(typeof(Entity), false);
+            ent.AddSubType(201, typeof(Arc));
+            ent.AddSubType(202, typeof(Composite));
+            ent.SetSurrogate(typeof(EntitySurrogate));
+
+            var entSur = m[typeof(EntitySurrogate)];
+            entSur.Add(10, "EntityData");
+            entSur.Add(100, "ReferenceId");
+            entSur.UseConstructor = false;
+            entSur.AddSubType(201, typeof(ArcSurrogate));
+            entSur.AddSubType(202, typeof(CompositeSurrogate));
+
+            m[typeof(ArcSurrogate)].Add(1, "Radius").UseConstructor = false;
+            m[typeof(CompositeSurrogate)].Add(1, "Name").UseConstructor = false;
+
+            return m;
+        }
+
+        [Fact]
+        public void Composite_EntityData_Is_Same_Instance_As_Earlier_Entity()
+        {
+            _currentModel = BuildModel();
+            s_cache.Reset();
+
+            var arc = new Arc { Radius = 7 };
+            var composite = new Composite { Name = "c" };
+            composite.EntityData = arc;
+
+            var list = new List<Entity> { arc, composite };
+
+            using var ms = new MemoryStream();
+            _currentModel.Serialize(ms, list);
+
+            ms.Position = 0;
+            s_cache.Reset();
+            var round = (List<Entity>)_currentModel.Deserialize(ms, null, typeof(List<Entity>));
+
+            Assert.NotNull(round);
+            Assert.Equal(2, round.Count);
+            Assert.IsType<Arc>(round[0]);
+            Assert.IsType<Composite>(round[1]);
+
+            // The assertion that matters:
+            Assert.True(ReferenceEquals(round[1].EntityData, round[0]),
+                "composite.EntityData must be the same instance as list[0] (reference preservation via ReferenceId).");
+        }
+    }
+}

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -1525,6 +1525,27 @@ namespace ProtoBuf.Meta
             }
         }
 
+        /// <summary>
+        /// Walks the inheritance chain and returns the topmost type that owns a surrogate
+        /// (directly or inherited). Returns this type's underlying <see cref="Type"/> if no
+        /// surrogate is present anywhere in the chain. Useful for callers that round-trip
+        /// surrogate-backed data without knowing the concrete subtype at read time — e.g.
+        /// stub surrogates whose subtype discriminator is absent on the wire, where the
+        /// only way to safely reach the conversion operator is via the surrogate-owning
+        /// root type.
+        /// </summary>
+        public Type GetSurrogateOwnerType()
+        {
+            MetaType walker = this;
+            MetaType owner = null;
+            while (walker is not null)
+            {
+                if (walker.surrogateType is not null) owner = walker;
+                walker = walker.baseType;
+            }
+            return owner is not null ? owner.Type : Type;
+        }
+
         internal MetaType GetSurrogateOrSelf()
         {
             if (surrogateType is not null) return model[surrogateType];

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -595,6 +595,22 @@ namespace ProtoBuf.Meta
         /// </summary>
         public MetaType this[Type type] { get { return (MetaType)types[FindOrAddAuto(type, true, false, false, DefaultCompatibilityLevel)]; } }
 
+        /// <summary>
+        /// Walks the inheritance chain of <paramref name="type"/> and returns the topmost
+        /// type that owns a surrogate (directly or inherited). Returns <paramref name="type"/>
+        /// itself if it is not known to the model or no surrogate is present anywhere in the
+        /// chain. Intended for callers round-tripping surrogate-backed data without knowing
+        /// the concrete subtype at read time — e.g. stub surrogates whose subtype discriminator
+        /// is absent on the wire, where the only way to safely reach the conversion operator
+        /// is via the surrogate-owning root type.
+        /// </summary>
+        public Type GetSurrogateOwnerType(Type type)
+        {
+            if (type is null) return null;
+            var found = FindWithoutAdd(type);
+            return found is not null ? found.GetSurrogateOwnerType() : type;
+        }
+
         internal MetaType FindWithAmbientCompatibility(Type type, CompatibilityLevel ambient)
         {
             var found = (MetaType)types[FindOrAddAuto(type, true, false, false, ambient)];


### PR DESCRIPTION
Adds a public API to resolve the topmost surrogate-owner for a given type, supporting stub-surrogate round-trip scenarios where a `RefId`-only payload must be deserialized back into a cached instance of the base type that declared the surrogate.

### Context

Part of the inheritance+surrogate work in #1213 (closes #1051). When a surrogate hierarchy is serialized as a stub (only `RefId`, no subtype tag), the reader must know which base type originally declared the surrogate so it can look the cached instance up in the round-trip table. That owner lookup currently only exists as an internal walker on `MetaType`; external callers (e.g. Eyeshot's serializer glue) cannot reach it.

### Changes

- `MetaType.GetSurrogateOwnerType()` — public instance method that walks the `baseType` chain and returns the topmost `MetaType` whose `surrogateType` is set, falling back to the type itself when no surrogate is declared anywhere in the chain.
- `RuntimeTypeModel.GetSurrogateOwnerType(Type)` — public wrapper that resolves via `FindWithoutAdd`, returning the input type unchanged when no `MetaType` is registered.

Generic API, no Eyeshot-specific code. No behavioural change for existing callers.

### Tests

Added `EyeshotEntityDataRefTests.Composite_EntityData_Is_Same_Instance_As_Earlier_Entity` covering the stub-surrogate cache-hit recovery path end-to-end.

Full suite: zero new regressions vs. baseline (29 pre-existing failures, 29 final).