### PR TITLE
Resolve ValueMember proxies pre-freeze during Compile

### DIFF
--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1084,6 +1084,24 @@ namespace ProtoBuf.Meta
 
                 if (GetServicesSlow(mt.Type, mt.CompatibilityLevel) is null) // respects enums, repeated, etc
                     throw new InvalidOperationException("No serializer available for " + mt.Type.NormalizeName());
+
+                // Additionally, force every ValueMember on this type to build its own serializer now,
+                // so that any referenced types get auto-added via TryGetCoreSerializer→IsDefined→
+                // FindOrAddAuto while the model is still mutable. The outer TypeSerializer only holds
+                // lazy ValueMemberSerializerProxy instances (introduced by commit 1ed20cb7 to avoid
+                // infinite regress during the outer build); without this pass, proxy resolution is
+                // deferred to emit time (after Freeze), and any auto-add there throws
+                // "The model cannot be changed once frozen". Walking fields here is safe: each
+                // referenced type's outer serializer is fetched lazily via the model's cache, and
+                // the containing MetaType outer is already built above, so no recursion re-enters
+                // this same member's Serializer getter.
+                if (mt.HasFields)
+                {
+                    foreach (var vm in mt.Fields)
+                    {
+                        _ = vm.Serializer;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes 3 IL-verification tests that regressed after the proxy commit `1ed20cb7` (*"Introduce proxy to defer serializer resolution for fields/sub-types, to prevent infinite regress"*) on the `inheritance-surrogate` branch:

- `Issues.Issue598.VerifyIL`
- `CustomScalarAllocator.CustomScalarIL`
- `EmitProtogenModel.CustomProtogenSerializer`

All failed the same way: `InvalidOperationException: "The model cannot be changed once frozen"` during `RuntimeTypeModel.Compile`.

### Root cause

`Compile` calls `BuildAllSerializers` then `Freeze`. Pre-`1ed20cb7`: `MetaType.BuildSerializer` walked each `ValueMember` and eagerly accessed `.Serializer`, so any auto-add of referenced types (`TryGetCoreSerializer → IsDefined → DynamicStub.IsKnownType → FindOrAddAuto → Create`) happened while the model was mutable. Post-`1ed20cb7`: fields store lazy `ValueMemberSerializerProxy` which defer resolution to `TypeSerializer.ResolveAllSerializers` — called during `EmitRead`/`EmitWrite`, **after** `Freeze`. Any auto-add at that point hits `ThrowIfFrozen`.

### Fix

`RuntimeTypeModel.BuildAllSerializers` now does two things per type in its iteration loop:

1. Build outer `MetaType.Serializer` (existing behaviour via `GetServicesSlow`).
2. Walk `mt.Fields` and touch each `ValueMember.Serializer`, forcing the proxy chain (and any transitive auto-adds) to resolve pre-freeze.

Single loop with dynamic `types.Count` check so newly-added types still get their outer serializer built before the next iteration touches their fields. No recursion hazard: the containing MetaType's outer serializer is already built in step 1, so step 2's field resolution picks up cached outer serializers for referenced types rather than re-entering the current member's getter. The infinite-regress scenario that `1ed20cb7` guarded against (nested MetaType outer builds) remains blocked.

### Validation

- Full suite on this branch: -3 failures (29 → 26), 0 new regressions.
- Canonical round-trips including inheritance+surrogate configurations unaffected.
- Verified by the 3 IL tests listed above.