### PR TITLE
AOT migration UX: PBN2010's example compiles; the generated model is internal and namespaced

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -20,6 +20,11 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
   `protobuf-net.BuildTools` package alongside remains harmless
 - **fix**: `protobuf-net.NodaTime` did not produce a package from a plain build (missing
   `GeneratePackageOnBuild`), and packed with a placeholder description
+- **fix**: `PBN2010`'s example now shows `Model.Instance.Serialize` — the generated accessor that
+  actually exists — rather than an imaginary camel-cased local
+- **fix**: the "add an AOT model" code fix now generates the model as `internal` (a fixer should not
+  add to the public surface) and inside the project's namespace (or the anchor contract's), rather
+  than a `public` type in the global root
 
 ## 3.3.0
 

--- a/src/BuildToolsUnitTests/AotMigrationAnalyzerTests.cs
+++ b/src/BuildToolsUnitTests/AotMigrationAnalyzerTests.cs
@@ -79,6 +79,9 @@ namespace BuildToolsUnitTests
 
             var hit = Assert.Single(diagnostics.Where(static x => x.Id == "PBN2010"));
             Assert.Contains("MyModel", hit.GetMessage());
+            // the example must name something that exists: the generated static accessor, not a
+            // camel-cased local that was never declared
+            Assert.Contains("'MyModel.Instance.Serialize'", hit.GetMessage());
         }
 
         [Fact]

--- a/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
+++ b/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
@@ -53,12 +53,55 @@ using ProtoBuf.Meta;
 // See https://protobuf-net.github.io/protobuf-net/aot
 [ProtoModel]
 [ProtoSerializable(typeof(global::Order))]
-public partial class ProtoModel : TypeModel
+internal partial class ProtoModel : TypeModel
 {
 }
 "));
             // deliberately no expected diagnostic here: the fix adds the model, which is exactly what
             // the announcement was asking for, so it stops firing
+
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+            await test.RunAsync();
+        }
+
+        /// <summary>
+        /// The model must not land in the global root: with no project default namespace to hand
+        /// (this harness supplies none), the anchor contract's namespace is used.
+        /// </summary>
+        [Fact]
+        public async Task GeneratedModelRespectsTheContractNamespace()
+        {
+            var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+                AotMigrationAnalyzer, AddProtoModelCodeFixProvider, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { Preamble + @"
+namespace Shop.Data { [ProtoContract] public class {|#0:Order|} { [ProtoMember(1)] public int Id { get; set; } } }" },
+                },
+            };
+            test.TestState.ExpectedDiagnostics.Add(
+                new DiagnosticResult(AotMigrationAnalyzer.NoModel).WithLocation(0));
+
+            test.FixedState.Sources.Add(Preamble + @"
+namespace Shop.Data { [ProtoContract] public class Order { [ProtoMember(1)] public int Id { get; set; } } }");
+            test.FixedState.Sources.Add(("ProtoModel.cs", @"using ProtoBuf;
+using ProtoBuf.Meta;
+
+// Compile-time serializers for this project. Name the types you serialize *directly*; everything
+// reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
+// sub-types - is included automatically.
+//
+// See https://protobuf-net.github.io/protobuf-net/aot
+namespace Shop.Data
+{
+    [ProtoModel]
+    [ProtoSerializable(typeof(global::Shop.Data.Order))]
+    internal partial class ProtoModel : TypeModel
+    {
+    }
+}
+"));
 
             test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
             await test.RunAsync();

--- a/src/BuildToolsUnitTests/CodeFixes/UseAotModelCodeFixProviderTests.cs
+++ b/src/BuildToolsUnitTests/CodeFixes/UseAotModelCodeFixProviderTests.cs
@@ -63,7 +63,7 @@ namespace BuildToolsUnitTests.CodeFixes
                 }
                 """,
                 new DiagnosticResult(AotMigrationAnalyzer.UsesRuntimeModel).WithLocation(0)
-                    .WithArguments("Serializer.Serialize", "the AOT model 'MyModel'", "myModel", "Serialize"));
+                    .WithArguments("Serializer.Serialize", "the AOT model 'MyModel'", "MyModel", "Serialize"));
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace BuildToolsUnitTests.CodeFixes
                 }
                 """,
                 new DiagnosticResult(AotMigrationAnalyzer.UsesRuntimeModel).WithLocation(0)
-                    .WithArguments("Serializer.Serialize", "the AOT model 'MyModel'", "myModel", "Serialize"));
+                    .WithArguments("Serializer.Serialize", "the AOT model 'MyModel'", "MyModel", "Serialize"));
         }
     }
 }

