### PR TITLE
Preserve null scalar ref values in maps under CompatibilityLevel < 300

### DIFF
--- a/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
+++ b/src/protobuf-net.Core/Internal/KeyValuePairSerializer.cs
@@ -58,6 +58,14 @@ namespace ProtoBuf.Internal
             {   // no field? treat as null
                 return default;
             }
+            if (features.HasAny(SerializerFeatures.OptionMapValuePreservesNull)
+                && features.GetCategory() == SerializerFeatures.CategoryScalar)
+            {   // v2-compat: preserve null for scalar reference-type map values (string, byte[])
+                // when no value field is present on the wire. Message / repeated values keep
+                // the existing "read empty payload / construct empty instance" semantics so
+                // older round-trips that rely on a non-null collection keep working.
+                return default;
+            }
             if (serializer is not null && serializer.Features.GetCategory() == SerializerFeatures.CategoryMessage)
             {
                 // get the serializer to do the work, by reading an empty payload

--- a/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
+++ b/src/protobuf-net.Core/Serializers/IProtoSerializerT.cs
@@ -130,6 +130,16 @@ namespace ProtoBuf.Serializers
         /// </summary>
         OptionTrySkipWritingWhenMeasuring = 1 << 16,
 
+        /// <summary>
+        /// For map value/key serializers: when the element is a reference type and the wire
+        /// carries no payload for it, preserve <c>null</c> instead of materialising the proto
+        /// default (e.g. <c>""</c> for <see cref="string"/>). Used for back-compat with v2
+        /// semantics at <see cref="CompatibilityLevel.Level200"/> / <see cref="CompatibilityLevel.Level240"/>,
+        /// where the writer already distinguishes null (value tag omitted) from empty
+        /// (value tag length 0) on the wire. No effect for value types.
+        /// </summary>
+        OptionMapValuePreservesNull = 1 << 17,
+
         // this isn't quite ready; the problem is that the property assignment / null-check logic
         // gets hella messy
         ///// <summary>
@@ -204,8 +214,8 @@ namespace ProtoBuf.Serializers
 
         [MethodImpl(ProtoReader.HotPath)]
         public static T DefaultFor<T>(this SerializerFeatures features)
-            // prefer true nunll when wrapped
-            => features.HasAny(SerializerFeatures.OptionWrappedValue) ? default(T) : TypeHelper<T>.Default;
+            // prefer true null when wrapped, or when the caller asked for null-preservation (v2-compat map values)
+            => features.HasAny(SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionMapValuePreservesNull) ? default(T) : TypeHelper<T>.Default;
 
         // core wire-type bits plus the zig-zag marker; first 4 bits
         private const SerializerFeatures WireTypeMask = (SerializerFeatures)15;

--- a/src/protobuf-net.Test/Issues/MapNullStringValueTests.cs
+++ b/src/protobuf-net.Test/Issues/MapNullStringValueTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ProtoBuf.Meta;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    /// <summary>
+    /// v2 round-tripped <c>null</c> values inside <see cref="Dictionary{TKey,TValue}"/> fields
+    /// preserving the null. v3's initial behaviour coerced a missing map value to the proto
+    /// default (e.g. <c>""</c> for <see cref="string"/>), losing the null/empty distinction.
+    ///
+    /// The writer already distinguishes the two on the wire
+    /// (HasNonTrivialValue omits the value tag entirely for null, writes a zero-length value
+    /// tag for "") so the coercion only happened on read. The fix keys off the compatibility
+    /// level: Level200 / Level240 preserve null (v2 semantics); Level300 keeps the proto3-style
+    /// "" coercion. Explicit <see cref="ValueMember.SupportNull"/> continues to preserve null
+    /// via the wrapped-value path and is unaffected.
+    /// </summary>
+    public class MapNullStringValueTests
+    {
+        [ProtoContract]
+        public class Holder
+        {
+            [ProtoMember(1)] public Dictionary<string, string> Map;
+        }
+
+        private static Holder Roundtrip(RuntimeTypeModel m, Holder h)
+        {
+            using var ms = new MemoryStream();
+            m.Serialize(ms, h);
+            ms.Position = 0;
+            return (Holder)m.Deserialize(ms, null, typeof(Holder));
+        }
+
+        private static byte[] Serialize(RuntimeTypeModel m, Holder h)
+        {
+            using var ms = new MemoryStream();
+            m.Serialize(ms, h);
+            return ms.ToArray();
+        }
+
+        private static Holder Source() => new Holder
+        {
+            Map = new Dictionary<string, string>
+            {
+                { "A", "alpha" },
+                { "N", null },
+                { "E", "" },
+            }
+        };
+
+        [Theory]
+        [InlineData((int)CompatibilityLevel.NotSpecified)] // defaults to Level200
+        [InlineData((int)CompatibilityLevel.Level200)]
+        [InlineData((int)CompatibilityLevel.Level240)]
+        public void V2Compat_PreservesNullAndEmptyValues(int level)
+        {
+            var m = RuntimeTypeModel.Create();
+            m.DefaultCompatibilityLevel = (CompatibilityLevel)level;
+            var r = Roundtrip(m, Source());
+            Assert.Equal("alpha", r.Map["A"]);
+            Assert.Null(r.Map["N"]);
+            Assert.Equal("", r.Map["E"]);
+        }
+
+        [Fact]
+        public void Level300_CoercesNullToEmpty_Proto3Semantics()
+        {
+            var m = RuntimeTypeModel.Create();
+            m.DefaultCompatibilityLevel = CompatibilityLevel.Level300;
+            var r = Roundtrip(m, Source());
+            Assert.Equal("alpha", r.Map["A"]);
+            Assert.Equal("", r.Map["N"]); // proto3: null coerced to ""
+            Assert.Equal("", r.Map["E"]);
+        }
+
+        [Fact]
+        public void Wire_WriterDistinguishesNullFromEmpty_AtAllLevels()
+        {
+            // Writer omits value tag for null (via HasNonTrivialValue); emits zero-length
+            // value tag for "". Reader behaviour (null preserved vs coerced) is separate
+            // from this wire-level distinction, which must hold across all levels.
+            foreach (var level in new[] { CompatibilityLevel.Level200, CompatibilityLevel.Level240, CompatibilityLevel.Level300 })
+            {
+                var m = RuntimeTypeModel.Create();
+                m.DefaultCompatibilityLevel = level;
+                var bNull = Serialize(m, new Holder { Map = new Dictionary<string, string> { { "K", null } } });
+                var bEmpty = Serialize(m, new Holder { Map = new Dictionary<string, string> { { "K", "" } } });
+                Assert.True(bEmpty.Length > bNull.Length,
+                    $"[{level}] expected empty-value payload to include value tag; null={bNull.Length} bytes, empty={bEmpty.Length} bytes");
+            }
+        }
+
+        [Fact]
+        public void Level300_WireFromLevel200_ReadsNullAsEmpty()
+        {
+            // Cross-level read: data produced under Level200 (with a null value) must read
+            // cleanly under Level300 with the proto3 coercion applied. This locks in that
+            // the wire format is unchanged — only the read-side interpretation differs.
+            var writer = RuntimeTypeModel.Create();
+            writer.DefaultCompatibilityLevel = CompatibilityLevel.Level200;
+            var bytes = Serialize(writer, Source());
+
+            var reader = RuntimeTypeModel.Create();
+            reader.DefaultCompatibilityLevel = CompatibilityLevel.Level300;
+            using var ms = new MemoryStream(bytes);
+            var r = (Holder)reader.Deserialize(ms, null, typeof(Holder));
+
+            Assert.Equal("alpha", r.Map["A"]);
+            Assert.Equal("", r.Map["N"]);
+            Assert.Equal("", r.Map["E"]);
+        }
+
+        [Fact]
+        public void Level200_WireFromLevel300_ReadsEmptyAsNullIsImpossible_ReadsAsEmpty()
+        {
+            // Reverse cross-level: Level300 writer collapses null→"" on write (because
+            // HasNonTrivialValue is the same), so reading under Level200 recovers "" not null
+            // — the null was already lost at the write step. This test documents that
+            // preservation only works when both write and read use a null-preserving level.
+            var writer = RuntimeTypeModel.Create();
+            writer.DefaultCompatibilityLevel = CompatibilityLevel.Level300;
+            var bytes = Serialize(writer, Source());
+
+            var reader = RuntimeTypeModel.Create();
+            reader.DefaultCompatibilityLevel = CompatibilityLevel.Level200;
+            using var ms = new MemoryStream(bytes);
+            var r = (Holder)reader.Deserialize(ms, null, typeof(Holder));
+
+            Assert.Equal("alpha", r.Map["A"]);
+            // on the wire: writer saw null, HasNonTrivialValue(null)=false → value tag omitted,
+            // same as Level200 would have done; so reader sees "no value field" and, under
+            // Level200, preserves null.
+            Assert.Null(r.Map["N"]);
+            Assert.Equal("", r.Map["E"]);
+        }
+
+        [Fact]
+        public void ExplicitSupportNull_PreservesNullRegardlessOfLevel()
+        {
+            // SupportNull uses the wrapped-value path which already preserves null; verify
+            // it keeps working under Level300 where the default coerces.
+            foreach (var level in new[] { CompatibilityLevel.Level200, CompatibilityLevel.Level240, CompatibilityLevel.Level300 })
+            {
+                var m = RuntimeTypeModel.Create();
+                m.DefaultCompatibilityLevel = level;
+                var mt = m.Add(typeof(Holder), false);
+                mt.Add(1, nameof(Holder.Map));
+                mt[1].SupportNull = true;
+                var r = Roundtrip(m, Source());
+                Assert.Equal("alpha", r.Map["A"]);
+                Assert.Null(r.Map["N"]);
+                Assert.Equal("", r.Map["E"]);
+            }
+        }
+
+        [ProtoContract]
+        public class HolderBytes
+        {
+            [ProtoMember(1)] public Dictionary<string, byte[]> Map;
+        }
+
+        [Fact]
+        public void V2Compat_PreservesNullBytesValues()
+        {
+            // byte[] is the other mainstream reference-type map value; verify the flag
+            // generalises beyond string.
+            var m = RuntimeTypeModel.Create();
+            m.DefaultCompatibilityLevel = CompatibilityLevel.Level200;
+            var src = new HolderBytes { Map = new Dictionary<string, byte[]>
+            {
+                { "A", new byte[] { 1, 2, 3 } },
+                { "N", null },
+                { "E", System.Array.Empty<byte>() },
+            }};
+            using var ms = new MemoryStream();
+            m.Serialize(ms, src);
+            ms.Position = 0;
+            var r = (HolderBytes)m.Deserialize(ms, null, typeof(HolderBytes));
+            Assert.Equal(new byte[] { 1, 2, 3 }, r.Map["A"]);
+            Assert.Null(r.Map["N"]);
+            Assert.NotNull(r.Map["E"]);
+            Assert.Empty(r.Map["E"]);
+        }
+    }
+}

