### PR TITLE
get-version scripts for the release flow

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nbgv": {
+      "version": "3.9.50",
+      "commands": [
+        "nbgv"
+      ]
+    }
+  }
+}

--- a/get-version.ps1
+++ b/get-version.ps1
@@ -1,0 +1,20 @@
+# Shows the version the current commit computes - i.e. the tag name to type into the GitHub
+# Release UI. Nerdbank.GitVersioning derives it from src/version.json plus commit height; creating
+# the release does not change it, and release.yml refuses a tag that disagrees with it.
+#
+# Run this on up-to-date main: the version belongs to the commit you are on.
+$ErrorActionPreference = 'Stop'
+Push-Location $PSScriptRoot
+try {
+    dotnet tool restore | Out-Null
+    $v = (dotnet tool run nbgv -- get-version --project src --variable Version).Trim()
+    $tag = ($v.Split('.')[0..2]) -join '.'
+    $where = "$(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
+
+    Write-Output "commit           : $where"
+    Write-Output "computed version : $v"
+    Write-Output "release tag      : $tag"
+    Write-Output ""
+    Write-Output "Releases -> Draft a new release -> tag '$tag' -> publish; release.yml does the rest."
+}
+finally { Pop-Location }

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Shows the version the current commit computes - i.e. the tag name to type into the GitHub
+# Release UI. Nerdbank.GitVersioning derives it from src/version.json plus commit height; creating
+# the release does not change it, and release.yml refuses a tag that disagrees with it.
+#
+# Run this on up-to-date main: the version belongs to the commit you are on.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+dotnet tool restore > /dev/null
+v=$(dotnet tool run nbgv -- get-version --project src --variable Version | tr -d '[:space:]')
+tag=$(echo "$v" | cut -d. -f1-3)
+where="$(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)"
+
+echo "commit           : $where"
+echo "computed version : $v"
+echo "release tag      : $tag"
+echo ""
+echo "Releases -> Draft a new release -> tag '$tag' -> publish; release.yml does the rest."


### PR DESCRIPTION
`./get-version.sh` (Linux/macOS) and `./get-version.ps1` (Windows) print the version the current commit computes and the tag to type into the GitHub Release UI:

```
commit           : main @ ce19b065
computed version : 3.3.4.52761
release tag      : 3.3.4

Releases -> Draft a new release -> tag '3.3.4' -> publish; release.yml does the rest.
```

`nbgv` comes from a new dotnet tool manifest (`.config/dotnet-tools.json`), pinned to **3.9.50** - the same Nerdbank.GitVersioning version the build itself uses - so the script computes exactly what MSBuild will; `dotnet tool restore` is run by the script and is a no-op when cached. No global installs.

Both tested and agree; the release flow is now: run the script on main, draft a release with that tag, publish - the workflow guard still refuses any tag that disagrees, so the two bracket the UX from both sides.