--- a/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
@@ -39,7 +39,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             title: "Call uses the runtime model, not the AOT model",
             messageFormat: "'{0}' serializes through the runtime model, which reflects and so does not "
                 + "work under native AOT; this project declares {1}, so call it on that instead "
-                + "(for example '{2}.{3}').",
+                + "(for example '{2}.Instance.{3}').",
             category: "ProtoBuf",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
@@ -273,9 +273,12 @@ namespace ProtoBuf.BuildTools.Analyzers
                 .Add(ModelsProperty, string.Join(";", models.Select(static m
                     => m.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))));
 
+            // the example names the generated static accessor - Model.Instance.Serialize - which is
+            // the one form guaranteed to exist and compile; a first cut camel-cased the model name
+            // into an imaginary local ('protoModel.Serialize'), which existed nowhere
             context.ReportDiagnostic(Diagnostic.Create(
                 UsesRuntimeModel, operation.Syntax.GetLocation(), properties, name, which,
-                ToCamel(models[0].Name), method.Name));
+                models[0].Name, method.Name));
         }
 
         /// <summary>
@@ -304,7 +307,5 @@ namespace ProtoBuf.BuildTools.Analyzers
             } && property.ContainingType?.ToDisplayString() == RuntimeTypeModelType;
         }
 
-        private static string ToCamel(string name)
-            => name.Length == 0 ? name : char.ToLowerInvariant(name[0]) + name.Substring(1);
     }
 }

--- a/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
+++ b/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
@@ -63,18 +63,45 @@ namespace ProtoBuf.CodeFixes
         {
             _ = cancellationToken;
             var name = contract.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            var source = $@"using ProtoBuf;
-using ProtoBuf.Meta;
 
-// Compile-time serializers for this project. Name the types you serialize *directly*; everything
+            // the project's own namespace, falling back to the anchor contract's: the model must not
+            // land in the global root just because a fixer wrote it. DefaultNamespace is null outside
+            // IDE-shaped hosts, which is what the fallback is for.
+            var ns = project.DefaultNamespace;
+            if (string.IsNullOrEmpty(ns) && contract.ContainingNamespace is { IsGlobalNamespace: false } containing)
+            {
+                ns = containing.ToDisplayString();
+            }
+
+            // internal, deliberately: a serialization model is project infrastructure, and a fixer
+            // should not add to the public surface. Block-scoped namespace, so the output parses at
+            // whatever LangVersion the project is on.
+            const string Comment = @"// Compile-time serializers for this project. Name the types you serialize *directly*; everything
 // reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
 // sub-types - is included automatically.
 //
 // See https://protobuf-net.github.io/protobuf-net/aot
-[ProtoModel]
+";
+            var source = string.IsNullOrEmpty(ns)
+                ? $@"using ProtoBuf;
+using ProtoBuf.Meta;
+
+{Comment}[ProtoModel]
 [ProtoSerializable(typeof({name}))]
-public partial class ProtoModel : TypeModel
+internal partial class ProtoModel : TypeModel
 {{
+}}
+"
+                : $@"using ProtoBuf;
+using ProtoBuf.Meta;
+
+{Comment}namespace {ns}
+{{
+    [ProtoModel]
+    [ProtoSerializable(typeof({name}))]
+    internal partial class ProtoModel : TypeModel
+    {{
+    }}
 }}
 ";
             // a unique name, so the fix is safe to apply in a project that already has a ProtoModel.cs


### PR DESCRIPTION
Feedback from the first real consumer of the migration flow, two fixes:

**PBN2010's example text named something that does not exist.** It camel-cased the model name into an imaginary local (`protoModel.Serialize`); the example now names the generated static accessor - `ProtoModel.Instance.Serialize` - which is the one form guaranteed to exist and compile (that accessor exists precisely for the mid-migration codebase with no model instance in scope). `ToCamel` is gone.

**The add-a-model fixer contributed a `public` type to the global root.** It now generates `internal` - a serialization model is project infrastructure, and a fixer should not add to the public API surface - and inside a namespace: the project's `DefaultNamespace` where the host supplies one, else the anchor contract's namespace, else (only when both are absent) global. Block-scoped namespace syntax deliberately, so the generated file parses at whatever `LangVersion` the project is on - the `[ProtoModel]` C#12 floor reports as a clean PBN2000 rather than a parse error.

Tests updated (the camel arguments were pinned in the fixer tests) plus a new case for the namespaced output; full BuildToolsUnitTests passes at 321; `BuildTools.Legacy` builds (house rule after touching `CodeFixes/`).