### PR TITLE
Release workflow: --skip-duplicate (singular)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,4 +76,4 @@ jobs:
         user: ${{ secrets.NUGET_USER }}
     - name: Push to nuget.org
       if: github.event_name == 'release'
-      run: dotnet nuget push .nupkgs\*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicates
+      run: dotnet nuget push .nupkgs\*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
The 3.3.7 run got further than any before it - guard, build, tests, differential, pack, artifact upload and the **trusted-publishing OIDC login all succeeded** - and then died on the final command: `dotnet nuget push` spells the flag `--skip-duplicate`, not `--skip-duplicates`. One character.

Same tag-burning rule as before (a release event runs the workflow as of the tag), so after this merges: delete the 3.3.7 release/tag, `get-version` will say **3.3.8**, release that. Every step of the pipeline has now been individually proven on a real release run except the upload itself, whose syntax is now actually valid.