--- a/src/protobuf-net.Test/Serializers/Proto3Tests.cs
+++ b/src/protobuf-net.Test/Serializers/Proto3Tests.cs
@@ -214,9 +214,14 @@ message HazAliasedEnum {
             Assert.Equal("def", val);
         }
 
-        [ProtoContract]
+        [ProtoContract, CompatibilityLevel(CompatibilityLevel.Level300)]
         public class HazMapString
         {
+            // Proto3 semantics: missing value-entries coerce to the proto default "" on read.
+            // Under Level200 / Level240 (the v2-compat path) a reference-type map value
+            // whose tag is absent on the wire is preserved as null instead; this type is
+            // explicitly marked Level300 so the omitted-value test below exercises the
+            // intended proto3 coercion rather than the v2-compat null-preservation.
             [ProtoMember(3), ProtoMap]
             public IDictionary<string, string> Lookup { get; } = new Dictionary<string, string>();
         }

--- a/src/protobuf-net/Meta/ValueMember.cs
+++ b/src/protobuf-net/Meta/ValueMember.cs
@@ -448,6 +448,18 @@ namespace ProtoBuf.Meta
             valueFeatures |= features & (SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionWrappedValueGroup);
             features &= ~(SerializerFeatures.OptionWrappedValue | SerializerFeatures.OptionWrappedValueGroup);
 
