### PR TITLE
Reduce allocations for large length-prefixed reads

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ but which makes it really easy to work with idiomatic .NET types, including pre-
 - [Build Tools for protobuf-net and protobuf-net.Grpc](https://protobuf-net.github.io/protobuf-net/build_tools)
 - [Generating code from .proto files at build-time](http://protobuf-net.github.io/protobuf-net/contract_first)
 - [Schema analysis tools](http://protobuf-net.github.io/protobuf-net/schemas)
+- [Memory use and message size limits](https://protobuf-net.github.io/protobuf-net/memory_and_size_limits)
 - [Using protobuf-net with Noda Time](http://protobuf-net.github.io/protobuf-net/nodatime)
 
 ## Donate

--- a/docs/memory_and_size_limits.md
+++ b/docs/memory_and_size_limits.md
@@ -1,0 +1,137 @@
+protobuf-net
+-
+
+# Memory use and message size limits
+
+The Protocol Buffers wire format is compact, and deliberately so - but that means the in-memory
+representation of a message can be substantially *larger* than the bytes it arrived as. If you
+enforce a maximum request or message size (and you should), it is worth knowing the ratio between
+the two, because the limit you set in wire bytes is not the limit you get in memory.
+
+This is a property of the wire format rather than anything specific to protobuf-net; the same
+arithmetic applies to any implementation.
+
+## Where the ratio comes from
+
+Variable-length integer encoding is the main source. A `long` with a small value encodes as a
+single byte on the wire, but still occupies eight bytes in a `long[]` or `List<long>`. A packed
+repeated field of small values is therefore about eight times larger in memory than on the wire,
+before any buffering overhead.
+
+Messages and strings have a similar effect via per-object overhead: a zero-length sub-message is
+two bytes on the wire, but a distinct object on the heap.
+
+## Indicative ratios
+
+Approximate bytes allocated per byte of payload, for 1MiB payloads of small values. Treat these as
+order-of-magnitude guidance rather than exact figures - they vary with runtime, buffer pool state,
+and the values involved:
+
+| field shape | approx. ratio |
+| ----------- | ------------- |
+| packed `long[]` / `List<long>`, varint (default) | 8x, up to ~24x with buffer growth |
+| packed `int[]`, varint (default) | 4x |
+| packed `long[]`, `DataFormat.FixedSize` | 1x |
+| repeated sub-message (small/empty messages) | ~16x |
+| repeated short `string` | ~11x |
+
+The high end of the first row is buffer growth: collections are accumulated into a pooled buffer
+that grows geometrically, so a request that misses the array pool transiently costs more than the
+resulting collection.
+
+## How to apply a limit
+
+There is no single "maximum message size" setting on `TypeModel` - the limit is applied at the point
+you hand data to the serializer, and how you do that depends on where the data comes from.
+
+### The `length` argument is not a limit
+
+It is worth being explicit about this, because the name invites the wrong reading. The `length`
+argument on `Deserialize` declares the **exact size of the message being read**. It is a framing
+mechanism, not a ceiling, and passing a maximum rather than the true size will not do what you want:
+
+| `length` versus the actual message | result |
+| ---------------------------------- | ------ |
+| equal to the message size | reads correctly |
+| larger, and the stream ends | `ProtoException` - "Incorrect number of bytes consumed" |
+| larger, and more data follows | reads on into whatever came next; usually a field-corruption error |
+| smaller | `EndOfStreamException` |
+
+A `MemoryStream` is a misleading special case: because the whole buffer is handed to the reader at
+once, an over-large `length` is quietly clipped to the buffer and appears to work. Do not infer from
+that test passing that the same call is safe against a network stream.
+
+### When you know the exact size
+
+Framed protocols, a `Content-Length`, a database column, a file on disk - pass it:
+
+```csharp
+var obj = Serializer.Deserialize<MyMessage>(stream, length: knownSize);
+```
+
+This is worth doing wherever you can. Besides the framing, it tells the reader how much data
+legitimately exists, so a length-prefix *inside* the message that claims more than that is rejected
+immediately rather than being acted upon.
+
+### When the size is declared in the data
+
+Read the prefix, decide, then pass the accepted length as the exact size:
+
+```csharp
+int len = ProtoReader.ReadLengthPrefix(stream, expectHeader: false, PrefixStyle.Base128,
+    out _, out _);
+if (len > MaxBytes) throw new InvalidDataException($"message too large: {len} bytes");
+var obj = Serializer.Deserialize<MyMessage>(stream, length: len);
+```
+
+### When you don't know the size and want a cap
+
+This is the case the `length` argument cannot serve. Bound the *input* instead - read up to your
+ceiling and refuse anything larger, then deserialize what you accepted:
+
+```csharp
+using var buffered = new MemoryStream();
+var chunk = new byte[8192];
+int read;
+while ((read = source.Read(chunk, 0, chunk.Length)) > 0)
+{
+    if (buffered.Length + read > MaxBytes)
+        throw new InvalidDataException("message too large");
+    buffered.Write(chunk, 0, read);
+}
+buffered.Position = 0;
+var obj = Serializer.Deserialize<MyMessage>(buffered);
+```
+
+Buffering is not the cost it looks like here: you have capped it, and the reader then knows the exact
+size, which is the best position for it to be in. If you would rather not buffer, the equivalent is a
+small `Stream` wrapper that counts bytes and throws once it passes your ceiling.
+
+### From a buffer
+
+When deserializing from `byte[]`, `ReadOnlyMemory<byte>` or `ReadOnlySequence<byte>` you already own
+the data, so check its length before you call - and the reader knows the exact size regardless, so it
+can reject implausible prefixes without help.
+
+### At the host
+
+If you are behind ASP.NET Core or gRPC, the cheapest limit is usually the one you never write
+yourself: Kestrel's `MaxRequestBodySize`, or `MaxReceiveMessageSize` for gRPC. Set those from your
+memory budget using the ratios above.
+
+## Practical guidance
+
+- **Size your limits from the memory budget, not the wire budget.** If you can afford *M* bytes of
+  memory for a deserialized message, a wire limit somewhere around *M*/24 is a safe starting point
+  for messages containing large packed varint collections, and you can raise it considerably if you
+  know your shapes.
+- **Use `DataFormat.FixedSize` for large numeric collections** if you want a predictable 1:1 ratio.
+  It costs more bytes on the wire for small values, but the memory cost stops being a multiple of
+  the payload size. This is worth considering for anything reading numeric arrays from an untrusted
+  source.
+- **Constrain nesting with `TypeModel.MaxDepth`** (default 512) if you accept arbitrary messages;
+  deeply nested data costs stack and bookkeeping independently of payload size.
+- **Prefer bounded readers where you can.** A `ReadOnlySequence<byte>`, a `MemoryStream`, or a stream
+  read with its true length lets the reader see how much data actually exists, so an implausible
+  length-prefix is rejected immediately rather than being taken at face value. An unbounded `Stream`
+  cannot offer that; reads there proceed incrementally instead of failing up front.

--- a/src/protobuf-net.Core/ProtoReader.ReadOnlySequence.cs
+++ b/src/protobuf-net.Core/ProtoReader.ReadOnlySequence.cs
@@ -143,11 +143,13 @@ namespace ProtoBuf
             }
 
             private ReadOnlySequence<byte>.Enumerator _source;
+            private long _end;
 
             public override void Dispose()
             {
                 base.Dispose();
                 _source = default;
+                _end = 0;
                 Pool<ReadOnlySequenceProtoReader>.Put(this);
             }
 
@@ -155,7 +157,11 @@ namespace ProtoBuf
             {
                 base.Init(model, userState);
                 _source = source.GetEnumerator();
+                _end = source.Length;
             }
+
+            // the length of a sequence is always known, so we can always answer this exactly
+            private protected override long MaxRemaining => _end - LongPosition;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private int GetSomeData(ref State state, bool throwIfEOF = true)
@@ -269,6 +275,7 @@ namespace ProtoBuf
             {
                 // we should probably do the work with a Decoder,
                 // but this works for today
+                state.AssertPlausibleLength(bytes); // don't rent against a length we can't satisfy
                 var arr = BufferPool.GetBuffer(bytes);
                 try
                 {

--- a/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
+++ b/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
@@ -2,6 +2,7 @@
 using ProtoBuf.Meta;
 using ProtoBuf.Serializers;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -243,6 +244,111 @@ namespace ProtoBuf
                 } while (TryReadFieldHeader(field));
             }
 
+            /// <summary>
+            /// The maximum number of bytes that could still be read at this point: the lesser of what
+            /// the source can supply and what the enclosing length-based sub-message allows. Negative
+            /// if neither is knowable (an unbounded stream, outside of any sub-message).
+            /// </summary>
+            private readonly long GetMaxRemaining()
+            {
+                var reader = _reader;
+                var fromSource = reader.MaxRemaining;
+
+                var blockEnd = reader.blockEnd64;
+                if (blockEnd == long.MaxValue) return fromSource; // not inside a length-based block
+
+                var fromBlock = blockEnd - reader._longPosition;
+                return fromSource < 0 ? fromBlock : Math.Min(fromSource, fromBlock);
+            }
+
+            /// <summary>
+            /// Rejects a length taken from the payload when the source provably cannot satisfy it; this
+            /// is what stops a tiny message from claiming a huge length. Lengths at or below
+            /// <see cref="ProtoReader.EagerAllocationLimit"/> are not policed, and neither is anything
+            /// on a source whose remaining length is unknowable.
+            /// </summary>
+            [MethodImpl(HotPath)]
+            internal void AssertPlausibleLength(long length)
+            {
+                if (length > ProtoReader.EagerAllocationLimit) AssertPlausibleLengthSlow(length);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private void AssertPlausibleLengthSlow(long length)
+            {
+                var remaining = GetMaxRemaining();
+                if (remaining >= 0 && length > remaining) ThrowImplausibleLength(length, remaining);
+            }
+
+            /// <summary>
+            /// Indicates whether it is safe to allocate <paramref name="length"/> bytes for data that
+            /// hasn't been read yet. Throws if the source is known to be too short; returns
+            /// <c>false</c> if the length is large and the source can't confirm it, in which case the
+            /// caller must read the data in bounded chunks rather than trusting the prefix.
+            /// </summary>
+            [MethodImpl(HotPath)]
+            internal bool CanAllocate(long length)
+                => length <= ProtoReader.EagerAllocationLimit || CanAllocateSlow(length);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private bool CanAllocateSlow(long length)
+            {
+                var remaining = GetMaxRemaining();
+                if (remaining < 0) return false; // unknowable; the caller needs to chunk it
+                if (length > remaining) ThrowImplausibleLength(length, remaining);
+                return true;
+            }
+
+            /// <summary>
+            /// Reads <paramref name="length"/> bytes into a pooled buffer that grows only as data
+            /// actually arrives, so that a payload overstating its length fails with EOF having cost
+            /// an allocation proportional to what it supplied rather than what it claimed. The caller
+            /// must return the buffer to <see cref="ArrayPool{T}.Shared"/>.
+            /// </summary>
+            private byte[] ReadBytesOversized(int length)
+            {
+                var pool = ArrayPool<byte>.Shared;
+                var buffer = pool.Rent(Math.Min(length, ProtoReader.EagerAllocationLimit));
+                try
+                {
+                    int have = 0;
+                    while (have < length)
+                    {
+                        if (have == buffer.Length)
+                        {   // double up, but never past what was claimed
+                            var larger = pool.Rent((int)Math.Min((long)buffer.Length * 2, length));
+                            Buffer.BlockCopy(buffer, 0, larger, 0, have);
+                            pool.Return(buffer);
+                            buffer = larger;
+                        }
+                        // cap each read so that the reader's own buffer stays bounded too
+                        var take = Math.Min(Math.Min(buffer.Length, length) - have, ProtoReader.EagerAllocationLimit);
+                        _reader.ImplReadBytes(ref this, new Span<byte>(buffer, have, take)); // EOF if short
+                        have += take;
+                    }
+                    return buffer;
+                }
+                catch
+                {
+                    pool.Return(buffer);
+                    throw;
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            internal string ReadStringOversized(int bytes)
+            {
+                var buffer = ReadBytesOversized(bytes);
+                try
+                {
+                    return ProtoReader.UTF8.GetString(buffer, 0, bytes);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+
             [MethodImpl(ProtoReader.HotPath)]
             private void ReadPackedScalar<TSerializer, TList, T>(ref TList list, WireType wireType, in TSerializer serializer)
                 where TSerializer : ISerializer<T>
@@ -251,6 +357,7 @@ namespace ProtoBuf
                 var bytes = (int)ReadUInt32Varint(Read32VarintMode.Unsigned);
                 if (bytes == 0) return;
                 if (bytes < 0) ThrowInvalidLength(bytes);
+                AssertPlausibleLength(bytes);
                 switch (wireType)
                 {
                     case WireType.Fixed32:
@@ -377,19 +484,31 @@ namespace ProtoBuf
                         if (len == 0) return converter.NonNull(value);
                         if (len < 0) ThrowInvalidLength(len);
 
-                        // expand the storage
+                        // Expand allocates the full claimed length before we've read a byte of it; if
+                        // the source can't confirm that it holds that much, buffer the payload first
+                        // (growing only as data arrives) so that a lie costs us what it supplied
+                        byte[] oversized = CanAllocate(len) ? null : ReadBytesOversized(len);
+                        try
+                        {
+                            // expand the storage
 #if DEBUG
-                        var oldLength = converter.GetLength(value);
+                            var oldLength = converter.GetLength(value);
 #endif
-                        var newChunk = converter.Expand(Context, ref value, len);
+                            var newChunk = converter.Expand(Context, ref value, len);
 #if DEBUG
-                        if (converter.GetLength(value) != (oldLength + len))
-                            ThrowHelper.ThrowInvalidOperationException($"The memory converter ({converter.GetType().NormalizeName()}) got the lengths wrong for the updated value; expected {oldLength + len}, got {converter.GetLength(value)}");
-                        if (newChunk.Length != len)
-                            ThrowHelper.ThrowInvalidOperationException($"The memory converter ({converter.GetType().NormalizeName()}) got the lengths wrong for the returned chunk; expected {len}, got {newChunk.Length}");
-#endif               
-                        // read the data into the new part
-                        _reader.ImplReadBytes(ref this, newChunk.Span);
+                            if (converter.GetLength(value) != (oldLength + len))
+                                ThrowHelper.ThrowInvalidOperationException($"The memory converter ({converter.GetType().NormalizeName()}) got the lengths wrong for the updated value; expected {oldLength + len}, got {converter.GetLength(value)}");
+                            if (newChunk.Length != len)
+                                ThrowHelper.ThrowInvalidOperationException($"The memory converter ({converter.GetType().NormalizeName()}) got the lengths wrong for the returned chunk; expected {len}, got {newChunk.Length}");
+#endif
+                            // read the data into the new part
+                            if (oversized is null) _reader.ImplReadBytes(ref this, newChunk.Span);
+                            else new ReadOnlySpan<byte>(oversized, 0, len).CopyTo(newChunk.Span);
+                        }
+                        finally
+                        {
+                            if (oversized is not null) ArrayPool<byte>.Shared.Return(oversized);
+                        }
 
                         return value;
                     //case WireType.Varint:
@@ -515,6 +634,10 @@ namespace ProtoBuf
                     case WireType.String:
                         long len = (long)ReadUInt64Varint();
                         if (len < 0) ThrowInvalidOperationException();
+                        // deliberately *not* vetting len against the source length here: nothing is
+                        // allocated from it, and callers depend on corruption being reported by the
+                        // existing end-group/sub-message checks instead (see issue 697). The
+                        // allocating paths still bound themselves via blockEnd64.
                         long lastEnd = reader.blockEnd64;
                         reader.blockEnd64 = reader._longPosition + len;
                         if (reader.IncrDepth()) ThrowTooDeep();
@@ -822,6 +945,10 @@ namespace ProtoBuf
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             internal void ThrowInvalidLength(long length) => ThrowInvalidOperationException("Invalid length: " + length.ToString());
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            internal void ThrowImplausibleLength(long length, long remaining)
+                => ThrowInvalidOperationException($"Invalid length: {length}; the source has at most {remaining} bytes remaining");
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             internal void ThrowArgumentException(string message)

--- a/src/protobuf-net.Core/ProtoReader.Stream.cs
+++ b/src/protobuf-net.Core/ProtoReader.Stream.cs
@@ -335,6 +335,10 @@ namespace ProtoBuf
 
             private protected override string ImplReadString(ref State state, int bytes)
             {
+                // Ensure would grow _ioBuffer to the full claimed length before reading a single
+                // byte of it; if we can't vouch for that length, read in chunks instead
+                if (!state.CanAllocate(bytes)) return state.ReadStringOversized(bytes);
+
                 if (_available < bytes) Ensure(ref state, bytes, true);
 
                 string s = UTF8.GetString(_ioBuffer, _ioIndex, bytes);
@@ -347,6 +351,19 @@ namespace ProtoBuf
 
             private protected override bool IsFullyConsumed(ref State state) =>
                 (_isFixedLength ? _dataRemaining64 : _available) == 0;
+
+            private protected override long MaxRemaining
+            {
+                get
+                {
+                    // no source means the whole payload was handed to us as a single buffer
+                    if (_source is null) return _available;
+                    // otherwise: what we've buffered, plus what we're still allowed to pull
+                    if (_isFixedLength) return _available + _dataRemaining64;
+                    // an unbounded stream; we genuinely cannot know
+                    return TO_EOF;
+                }
+            }
 
             private protected override uint ImplReadUInt32Fixed(ref State state)
             {

--- a/src/protobuf-net.Core/ProtoReader.cs
+++ b/src/protobuf-net.Core/ProtoReader.cs
@@ -79,6 +79,21 @@ namespace ProtoBuf
         internal const long TO_EOF = -1;
 
         /// <summary>
+        /// Lengths at or below this are taken at face value; vetting them isn't worth the cycles,
+        /// and a payload that lies about a length this small can't do much harm. Above this, a
+        /// claimed length is checked against <see cref="MaxRemaining"/> before it is allowed to
+        /// size an allocation; where that isn't knowable, the data is read in bounded chunks
+        /// instead of being trusted up-front.
+        /// </summary>
+        internal const int EagerAllocationLimit = 32 * 1024;
+
+        /// <summary>
+        /// The maximum number of bytes that this source could still supply, or a negative value if
+        /// that cannot be determined cheaply (i.e. a stream of unknown length).
+        /// </summary>
+        private protected abstract long MaxRemaining { get; }
+
+        /// <summary>
         /// Gets / sets a flag indicating whether strings should be checked for repetition; if
         /// true, any repeated UTF-8 byte sequence will result in the same String instance, rather
         /// than a second instance of the same string. Disabled by default. Note that this uses

--- a/src/protobuf-net.Test/LengthPrefixAllocationTests.cs
+++ b/src/protobuf-net.Test/LengthPrefixAllocationTests.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf.Test
+{
+    /// <summary>
+    /// Asserts that a length-prefix is not used to size an allocation before the data behind it has
+    /// been read. A prefix that overstates the data available should fail cheaply, with allocation
+    /// proportional to the bytes actually supplied rather than to the declared length.
+    /// </summary>
+    public class LengthPrefixAllocationTests
+    {
+        // large enough that an allocation against it is unmistakable in the measurement, small
+        // enough to stay comfortably allocatable so the assertion reports rather than OOMs
+        const int ClaimedLength = 512 * 1024 * 1024;
+
+        // headroom for the read itself; the bounded paths rent at most a handful of 32KiB chunks
+        const long AllowedBytes = 4 * 1024 * 1024;
+
+        [ProtoContract]
+        public class HazBlob
+        {
+            [ProtoMember(1)]
+            public byte[] Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazString
+        {
+            [ProtoMember(1)]
+            public string Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazPackedFixed
+        {
+            [ProtoMember(1, IsPacked = true, DataFormat = DataFormat.FixedSize)]
+            public long[] Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazPackedVarint
+        {
+            [ProtoMember(1, IsPacked = true)]
+            public int[] Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazSubMessage
+        {
+            [ProtoMember(1)]
+            public HazString Value { get; set; }
+        }
+
+        /// <summary>
+        /// field 1, wire-type 2 (length-prefixed), declaring <paramref name="length"/> bytes -
+        /// and then supplying none of them.
+        /// </summary>
+        static byte[] OverstatedLengthPrefix(int length = ClaimedLength)
+        {
+            var buffer = new List<byte> { 0x0A }; // field 1, WireType.String
+            var value = (uint)length;
+            while (value > 127)
+            {
+                buffer.Add((byte)(value | 0x80));
+                value >>= 7;
+            }
+            buffer.Add((byte)value);
+            return buffer.ToArray();
+        }
+
+        [Fact]
+        public void OverstatedLengthPrefixEncoding() // sanity-check the payload construction itself
+        {
+            Assert.Equal(new byte[] { 0x0A, 0x80, 0x80, 0x80, 0x80, 0x02 }, OverstatedLengthPrefix());
+        }
+
+        // ---- the four ways a payload reaches a reader ----------------------------------------
+
+        static void ViaMemoryStream<T>(byte[] payload)
+        {
+            // StreamProtoReader, but the buffer is handed over wholesale: length is known exactly
+            using var ms = new MemoryStream(payload);
+            Serializer.Deserialize<T>(ms);
+        }
+
+        static void ViaUnboundedStream<T>(byte[] payload)
+        {
+            // StreamProtoReader with a stream it can neither seek nor size: length is unknowable
+            using var stream = new UnseekableStream(payload);
+            Serializer.Deserialize<T>(stream);
+        }
+
+        static void ViaSingleSegment<T>(byte[] payload)
+        {
+            Serializer.Deserialize<T>(new ReadOnlySequence<byte>(payload));
+        }
+
+        static void ViaMultiSegment<T>(byte[] payload)
+        {
+            // ReadOnlySequenceProtoReader across segment boundaries - the pipelines/Kestrel shape
+            Serializer.Deserialize<T>(Segment.Create(payload, chunkSize: 2));
+        }
+
+        public static IEnumerable<object[]> AllReaders => new[]
+        {
+            new object[] { nameof(ViaMemoryStream) },
+            new object[] { nameof(ViaUnboundedStream) },
+            new object[] { nameof(ViaSingleSegment) },
+            new object[] { nameof(ViaMultiSegment) },
+        };
+
+        static void Invoke<T>(string reader, byte[] payload)
+        {
+            switch (reader)
+            {
+                case nameof(ViaMemoryStream): ViaMemoryStream<T>(payload); break;
+                case nameof(ViaUnboundedStream): ViaUnboundedStream<T>(payload); break;
+                case nameof(ViaSingleSegment): ViaSingleSegment<T>(payload); break;
+                case nameof(ViaMultiSegment): ViaMultiSegment<T>(payload); break;
+                default: throw new ArgumentOutOfRangeException(nameof(reader));
+            }
+        }
+
+        // ---- the tests ------------------------------------------------------------------------
+
+        [Theory, MemberData(nameof(AllReaders))]
+        public void BlobDoesNotAllocateAgainstClaimedLength(string reader)
+            => AssertBoundedAllocation<HazBlob>(reader, OverstatedLengthPrefix());
+
+        [Theory, MemberData(nameof(AllReaders))]
+        public void StringDoesNotAllocateAgainstClaimedLength(string reader)
+            => AssertBoundedAllocation<HazString>(reader, OverstatedLengthPrefix());
+
+        [Theory, MemberData(nameof(AllReaders))]
+        public void PackedFixedDoesNotAllocateAgainstClaimedLength(string reader)
+            => AssertBoundedAllocation<HazPackedFixed>(reader, OverstatedLengthPrefix());
+
+        [Theory, MemberData(nameof(AllReaders))]
+        public void PackedVarintDoesNotAllocateAgainstClaimedLength(string reader)
+            => AssertBoundedAllocation<HazPackedVarint>(reader, OverstatedLengthPrefix());
+
+        [Theory, MemberData(nameof(AllReaders))]
+        public void SubMessageDoesNotAllocateAgainstClaimedLength(string reader)
+            => AssertBoundedAllocation<HazSubMessage>(reader, OverstatedLengthPrefix());
+
+        /// <summary>
+        /// A blob whose length-prefix is honest must still round-trip, including at sizes past the
+        /// point where the reader stops trusting the prefix outright.
+        /// </summary>
+        [Theory, MemberData(nameof(AllReaders))]
+        public void HonestLargeBlobStillRoundTrips(string reader)
+        {
+            var expected = new byte[256 * 1024]; // comfortably over the 32KiB eager-allocation limit
+            new Random(12345).NextBytes(expected);
+
+            using var ms = new MemoryStream();
+            Serializer.Serialize(ms, new HazBlob { Value = expected });
+            var payload = ms.ToArray();
+
+            HazBlob actual = null;
+            switch (reader)
+            {
+                case nameof(ViaMemoryStream):
+                    using (var source = new MemoryStream(payload)) actual = Serializer.Deserialize<HazBlob>(source);
+                    break;
+                case nameof(ViaUnboundedStream):
+                    using (var source = new UnseekableStream(payload)) actual = Serializer.Deserialize<HazBlob>(source);
+                    break;
+                case nameof(ViaSingleSegment):
+                    actual = Serializer.Deserialize<HazBlob>(new ReadOnlySequence<byte>(payload));
+                    break;
+                case nameof(ViaMultiSegment):
+                    actual = Serializer.Deserialize<HazBlob>(Segment.Create(payload, chunkSize: 1024));
+                    break;
+            }
+
+            Assert.Equal(expected, actual.Value);
+        }
+
+        /// <summary>
+        /// As above, for strings - this is the path that previously had to fit the whole value in a
+        /// single contiguous buffer sized from the prefix.
+        /// </summary>
+        [Theory, MemberData(nameof(AllReaders))]
+        public void HonestLargeStringStillRoundTrips(string reader)
+        {
+            // include multi-byte characters so a chunked decode can't get away with byte-slicing
+            var expected = string.Join("|", new string('a', 100_000), new string('ä', 100_000), new string('中', 100_000));
+
+            using var ms = new MemoryStream();
+            Serializer.Serialize(ms, new HazString { Value = expected });
+            var payload = ms.ToArray();
+
+            HazString actual = null;
+            switch (reader)
+            {
+                case nameof(ViaMemoryStream):
+                    using (var source = new MemoryStream(payload)) actual = Serializer.Deserialize<HazString>(source);
+                    break;
+                case nameof(ViaUnboundedStream):
+                    using (var source = new UnseekableStream(payload)) actual = Serializer.Deserialize<HazString>(source);
+                    break;
+                case nameof(ViaSingleSegment):
+                    actual = Serializer.Deserialize<HazString>(new ReadOnlySequence<byte>(payload));
+                    break;
+                case nameof(ViaMultiSegment):
+                    actual = Serializer.Deserialize<HazString>(Segment.Create(payload, chunkSize: 1024));
+                    break;
+            }
+
+            Assert.Equal(expected, actual.Value);
+        }
+
+        // ---- assertion machinery --------------------------------------------------------------
+
+        /// <summary>
+        /// Asserts that deserializing the payload fails, and that it fails without allocating
+        /// anything like the length it claimed.
+        /// </summary>
+        static void AssertBoundedAllocation<T>(string reader, byte[] payload)
+        {
+            // warm up every code path involved (JIT, model build, serializer construction) against
+            // a well-formed payload, so that the measurement below sees only the read itself
+            try { Invoke<T>(reader, new byte[] { 0x0A, 0x00 }); } catch { }
+
+            long before = GetAllocatedBytes();
+            var ex = Record.Exception(() => Invoke<T>(reader, payload));
+            long allocated = GetAllocatedBytes() - before;
+
+            Assert.NotNull(ex); // the prefix cannot be satisfied; it must not succeed
+            Assert.IsNotType<OutOfMemoryException>(ex);
+            Assert.True(allocated < AllowedBytes,
+                $"{reader}/{typeof(T).Name}: allocated {allocated:n0} bytes for a payload of {payload.Length} bytes claiming {ClaimedLength:n0}; threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        static long GetAllocatedBytes()
+        {
+#if NET8_0_OR_GREATER
+            return GC.GetAllocatedBytesForCurrentThread();
+#else
+            return GC.GetTotalMemory(forceFullCollection: false);
+#endif
+        }
+
+        // ---- helpers --------------------------------------------------------------------------
+
+        /// <summary>A stream that reveals nothing about its length, forcing the streaming reader.</summary>
+        sealed class UnseekableStream : Stream
+        {
+            private readonly byte[] _data;
+            private int _position;
+            public UnseekableStream(byte[] data) => _data = data;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override void Flush() { }
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int take = Math.Min(count, _data.Length - _position);
+                if (take <= 0) return 0;
+                Buffer.BlockCopy(_data, _position, buffer, offset, take);
+                _position += take;
+                return take;
+            }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        /// <summary>Splits a payload into a genuinely multi-segment sequence.</summary>
+        sealed class Segment : ReadOnlySequenceSegment<byte>
+        {
+            public static ReadOnlySequence<byte> Create(byte[] data, int chunkSize)
+            {
+                Segment first = null, last = null;
+                for (int offset = 0; offset < data.Length; offset += chunkSize)
+                {
+                    var chunk = new ReadOnlyMemory<byte>(data, offset, Math.Min(chunkSize, data.Length - offset));
+                    var next = new Segment { Memory = chunk, RunningIndex = offset };
+                    if (first is null) first = next;
+                    else last.Next = next;
+                    last = next;
+                }
+                if (first is null) return ReadOnlySequence<byte>.Empty;
+                return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reduce memory allocations in incomplete message scenarios.

With thanks to @pawlos