### PR TITLE
Add-a-model fixer: resolve the namespace from RootNamespace first

### DIFF
--- a/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
+++ b/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
@@ -65,6 +65,55 @@ internal partial class ProtoModel : TypeModel
         }
 
         /// <summary>
+        /// The console-app shape: top-level statements put the contracts in the global namespace,
+        /// so the contract's namespace says nothing - but RootNamespace (which MSBuild defaults to
+        /// the project name, and the SDK makes compiler-visible) still names the right home. A
+        /// project ConsoleApp11 gets its model in namespace ConsoleApp11.
+        /// </summary>
+        [Fact]
+        public async Task GeneratedModelUsesRootNamespaceWhenContractIsGlobal()
+        {
+            var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+                AotMigrationAnalyzer, AddProtoModelCodeFixProvider, DefaultVerifier>
+            {
+                TestState =
+                {
+                    Sources = { Preamble + @"
+[ProtoContract] public class {|#0:Order|} { [ProtoMember(1)] public int Id { get; set; } }" },
+                    AnalyzerConfigFiles = { ("/.globalconfig", @"is_global = true
+build_property.RootNamespace = ConsoleApp11") },
+                },
+            };
+            test.TestState.ExpectedDiagnostics.Add(
+                new DiagnosticResult(AotMigrationAnalyzer.NoModel).WithLocation(0));
+
+            test.FixedState.Sources.Add(Preamble + @"
+[ProtoContract] public class Order { [ProtoMember(1)] public int Id { get; set; } }");
+            test.FixedState.AnalyzerConfigFiles.Add(("/.globalconfig", @"is_global = true
+build_property.RootNamespace = ConsoleApp11"));
+            test.FixedState.Sources.Add(("ProtoModel.cs", @"using ProtoBuf;
+using ProtoBuf.Meta;
+
+// Compile-time serializers for this project. Name the types you serialize *directly*; everything
+// reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
+// sub-types - is included automatically.
+//
+// See https://protobuf-net.github.io/protobuf-net/aot
+namespace ConsoleApp11
+{
+    [ProtoModel]
+    [ProtoSerializable(typeof(global::Order))]
+    internal partial class ProtoModel : TypeModel
+    {
+    }
+}
+"));
+
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+            await test.RunAsync();
+        }
+
+        /// <summary>
         /// The model must not land in the global root: with no project default namespace to hand
         /// (this harness supplies none), the anchor contract's namespace is used.
         /// </summary>

--- a/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
+++ b/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
@@ -64,10 +64,23 @@ namespace ProtoBuf.CodeFixes
             _ = cancellationToken;
             var name = contract.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
-            // the project's own namespace, falling back to the anchor contract's: the model must not
-            // land in the global root just because a fixer wrote it. DefaultNamespace is null outside
-            // IDE-shaped hosts, which is what the fallback is for.
-            var ns = project.DefaultNamespace;
+            // Namespace resolution, most-authoritative first. The first tier is what rescues the
+            // common console shape: with top-level statements the anchor contract sits in the global
+            // namespace and DefaultNamespace has proven unreliable in practice, but RootNamespace is
+            // compiler-visible by default in the SDK and MSBuild defaults it to the project name.
+            // 1. build_property.RootNamespace;
+            // 2. the workspace's DefaultNamespace, where the host supplies one;
+            // 3. the anchor contract's own namespace;
+            // 4. none - and since the file is added at the project *root*, the csproj convention
+            //    (folders, not project or assembly name) genuinely says global namespace there.
+            string? ns = null;
+            if (project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions
+                    .TryGetValue("build_property.RootNamespace", out var rootNamespace)
+                && !string.IsNullOrWhiteSpace(rootNamespace))
+            {
+                ns = rootNamespace;
+            }
+            if (string.IsNullOrEmpty(ns)) ns = project.DefaultNamespace;
             if (string.IsNullOrEmpty(ns) && contract.ContainingNamespace is { IsGlobalNamespace: false } containing)
             {
                 ns = containing.ToDisplayString();
@@ -109,8 +122,10 @@ using ProtoBuf.Meta;
                 ? $"ProtoModel.{contract.Name}.cs"
                 : FileName;
 
+            // at the project root, deliberately: the folder half of the namespace convention is then
+            // empty by construction, so the namespace above is the whole answer
             return Task.FromResult(project
-                .AddDocument(fileName, SourceText.From(source), project.Documents.FirstOrDefault()?.Folders)
+                .AddDocument(fileName, SourceText.From(source))
                 .Project.Solution);
         }
     }


### PR DESCRIPTION
Follow-up from real use: applying the fix in a console app (`ConsoleApp11`) still produced an unnamespaced model. With top-level statements, the anchor contract lives in the global namespace - so the contract-namespace fallback says nothing - and `Project.DefaultNamespace` proved unreliable in practice. The one source that is both authoritative and reliably present is **`RootNamespace`**: MSBuild defaults it to the project name, and the SDK makes it compiler-visible (`build_property.RootNamespace`), so the fixer can read it through the analyzer-config options even when nothing else knows.

Resolution order is now:

1. `build_property.RootNamespace` - fixes the console case: `ConsoleApp11` gets `namespace ConsoleApp11`;
2. `Project.DefaultNamespace`, where the host supplies one;
3. the anchor contract's namespace;
4. genuinely global - and the generated file now lands at the **project root** (previously: beside whatever document happened to be first), where the csproj folder convention (folders, not project/assembly name) legitimately means no namespace segments.

New test pins the console shape (global-namespace contract + `RootNamespace` via global analyzer config); the two existing tests pin the fallback tiers unchanged. Full BuildToolsUnitTests at 326; Legacy builds.