### PR TITLE
Implemented MemorySerializer<T> to serialize Memory<> of poco objects.

### DIFF
--- a/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
+++ b/src/protobuf-net.Core/Serializers/RepeatedSerializer.cs
@@ -83,6 +83,8 @@ namespace ProtoBuf.Serializers
             => SerializerCache<SetSerializer<TCollection, T>>.InstanceField;
 
 #if NET6_0_OR_GREATER
+        [MethodImpl(ProtoReader.HotPath)]
+        public static RepeatedSerializer<Memory<T>, T> CreateMemory<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>() => SerializerCache<MemorySerializer<T>>.InstanceField;
         /// <summary>Create a serializer that operates on sets</summary>
         [MethodImpl(ProtoReader.HotPath)]
         public static RepeatedSerializer<IReadOnlySet<T>, T> CreateReadOnySet<[DynamicallyAccessedMembers(DynamicAccess.ContractType)] T>()
@@ -720,6 +722,84 @@ namespace ProtoBuf.Serializers
         {
             var iter = values.GetEnumerator();
             Write(ref state, fieldNumber, category, wireType, ref iter, serializer, features);
+        }
+    }
+
+    class MemorySerializer<T> : RepeatedSerializer<Memory<T>, T>
+    {
+        protected override Memory<T> Initialize(Memory<T> values, ISerializationContext context) => values;
+
+        protected override int TryGetCount(Memory<T> values) => values.Length;
+
+        internal override long Measure(Memory<T> values, IMeasuringSerializer<T> serializer, ISerializationContext context, WireType wireType)
+        {
+            long length = 0;
+            for (int i = 0; i < values.Length; i++)
+            {
+                length += serializer.Measure(context, wireType, values.Span[i]);
+            }
+            return length;
+        }
+
+        internal override void WritePacked(ref ProtoWriter.State state, Memory<T> values, IMeasuringSerializer<T> serializer, WireType wireType)
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                state.WireType = wireType; // tell the serializer what we want to do
+                serializer.Write(ref state, values.Span[i]);
+            }
+        }
+
+        internal override void Write(ref ProtoWriter.State state, int fieldNumber, SerializerFeatures category, WireType wireType, Memory<T> values, ISerializer<T> serializer, SerializerFeatures features)
+        {
+            var writer = state.GetWriter();
+            bool wrapped = features.HasAny(SerializerFeatures.OptionWrappedValue);
+            // when wrapping inside a collection, we always need to write the message header, so:
+            // we must use field-presence rules
+            if (wrapped) features |= SerializerFeatures.OptionWrappedValueFieldPresence;
+            for (int i = 0; i < values.Length; i++)
+            {
+                T value = values.Span[i];
+
+                if (wrapped)
+                {
+                    state.WriteWrapped(fieldNumber, features, value, serializer);
+                }
+                else
+                {
+                    if (TypeHelper<T>.CanBeNull && TypeHelper<T>.ValueChecker.IsNull(value))
+                        ThrowHelper.ThrowNullRepeatedContents<T>();
+
+                    state.WriteFieldHeader(fieldNumber, wireType);
+                    switch (category)
+                    {
+                        case SerializerFeatures.CategoryMessageWrappedAtRoot:
+                        case SerializerFeatures.CategoryMessage:
+                            writer.WriteMessage(ref state, value, serializer, PrefixStyle.Base128, true);
+                            break;
+                        case SerializerFeatures.CategoryScalar:
+                            serializer.Write(ref state, value);
+                            break;
+                        default:
+                            category.ThrowInvalidCategory();
+                            break;
+                    }
+                }
+            }
+        }
+
+        protected override Memory<T> Clear(Memory<T> values, ISerializationContext context)
+        {
+            values.Span.Clear();
+            return values;
+        }
+
+        protected override Memory<T> AddRange(Memory<T> values, ref ArraySegment<T> newValues, ISerializationContext context)
+        {
+            T[] result = new T[values.Length + newValues.Count];
+            values.CopyTo(result);
+            newValues.CopyTo(result, values.Length);
+            return result;
         }
     }
 #endif

--- a/src/protobuf-net.Test/BufferWriteCountTests.cs
+++ b/src/protobuf-net.Test/BufferWriteCountTests.cs
@@ -323,6 +323,270 @@ namespace ProtoBuf.Test
             }
         }
 
