### PR TITLE
Reinitialize the _knownLengths-Dictionary to free up its allocated memory

### DIFF
--- a/src/protobuf-net.Core/NetObjectCache.cs
+++ b/src/protobuf-net.Core/NetObjectCache.cs
@@ -7,7 +7,7 @@ namespace ProtoBuf
 {
     internal sealed class NetObjectCache
     {
-        private readonly Dictionary<ObjectKey, long> _knownLengths = new Dictionary<ObjectKey, long>();
+        private Dictionary<ObjectKey, long> _knownLengths = new Dictionary<ObjectKey, long>();
 
         [StructLayout(LayoutKind.Auto)]
         private readonly struct ObjectKey : IEquatable<ObjectKey>
@@ -232,7 +232,7 @@ namespace ProtoBuf
             if (stringKeys is object) stringKeys.Clear();
             if (objectKeys is object) objectKeys.Clear();
 #endif
-            _knownLengths.Clear();
+            _knownLengths = new Dictionary<ObjectKey, long>(); // reinitialize the Dictionary<> to free up all allocated memory
             _hit = _miss = 0;
         }
 

--- a/src/protobuf-net.Core/NetObjectCache.cs
+++ b/src/protobuf-net.Core/NetObjectCache.cs
@@ -7,7 +7,11 @@ namespace ProtoBuf
 {
     internal sealed class NetObjectCache
     {
-        private Dictionary<ObjectKey, long> _knownLengths = new Dictionary<ObjectKey, long>();
+        private
+#if NET
+            readonly
+#endif
+            Dictionary<ObjectKey, long> _knownLengths = new();
 
         [StructLayout(LayoutKind.Auto)]
         private readonly struct ObjectKey : IEquatable<ObjectKey>
@@ -232,7 +236,12 @@ namespace ProtoBuf
             if (stringKeys is object) stringKeys.Clear();
             if (objectKeys is object) objectKeys.Clear();
 #endif
-            _knownLengths = new Dictionary<ObjectKey, long>(); // reinitialize the Dictionary<> to free up all allocated memory
+#if NET
+            _knownLengths.Clear();
+            _knownLengths.TrimExcess();
+#else
+            _knownLengths = new(); // reinitialize the Dictionary<> to free up all allocated memory
+#endif
             _hit = _miss = 0;
         }
 


### PR DESCRIPTION
**Issue**
In certain situations the `_knownLengths`-Dictionary of the `NetObjectCache` can become quiet big in size (many megabytes, millions of entries).
When the NetObjectCache gets cleared the Dictionary did get cleared too. 
Calling `.Clear()` on a dictionary only zeroes out its allocated memory, it does not however free up any unused memory which has been allocated before. 
This resulted in excessive memory consumption.

**Fix**
This PR fixes the issue by no longer calling `.Clear()` on the dictionary but by replacing the Dictionary with a new instance, freeing up the memory that was used before.

**Reasoning for my implementation**
My initial idea was to use compiler flags (`#if NET462 || NETSTANDARD2_0`) for this change. 
When in .NET4.6.2 or NetStandard2.0 I'd have replaced the dictionary and when in .NET8 or NetStandard21 I'd have called `.Clear()` and `.TrimExcess()`.

I have decided against using compiler flags and against having two separate implementations. 
The reason for this descision is that the solution I've choosen here is both easier to maintain in the future and has slight performance benefits too (it's more efficient to reinitialize with a new dictionary than to shrink the existing dictionary).

