### PR TITLE
PBN0022 no longer fires for collection members

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -20,6 +20,9 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
   `protobuf-net.BuildTools` package alongside remains harmless
 - **fix**: `protobuf-net.NodaTime` did not produce a package from a plain build (missing
   `GeneratePackageOnBuild`), and packed with a placeholder description
+- **fix**: `PBN0022` ("should declare `IsRequired`") no longer fires for collection members —
+  `List<T> Lines { get; } = [];` is the standard pattern, an empty collection has no wire presence
+  to force, and `IsRequired` is only observable for value-type scalars anyway
 
 ## 3.3.0
 

--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
@@ -42,6 +42,31 @@ namespace BuildToolsUnitTests
             );
         }
 
+        // a collection member has no wire presence to force - an empty collection writes nothing,
+        // and IsRequired is only observable for value-type scalars - so initializing one (the
+        // standard pattern, including getter-only) must not trigger the IsRequired nag
+        [Theory]
+        [InlineData("System.Collections.Generic.List<int>", "new()")]
+        [InlineData("System.Collections.Generic.Dictionary<int, string>", "new()")]
+        [InlineData("System.Collections.Generic.IList<int>", "new System.Collections.Generic.List<int>()")]
+        [InlineData("int[]", "new int[0]")]
+        public async Task DoesNotReportShouldDeclareIsRequiredForCollections(string type, string value)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+
+                [ProtoContract]
+                public class Foo {{
+                    [ProtoMember(1)] public {type} FieldBar = {value};
+                    [ProtoMember(2)] public {type} PropertyBar {{ get; set; }} = {value};
+                    [ProtoMember(3)] public {type} GetterOnlyBar {{ get; }} = {value};
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
+        }
+
         [Theory]
         [InlineData("bool", "true")]
         [InlineData("DayOfWeek", "DayOfWeek.Monday")]

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -556,7 +556,27 @@ namespace ProtoBuf.BuildTools.Internal
         }
 
         /// <remarks>Ensure to validate member before (i.e. calculate default value of member)</remarks>
-        private bool ShouldDeclareIsRequired(Member member) => !member.IsRequired;
+        private bool ShouldDeclareIsRequired(Member member)
+            => !member.IsRequired && !IsCollectionLike(member.MemberType);
+
+        // A collection member is exempt from the IsRequired nag: an empty collection has no wire
+        // presence to force (repeated fields write per element), initializing to an empty collection
+        // is the standard pattern, and IsRequired is only observable for value-type scalars anyway.
+        // This is deliberately broader than the runtime's TryGetRepeatedProvider walk, which decides
+        // the *serializer*: suppressing the nag on an exotic type the runtime treats as a message is
+        // harmless, where nagging on `List<T> x { get; } = [];` is not. Strings are IEnumerable but
+        // are scalars, and are kept out explicitly.
+        private static bool IsCollectionLike(ITypeSymbol? type)
+        {
+            if (type is null || type.SpecialType == SpecialType.System_String) return false;
+            if (type is IArrayTypeSymbol) return true;
+            if (type.SpecialType == SpecialType.System_Collections_IEnumerable) return true;
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (iface.SpecialType == SpecialType.System_Collections_IEnumerable) return true;
+            }
+            return false;
+        }
 
         /// <remarks>Ensure to validate member before (i.e. calculate default value of member)</remarks>
         private bool ShouldDeclareDefault(Member member, object? memberInitValue)

--- a/src/protobuf-net.BuildTools/Internal/TypeItems.cs
+++ b/src/protobuf-net.BuildTools/Internal/TypeItems.cs
@@ -25,17 +25,18 @@ namespace ProtoBuf.BuildTools.Internal
         public ISymbol Symbol { get; }
         public bool IsRequired { get; }
 
+        public ITypeSymbol? MemberType => Symbol switch
+        {
+            IPropertySymbol propSym => propSym.Type,
+            IFieldSymbol fieldSym => fieldSym.Type,
+            _ => null
+        };
+
         public SpecialType? SymbolSpecialType
         {
             get
             {
-                var memberSymbol = Symbol switch
-                {
-                    IPropertySymbol propSym => propSym.Type,
-                    IFieldSymbol fieldSym => fieldSym.Type,
-                    _ => null
-                };
-
+                var memberSymbol = MemberType;
                 if (memberSymbol?.TypeKind == TypeKind.Enum) return SpecialType.System_Enum;
                 return memberSymbol?.SpecialType;
             }


### PR DESCRIPTION
`[ProtoMember(4)] public List<OrderLine> Lines { get; } = [];` triggered PBN0022 ("should declare `IsRequired`"). It should not, and no collection should: an empty collection has no wire presence to force (repeated fields write per element), the initializer is the standard pattern, and the suggested fix is a no-op - `IsRequired` is only observable for value-type scalars.

The exemption is any array or `IEnumerable`-implementing type except `string`, applied in `ShouldDeclareIsRequired`. Deliberately broader than the runtime's `TryGetRepeatedProvider` walk: over-suppression can only hide the nag on exotic shapes (ambiguous `IEnumerable<T>` pairs, `IgnoreListHandling` contracts) where it was equally meaningless, so the cheap predicate is the right altitude - and the faithful `ResolveRepeated` port lives in `ProtoModelGenerator`, which `BuildTools.Legacy` deliberately does not compile, whereas `Internal/` (where this lives) it does. Legacy build verified.

Four new test cases (`List<T>`, `Dictionary<K,V>`, `IList<T>`, `T[]`, each as field / property / getter-only property); full BuildToolsUnitTests suite passes at 324.