+            // v2 semantics (Level200 / Level240) preserve null for reference-type map values:
+            // the writer already distinguishes null (value tag omitted) from empty (value tag
+            // length 0) on the wire via HasNonTrivialValue, but on read v3's default behaviour
+            // coerces a missing value to the proto default (e.g. "" for string), discarding
+            // the distinction. Opt-in to null-preservation on the value side so Dictionary
+            // round-trips like-for-like under the default compat level. Level300 keeps the
+            // proto3-style "" coercion unchanged.
+            if (valueCompatibilityLevel < CompatibilityLevel.Level300)
+            {
+                valueFeatures |= SerializerFeatures.OptionMapValuePreservesNull;
+            }
+
             return MapDecorator.Create(repeated, keyType, valueType, fieldNumber, features,
                 keyWireType.AsFeatures(), keyCompatibilityLevel, keyFormat, valueFeatures, valueCompatibilityLevel, valueFormat);
         }


### PR DESCRIPTION
Fixes a v2→v3 regression where map values of reference-type scalars (e.g. `string`, `byte[]`) that were written as `null` by the writer are silently coerced to the proto default (`\"\"`, `Array.Empty<byte>()`) on read, even at `CompatibilityLevel.Level200` / `Level240` where v2 semantics should preserve the null.

### Background

