### PR TITLE
Walk surrogate inheritance chain in BuildSerializer (non-root surrogate)

### DIFF
--- a/src/protobuf-net/Internal/Serializers/SurrogateSerializer.cs
+++ b/src/protobuf-net/Internal/Serializers/SurrogateSerializer.cs
@@ -28,9 +28,16 @@ namespace ProtoBuf.Internal.Serializers
         bool IProtoTypeSerializer.ShouldEmitCreateInstance => false;
         bool IProtoTypeSerializer.CanCreateInstance() => false;
 
-        public SerializerFeatures Features => // trust only when we've unwrapped
-            _metaTypeOrSerializer is IProtoTypeSerializer known ? _features : Unwrap().Features;
-        
+        public SerializerFeatures Features
+        {
+            get
+            {
+                // MetaType path still needs resolution; direct IRuntimeProtoSerializerNode (incl. scalar or already-unwrapped) has _features valid.
+                if (_metaTypeOrSerializer is MetaType) Unwrap();
+                return _features;
+            }
+        }
+
         bool IRuntimeProtoSerializerNode.IsScalar => Features.IsScalar();
 
         object IProtoTypeSerializer.CreateInstance(ISerializationContext source) => throw new NotSupportedException();
@@ -69,33 +76,34 @@ namespace ProtoBuf.Internal.Serializers
         private object _metaTypeOrSerializer;
         private SerializerFeatures _features;
 
-        private IProtoTypeSerializer RootTail
-            => _metaTypeOrSerializer is IProtoTypeSerializer ser ? ser : Unwrap();
+        private IRuntimeProtoSerializerNode RootTail
+            => _metaTypeOrSerializer is IRuntimeProtoSerializerNode node ? node : Unwrap();
 
 #if DEBUG
         private int unwrapThreadId;
 #endif
-        
-        private IProtoTypeSerializer Unwrap()
+
+        private IRuntimeProtoSerializerNode Unwrap()
         {
             var obj = _metaTypeOrSerializer;
-            if (obj is IProtoTypeSerializer ser)
+            if (obj is IRuntimeProtoSerializerNode directNode)
             {
-                return ser;
+                // already resolved (IProtoTypeSerializer) or direct scalar serializer
+                return directNode;
             }
 #if DEBUG
             int currentThreadId = Environment.CurrentManagedThreadId,
                 existingThreadId = Interlocked.CompareExchange(ref unwrapThreadId, currentThreadId, 0);
             Debug.Assert(existingThreadId == 0 || existingThreadId !=  currentThreadId, "Re-entrant/recursive call to Unwrap");
             Debug.WriteLine($"Unwrapping serializer for {declaredType.Name}");
-#endif      
-            
-            var metaType = (MetaType)obj; 
-            ser = metaType.Serializer;
+#endif
+
+            var metaType = (MetaType)obj;
+            var ser = metaType.Serializer;
             Debug.Assert(declaredType == ser.ExpectedType || Helpers.IsSubclassOf(declaredType, ser.ExpectedType), "surrogate type mismatch");
             _features = ser.Features; // swap this first, for test order
             _metaTypeOrSerializer = ser;
-            
+
 #if DEBUG
             Interlocked.CompareExchange(ref unwrapThreadId, 0, currentThreadId); // end recursion check
 #endif

--- a/src/protobuf-net/Meta/MetaType.cs
+++ b/src/protobuf-net/Meta/MetaType.cs
@@ -557,18 +557,14 @@ namespace ProtoBuf.Meta
                 else
                 {
                     MetaType mt = model[surrogateType];
-                    if (mt.BaseType is not null)
+                    // walk up the surrogate inheritance chain so polymorphic dispatch handles the actual concrete surrogate via sub-type metadata
+                    while (mt.BaseType is not null)
                     {
-                        ThrowHelper.ThrowInvalidOperationException("Surrogate type must refer to the root inheritance type (for now; log an issue if this is a barrier): " + surrogateType.NormalizeName());
+                        mt = mt.BaseType;
                     }
 
                     metaTypeOrSerializer = mt;
                     features = default;
-                    // , mtBase;
-                    //while ((mtBase = mt.baseType) is not null)
-                    //{serializer
-                    //    mt = mtBase;
-                    //}
                 }
                 var root = GetInheritanceRoot();
                 if (root is null)


### PR DESCRIPTION
Unblocks models where the surrogate is not the root of its own hierarchy. Before this change, `MetaType.BuildSerializer` threw when encountering a surrogate whose `MetaType.baseType` chain was non-trivial, breaking `RecursiveModel` compile.

> Note: stacked on top of PR #1239 (scalar-surrogate). Review the 1239 commit first; this PR shows a single additional commit (`f16b1ba1`) once 1239 is merged. If you prefer I can rebase onto the merge point afterwards.

### Change

In `MetaType.BuildSerializer`, walk up the surrogate's `baseType` chain to locate the topmost surrogate `MetaType` before constructing `SurrogateSerializer`. Mirrors v2's upward walk on the surrogate side.

### Side-effects (pre-existing test adjustments)

Two pre-existing assertions in `SurrogateTests.ExecuteWithInheritance` (derivedSurrogate=true) and `Issues.SO6407130.Execute` previously asserted that the model threw during build. With this fix, both now round-trip cleanly instead. Assertions updated to reflect the new (correct) behaviour.

### Test state

Full suite on this branch (with #1239 applied underneath): zero new regressions vs. baseline. `RecursiveModel` compile now succeeds.