### PR TITLE
AotDifferential: scan the configuration it was built as (unblocks the release workflow)

### DIFF
--- a/src/AotDifferential/Corpus.cs
+++ b/src/AotDifferential/Corpus.cs
@@ -320,12 +320,22 @@ internal sealed class Corpus
         return dir;
     }
 
+    // the configuration this assembly was built as, which by construction is the configuration the
+    // traversal build produced the targets in - CI runs everything Debug, the release workflow
+    // everything Release. A probe-both fallback was considered and rejected: silently scanning a
+    // stale build from the *other* configuration is worse than failing loudly.
+#if DEBUG
+    private const string Configuration = "Debug";
+#else
+    private const string Configuration = "Release";
+#endif
+
     public static IEnumerable<string> DefaultTargets()
     {
         if (RepoRoot() is not { } dir) yield break;
         foreach (var project in new[] { "protobuf-net.Test", "Examples", "protobuf-net.Reflection.Test" })
         {
-            yield return Path.Combine(dir, "src", project, "bin", "Debug", "net8.0", project + ".dll");
+            yield return Path.Combine(dir, "src", project, "bin", Configuration, "net8.0", project + ".dll");
         }
     }
 


### PR DESCRIPTION
The 3.3.6 release run failed at the AOT differential with `nothing to scan; build the target projects first`: `Corpus.DefaultTargets()` hardcoded `bin/Debug/net8.0`, which CI never noticed because CI builds Debug - the release workflow builds Release, so the scanner found no target assemblies and (correctly, loudly) killed the run before pack/push.

The path now follows the configuration the differential itself was built as (`#if DEBUG`), which by construction is the configuration the traversal build produced the targets in - Debug in CI, Release in the release workflow. Probe-both-configurations was considered and rejected: silently scanning a stale build from the other configuration would be worse than failing loudly.

Verified both ways locally: Release recipe (exact workflow invocation) compares 3,019 contracts at 100% match; Debug compares 3,021 at 100% (the two extra are Span-shaped fixtures the Release filler also cannot instantiate - reported, not hidden).

Release logistics: the 3.3.6 tag is burned (a release event runs the tree as of the tag, which has the old path), so after this merges the flow is: delete the 3.3.6 release/tag, run `get-version` (it will say **3.3.7**), tag and release that.