The writer already distinguishes null from empty on the wire: null values omit the value tag entirely (`HasNonTrivialValue` guard), while empty values emit tag + zero-length payload. The v3 reader, however, unconditionally materializes a default instance when no value field is present on the wire, which is correct for proto3 (`map<K, V>` entries always have a value) but breaks v2 back-compat.

### Fix

New `SerializerFeatures.OptionMapValuePreservesNull` flag (bit `1 << 17`), wired by `ValueMember.CreateMap` when `valueCompatibilityLevel < CompatibilityLevel.Level300`. The flag is consumed by `KeyValuePairSerializer.CreateDefault` under a narrow gate:

```csharp
if (features.HasAny(SerializerFeatures.OptionMapValuePreservesNull)
    && features.GetCategory() == SerializerFeatures.CategoryScalar)
{
    return default;
}
```

The `CategoryScalar` narrowing is deliberate — message/repeated map values keep the existing \"read empty payload / construct empty instance\" semantics so that older round-trips relying on a non-null collection (e.g. `Dictionary<string, List<string>>`) keep working.

`SerializerFeaturesExtensions.DefaultFor<T>` is extended to return `default(T)` when either `OptionWrappedValue` or the new flag is set.

### Tests

New `MapNullStringValueTests` matrix (9 tests):

- `V2Compat_PreservesNullAndEmptyValues` (theory over NotSpecified / Level200 / Level240)
- `Level300_CoercesNullToEmpty_Proto3Semantics`
- `Wire_WriterDistinguishesNullFromEmpty_AtAllLevels`
- `Level300_WireFromLevel200_ReadsNullAsEmpty`
- `Level200_WireFromLevel300_ReadsEmptyAsNullIsImpossible_ReadsAsEmpty`
- `ExplicitSupportNull_PreservesNullRegardlessOfLevel`
- `V2Compat_PreservesNullBytesValues` (byte[] variant)

Incidental fix in `Proto3Tests.HazMapString`: added explicit `[CompatibilityLevel(Level300)]` attribute — the test was exercising scalar string map values under default `Level200` and passing only because of this same bug. With the fix it now passes under the correct level.

### Risk

Full suite run against this branch: **zero new regressions**, pre-existing failure count unchanged.

Wire format is unchanged. The fix is read-side only and gated behind `CompatibilityLevel < 300`, so proto3-tagged contracts are unaffected.