### PR TITLE
Accept bare release tags (3.3.5) as public releases, not just v-prefixed

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -8,8 +8,12 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/tags/\\d+\\.\\d+",
     "^refs/tags/v\\d+\\.\\d+"
   ],
+  "release": {
+    "tagName": "{version}"
+  },
   "cloudBuild": {
     "buildNumber": {
       "enabled": true,


### PR DESCRIPTION
The 3.3.5 release failed its guard step with `Tag '3.3.5' does not match the computed version '3.3.5-gd0fe4e5ae4'` - and the guard was right to refuse: had it passed, the packed nupkgs would have carried that same `-g` suffix. The root cause is that `publicReleaseRefSpec` only listed `^refs/tags/v\d+\.\d+`, while every release tag this repo has ever had is **bare** (`3.3.0`, `3.3.5`). The v-form refspec has never once matched a real tag here.

Two changes to `src/version.json`:

- `^refs/tags/\d+\.\d+` joins the refspec, so bare tags count as public releases (the v-form stays, and the workflow guard already tolerated both spellings);
- `release.tagName` is set to `{version}`, so `nbgv tag` also produces the bare form rather than fighting the convention.

Verified on a real commit: this branch computes **3.3.6**, which is what the next release will be after this merges (3.3.5 never shipped and its number is simply skipped). One operational note learned in the process: run `get-version` on a **clean tree** - NB.GV provisionally treats an uncommitted `version.json` edit as a version change, which skews the display (it corrects itself on commit).