+#if NET6_0_OR_GREATER
+        [Fact]
+        public void WriteAllTheThingsMemory()
+        {
+            using var cw = new CountingWriter();
+
+            var state = ProtoWriter.State.Create(cw, MyTypeModel.Instance);
+            try
+            {
+                var rand = new Random(12345);
+                const int ITER_COUNT = 1024, SMALL_ITER_COUNT = 128, MAXLEN = 2048;
+                int GetField() => rand.Next(1, 2048);
+                int GetInt32() => rand.Next(int.MinValue, int.MaxValue);
+                long GetInt64()
+                {
+                    long x = GetInt32(), y = GetInt32();
+                    return (x << 32) | y;
+                }
+                unsafe string GetString()
+                {
+                    const string alphabet = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 ";
+                    var len = rand.Next(MAXLEN);
+                    string s = new string('\0', len);
+                    fixed (char* c = s)
+                    {
+                        for (int i = 0; i < len; i++)
+                            c[i] = alphabet[rand.Next(alphabet.Length)];
+                    }
+                    return s;
+                }
+                ArraySegment<byte> GetBytes(byte[] array)
+                {
+                    rand.NextBytes(array);
+                    var len = rand.Next(array.Length);
+                    return new ArraySegment<byte>(array, 0, len);
+                }
+                var valuesInt32 = new List<int>();
+                List<int> GetValuesInt32()
+                {
+                    valuesInt32.Clear();
+                    var len = rand.Next(MAXLEN);
+                    for (int i = 0; i < len; i++)
+                        valuesInt32.Add(GetInt32());
+                    return valuesInt32;
+                }
+                var valuesString = new List<string>();
+                List<string> GetValuesString()
+                {
+                    valuesString.Clear();
+                    var len = rand.Next(MAXLEN);
+                    for (int i = 0; i < len; i++)
+                        valuesString.Add(GetString());
+                    return valuesString;
+                }
+
+                MyMessage GetMessage()
+                {
+                    return new MyMessage { X = GetInt32(), Y = GetString() };
+                }
+                var valuesMessage = new List<MyMessage>();
+                List<MyMessage> GetValuesMessage()
+                {
+                    valuesMessage.Clear();
+                    var len = rand.Next(MAXLEN);
+                    for (int i = 0; i < len; i++)
+                        valuesMessage.Add(GetMessage());
+                    return valuesMessage;
+                }
+
+                //////////////////////////////////////
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.Varint);
+                    state.WriteInt32(GetInt32());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt32)}/{WireType.Varint}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.SignedVarint);
+                    state.WriteInt32(GetInt32());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt32)}/{WireType.SignedVarint}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.Fixed32);
+                    state.WriteInt32(GetInt32());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt32)}/{WireType.Fixed32}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.Fixed64);
+                    state.WriteInt32(GetInt32());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt32)}/{WireType.Fixed64}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.Varint);
+                    state.WriteInt64(GetInt64());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt64)}/{WireType.Varint}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.SignedVarint);
+                    state.WriteInt64(GetInt64());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt64)}/{WireType.SignedVarint}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.Fixed64);
+                    state.WriteInt64(GetInt64());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteInt64)}/{WireType.Fixed64}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.String);
+                    state.WriteString(GetString());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteString)}/{WireType.String}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+
+                var arr = ArrayPool<byte>.Shared.Rent(MAXLEN);
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.String);
+                    state.WriteBytes(GetBytes(arr));
+                }
+                ArrayPool<byte>.Shared.Return(arr);
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteBytes)}/{WireType.String}: {cw.TotalBytes}");
+                Assert.Equal(cw.TotalBytes, state.GetPosition());
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.String);
+                    state.WriteMessage(default, GetMessage());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteMessage)}/{WireType.String}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    state.WriteFieldHeader(GetField(), WireType.StartGroup);
+                    state.WriteMessage(default, GetMessage());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(state.WriteMessage)}/{WireType.StartGroup}: {cw.TotalBytes}");
+
+                var repeatedInt32 = RepeatedSerializer.CreateMemory<int>();
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeVarint, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeVarint}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeSignedVarint, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeSignedVarint}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeFixed32, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeFixed32}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeFixed64, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeFixed64}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeVarint | SerializerFeatures.OptionPackedDisabled, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeVarint | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeSignedVarint | SerializerFeatures.OptionPackedDisabled, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeSignedVarint | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeFixed32 | SerializerFeatures.OptionPackedDisabled, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeFixed32 | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                for (int i = 0; i < ITER_COUNT; i++)
+                {
+                    repeatedInt32.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeFixed64 | SerializerFeatures.OptionPackedDisabled, GetValuesInt32().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {ITER_COUNT}x{nameof(repeatedInt32.WriteRepeated)}/{SerializerFeatures.WireTypeFixed64 | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                var repeatedString = RepeatedSerializer.CreateMemory<string>();
+                for (int i = 0; i < SMALL_ITER_COUNT; i++)
+                {
+                    repeatedString.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeString, GetValuesString().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {SMALL_ITER_COUNT}x{nameof(repeatedString.WriteRepeated)} ({nameof(String)})/{SerializerFeatures.WireTypeString | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                var repeatedMessage = RepeatedSerializer.CreateMemory<MyMessage>();
+                for (int i = 0; i < SMALL_ITER_COUNT; i++)
+                {
+                    repeatedMessage.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeString, GetValuesMessage().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {SMALL_ITER_COUNT}x{nameof(repeatedString.WriteRepeated)} ({nameof(MyMessage)})/{SerializerFeatures.WireTypeString | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+
+                for (int i = 0; i < SMALL_ITER_COUNT; i++)
+                {
+                    repeatedMessage.WriteRepeated(ref state, GetField(), SerializerFeatures.WireTypeStartGroup, GetValuesMessage().ToArray().AsMemory());
+                }
+                state.Flush();
+                Log($"After {SMALL_ITER_COUNT}x{nameof(repeatedString.WriteRepeated)} ({nameof(MyMessage)})/{SerializerFeatures.WireTypeStartGroup | SerializerFeatures.OptionPackedDisabled}: {cw.TotalBytes}");
+            }
+            catch
+            {
+                state.Abandon();
+                throw;
+            }
+            finally
+            {
+                state.Dispose();
+            }
+        }
+#endif
+
         internal class StreamCopyingBufferWriter : CountingWriter
         {
             private readonly Stream _destination;

--- a/src/protobuf-net.Test/Serializers/Collections.cs
+++ b/src/protobuf-net.Test/Serializers/Collections.cs
@@ -61,6 +61,7 @@ namespace ProtoBuf.Serializers
         [InlineData(typeof(HashSet<int>), typeof(SetSerializer<HashSet<int>, int>))]
         [InlineData(typeof(ISet<int>), typeof(SetSerializer<ISet<int>, int>))]
 #if NET6_0_OR_GREATER
+        [InlineData(typeof(Memory<int>), typeof(MemorySerializer<int>))]
         [InlineData(typeof(IReadOnlySet<int>), typeof(ReadOnlySetSerializer<int>))]
 #endif
         public void TestWhatProviderWeGet(Type type, Type expected)
@@ -89,8 +90,10 @@ namespace ProtoBuf.Serializers
 
         // these are things we'll probably light up later as "repeated",
         [InlineData(typeof(ArraySegment<int>))]
+#if !NET6_0_OR_GREATER
         [InlineData(typeof(Memory<int>))]
         [InlineData(typeof(ReadOnlyMemory<int>))]
+#endif
         [InlineData(typeof(ReadOnlySequence<int>))]
         [InlineData(typeof(IMemoryOwner<int>))]
 
@@ -122,7 +125,7 @@ namespace ProtoBuf.Serializers
             {
                 RepeatedSerializers.TryGetRepeatedProvider(type);
             });
-            Assert.Equal("Serialization cannot work with [ReadOnly]Span<T>; [ReadOnly]Memory<T> may be enabled later", ex.Message);
+            Assert.Equal("Serialization cannot work with [ReadOnly]Span<T>.", ex.Message);
         }
 
         class CustomEnumerable : IEnumerable<int>, ICollection<int>

--- a/src/protobuf-net/Serializers/RepeatedSerializers.cs
+++ b/src/protobuf-net/Serializers/RepeatedSerializers.cs
@@ -65,6 +65,9 @@ namespace ProtoBuf.Serializers
             s_providers = new Hashtable();
 
             // the orignal! the best! accept no substitutes!
+#if NET6_0_OR_GREATER
+            Add(typeof(Memory<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateMemory), root == current ? targs : new[] { root, targs[0] }));
+#endif
             Add(typeof(List<>), (root, current, targs) => Resolve(typeof(RepeatedSerializer), nameof(RepeatedSerializer.CreateList),
                 root == current ? targs : new[] { root, targs[0] }), false);
 
@@ -133,7 +136,7 @@ namespace ProtoBuf.Serializers
                 {
                     if (genDef == typeof(Span<>) || genDef == typeof(ReadOnlySpan<>))
                     {   // needs special handling because can't use Span<T> as a TSomething in a Foo<TSomething>
-                        throw new NotSupportedException("Serialization cannot work with [ReadOnly]Span<T>; [ReadOnly]Memory<T> may be enabled later");
+                        throw new NotSupportedException("Serialization cannot work with [ReadOnly]Span<T>.");
                     }
                     known = NotSupported(s_GeneralNotSupported, type, type.GetGenericArguments()[0]);
                 }
@@ -178,8 +181,10 @@ namespace ProtoBuf.Serializers
             typeof(Span<>),
             typeof(ReadOnlySpan<>),
             typeof(ReadOnlySequence<>),
+#if !NET6_0_OR_GREATER
             typeof(ReadOnlyMemory<>),
             typeof(Memory<>),
+#endif
             typeof(ArraySegment<>),
             typeof(IMemoryOwner<>),
         };


### PR DESCRIPTION
I implemented `MemorySerializer<T>` in protobuf-net.Core/Serializers/RepeatedSerializer.cs by taking existing serializers as reference.
I deliberately skipped `ReadonlyMemory<>` because deserializing would not be possible.
For the time being I placed `MemorySerializer` above the `ListSerializer` in protobuf-net/Serializers/RepeatedSerializers.cs static constructor. I'm not in a position to make the final decision of ranking--even though my instincts really tell me that Memory should rank the first.

The implementation passes all tests added for the new serializer.