### PR TITLE
Stop publishing protobuf-net.BuildTools (3.3.8 is final; deprecate it)

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -14,6 +14,9 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## unreleased
 
+- **`protobuf-net.BuildTools` is no longer published** (last standalone version: 3.3.8, deprecated):
+  the same tooling ships inside protobuf-net.Core and reaches every consumer by default;
+  `protobuf-net.BuildTools.Legacy` (for very old SDKs) is unaffected
 - the build-time tooling now ships inside **protobuf-net.Core** rather than protobuf-net, so
   compile-time serialization works with only a Core reference; it still reaches consumers who
   reference only protobuf-net (the dependency edge forwards it), and the legacy

--- a/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
+++ b/src/protobuf-net.BuildTools/protobuf-net.BuildTools.csproj
@@ -4,7 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>ProtoBuf</RootNamespace> <!-- need this to be ProtoBuf for Embedded Resource naming reasons -->
     <AssemblyName>protobuf-net.BuildTools</AssemblyName>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <!-- retired as a package at 3.3.8 (deprecated on nuget.org): the same assembly ships inside
+         protobuf-net.Core, reaching every consumer by default. The project still builds - Core
+         packs its dll - it just no longer publishes anything of its own. -->
+    <IsPackable>false</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>$(NoWarn);RS2007;NU5128</NoWarn>
     <Description>Analyzer and Generator support for protobuf-net</Description>


### PR DESCRIPTION
The standalone package is now redundant by construction: the same `protobuf-net.BuildTools.dll` ships inside protobuf-net.Core and reaches every consumer, direct or transitive, with `ProtoBufDisableBuildTools` as the opt-out. Publishing new versions could only duplicate what consumers already have and resurrect a non-deprecated "latest" over the deprecation notice on 3.3.8.

`IsPackable=false` replaces `GeneratePackageOnBuild` - the project still **builds** (Core packs its dll from it); it just never produces a package. The traversal pack skips non-packable projects gracefully, so `Build.csproj` and the release workflow need no changes. Verified against the exact release recipe: `protobuf-net.BuildTools` is absent from the pack output, and Core still carries `analyzers/dotnet/cs/protobuf-net.BuildTools.dll` + `build/protobuf-net.Core.props`.

`protobuf-net.BuildTools.Legacy` is deliberately unaffected - its very-old-SDK audience is a separate decision (and one line, if wanted).

After merge: mark 3.3.8 of `protobuf-net.BuildTools` deprecated on nuget.org (suggest "Legacy" reason with protobuf-net.Core as the alternate package) - no future release will disturb it.