### PR TITLE
Parse the list form of aggregate option values: `foo: [a, b]`

### DIFF
--- a/src/protobuf-net.Reflection.Test/AggregateListOptions.cs
+++ b/src/protobuf-net.Reflection.Test/AggregateListOptions.cs
@@ -1,6 +1,7 @@
 using Google.Protobuf.Reflection;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.IO;
 using Xunit;
 
@@ -234,6 +235,58 @@ message Subject {
     string id = 1;
 }", msg => msg.Options);
             Assert.Equal(new[] { "mA", "mB" }, meta.Rules.ConvertAll(x => x.Name));
+        }
+        [Fact]
+        public void SeparateListStatementsAppendRatherThanCollide()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = {
+        rules: [ { name: ""a"" } ]
+        rules: [ { name: ""b"", expr: ""e2"" } ]
+    }];
+}");
+            // Each element gets its own index for the whole parse, so the second statement
+            // appends instead of merging into the first element.
+            Assert.Equal(new[] { "a", "b" }, meta.Rules.ConvertAll(x => x.Name));
+            Assert.Equal("e2", meta.Rules[1].Expr);
+        }
+
+        [Fact]
+        public void SeparateScalarListStatementsKeepTheirWrittenOrder()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = {
+        tags: [ ""a"", ""b"" ]
+        tags: [ ""c"" ]
+    }];
+}");
+            Assert.Equal(new[] { "a", "b", "c" }, meta.Tags);
+        }
+
+        [Fact]
+        public void LongListsKeepTheirWrittenOrder()
+        {
+            // Every element is a same-field-number sibling, so the sub-field sort has 20 ties
+            // to resolve. List<T>.Sort only behaves stably below its insertion-sort cutoff of
+            // 16, so a shorter list would not catch a reordering here.
+            const int count = 20;
+            var body = new StringBuilder("\nmessage Subject {\n    string id = 1 [(rtest.field_meta) = {\n        rules: [\n");
+            for (int i = 0; i < count; i++)
+            {
+                body.Append("            { name: \"r").Append(i).Append("\" }");
+                body.Append(i == count - 1 ? "\n" : ",\n");
+            }
+            body.Append("        ]\n    }];\n}");
+
+            var meta = ParseFieldMeta(body.ToString());
+            var expected = new List<string>();
+            for (int i = 0; i < count; i++)
+            {
+                expected.Add("r" + i);
+            }
+            Assert.Equal(expected, meta.Rules.ConvertAll(x => x.Name));
         }
     }
 }

--- a/src/protobuf-net.Reflection.Test/AggregateListOptions.cs
+++ b/src/protobuf-net.Reflection.Test/AggregateListOptions.cs
@@ -1,0 +1,239 @@
+using Google.Protobuf.Reflection;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf
+{
+    /// <summary>
+    /// Covers the list form of aggregate option values, i.e. `foo: [a, b]` and
+    /// `foo: [{..}, {..}]`, which protoc accepts for repeated fields.
+    /// </summary>
+    public class AggregateListOptions
+    {
+        private const int MetaFieldNumber = 1088;
+
+        private const string Preamble = @"
+syntax = ""proto3"";
+package rtest;
+import ""google/protobuf/descriptor.proto"";
+
+message Meta {
+    string doc = 1;
+    repeated string tags = 3;
+    repeated Rule rules = 4;
+}
+message Rule {
+    string name = 1;
+    string expr = 3;
+}
+extend google.protobuf.FieldOptions { Meta field_meta = 1088; }
+extend google.protobuf.MessageOptions { Meta message_meta = 1088; }
+";
+
+        /// <summary>
+        /// The custom option as read back from the resolved extension data; this is what
+        /// consumers see, so it exercises both the parser and the option hive.
+        /// </summary>
+        private sealed class Meta
+        {
+            public string Doc { get; set; }
+            public List<string> Tags { get; } = new List<string>();
+            public List<Rule> Rules { get; } = new List<Rule>();
+        }
+
+        private sealed class Rule
+        {
+            public string Name { get; set; }
+            public string Expr { get; set; }
+        }
+
+        private static Meta ParseFieldMeta(string body)
+            => Parse(body, msg => msg.Fields[0].Options);
+
+        private static Meta Parse(string body, Func<DescriptorProto, IExtensible> selector)
+        {
+            var set = new FileDescriptorSet();
+            using (var reader = new StringReader(Preamble + body))
+            {
+                Assert.True(set.Add("list_options.proto", true, reader));
+            }
+            set.Process();
+            Assert.Empty(set.GetErrors());
+
+            var options = selector(set.Files[0].MessageTypes.Find(x => x.Name == "Subject"));
+            var extension = options?.GetExtensionObject(false);
+            Assert.NotNull(extension);
+
+            var stream = extension.BeginQuery();
+            try
+            {
+                var state = ProtoReader.State.Create(stream, null);
+                try
+                {
+                    return ReadMeta(ref state);
+                }
+                finally
+                {
+                    state.Dispose();
+                }
+            }
+            finally
+            {
+                extension.EndQuery(stream);
+            }
+        }
+
+        private static Meta ReadMeta(ref ProtoReader.State state)
+        {
+            var meta = new Meta();
+            int field;
+            while ((field = state.ReadFieldHeader()) > 0)
+            {
+                if (field != MetaFieldNumber)
+                {
+                    state.SkipField();
+                    continue;
+                }
+                var outer = state.StartSubItem();
+                while ((field = state.ReadFieldHeader()) > 0)
+                {
+                    switch (field)
+                    {
+                        case 1:
+                            meta.Doc = state.ReadString();
+                            break;
+                        case 3:
+                            meta.Tags.Add(state.ReadString());
+                            break;
+                        case 4:
+                            meta.Rules.Add(ReadRule(ref state));
+                            break;
+                        default:
+                            state.SkipField();
+                            break;
+                    }
+                }
+                state.EndSubItem(outer);
+            }
+            return meta;
+        }
+
+        private static Rule ReadRule(ref ProtoReader.State state)
+        {
+            var rule = new Rule();
+            var token = state.StartSubItem();
+            int field;
+            while ((field = state.ReadFieldHeader()) > 0)
+            {
+                switch (field)
+                {
+                    case 1:
+                        rule.Name = state.ReadString();
+                        break;
+                    case 3:
+                        rule.Expr = state.ReadString();
+                        break;
+                    default:
+                        state.SkipField();
+                        break;
+                }
+            }
+            state.EndSubItem(token);
+            return rule;
+        }
+
+        [Fact]
+        public void ListOfAggregatesKeepsEveryElement()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = {
+        rules: [
+            { name: ""a"", expr: ""e1"" },
+            { name: ""b"", expr: ""e2"" }
+        ]
+    }];
+}");
+            Assert.Collection(meta.Rules,
+                x => { Assert.Equal("a", x.Name); Assert.Equal("e1", x.Expr); },
+                x => { Assert.Equal("b", x.Name); Assert.Equal("e2", x.Expr); });
+        }
+
+        [Fact]
+        public void ListOfScalarsKeepsEveryElement()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = { tags: [ ""PII"", ""SENSITIVE"" ] }];
+}");
+            Assert.Equal(new[] { "PII", "SENSITIVE" }, meta.Tags);
+        }
+
+        [Fact]
+        public void TrailingCommaIsAllowed()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = { tags: [ ""x"", ""y"", ] }];
+}");
+            Assert.Equal(new[] { "x", "y" }, meta.Tags);
+        }
+
+        [Fact]
+        public void EmptyListAddsNothing()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = { doc: ""d"", rules: [] }];
+}");
+            Assert.Equal("d", meta.Doc);
+            Assert.Empty(meta.Rules);
+        }
+
+        [Fact]
+        public void ListCombinesWithOtherValues()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = {
+        doc: ""docs""
+        rules: [ { name: ""r1"", expr: ""e1"" } ]
+        tags: [ ""t1"" ]
+    }];
+}");
+            Assert.Equal("docs", meta.Doc);
+            Assert.Equal(new[] { "t1" }, meta.Tags);
+            var rule = Assert.Single(meta.Rules);
+            Assert.Equal("r1", rule.Name);
+            Assert.Equal("e1", rule.Expr);
+        }
+
+        [Fact]
+        public void ListElementsAppendToEarlierBlocks()
+        {
+            var meta = ParseFieldMeta(@"
+message Subject {
+    string id = 1 [(rtest.field_meta) = {
+        rules { name: ""m1"" }
+        rules: [ { name: ""m2"" }, { name: ""m3"" } ]
+    }];
+}");
+            Assert.Equal(new[] { "m1", "m2", "m3" }, meta.Rules.ConvertAll(x => x.Name));
+        }
+
+        [Fact]
+        public void ListWorksOnMessageOptions()
+        {
+            var meta = Parse(@"
+message Subject {
+    option (rtest.message_meta) = {
+        rules: [ { name: ""mA"" }, { name: ""mB"" } ]
+    };
+    string id = 1;
+}", msg => msg.Options);
+            Assert.Equal(new[] { "mA", "mB" }, meta.Rules.ConvertAll(x => x.Name));
+        }
+    }
+}

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -1524,11 +1524,12 @@ namespace Google.Protobuf.Reflection
 
         private class OptionHive
         {
-            public OptionHive(string name, bool isExtension, Token token, int? repeatIndex = null)
+            public OptionHive(string name, bool isExtension, Token token, int ordinal, int? repeatIndex = null)
             {
                 Name = name;
                 IsExtension = isExtension;
                 Token = token;
+                Ordinal = ordinal;
                 RepeatIndex = repeatIndex;
             }
             public override string ToString()
@@ -1556,6 +1557,13 @@ namespace Google.Protobuf.Reflection
             }
             public bool IsExtension { get; }
             public string Name { get; }
+            /// <summary>
+            /// Position of this node among its siblings, in the order they were encountered.
+            /// Used to break ties when sorting sub-fields by field number: the elements of a
+            /// list value are same-named siblings of the same field, and <see cref="List{T}.Sort"/>
+            /// is not stable.
+            /// </summary>
+            public int Ordinal { get; }
             public int? RepeatIndex { get; }
             public Token Token { get; }
             public List<UninterpretedOption> Options { get; } = new List<UninterpretedOption>();
@@ -1566,7 +1574,7 @@ namespace Google.Protobuf.Reflection
             {
                 if (options == null || options.Count == 0) return null;
 
-                var root = new OptionHive(null, false, default);
+                var root = new OptionHive(null, false, default, 0);
                 foreach (var option in options)
                 {
                     var level = root;
@@ -1577,7 +1585,8 @@ namespace Google.Protobuf.Reflection
                             && x.IsExtension == name.IsExtension && x.RepeatIndex == name.RepeatIndex);
                         if (nextLevel == null)
                         {
-                            nextLevel = new OptionHive(name.name_part, name.IsExtension, name.Token, name.RepeatIndex);
+                            nextLevel = new OptionHive(name.name_part, name.IsExtension, name.Token,
+                                level.Children.Count, name.RepeatIndex);
                             level.Children.Add(nextLevel);
                         }
                         level = nextLevel;
@@ -1594,8 +1603,14 @@ namespace Google.Protobuf.Reflection
 
             if (resolveOnly && depth != 0) // fun fact: proto writes root fields in *file* order, but sub-fields in *field* order
             {
-                // ascending field order
-                options.Sort((x, y) => (x.Field?.Number ?? 0).CompareTo(y.Field?.Number ?? 0));
+                // ascending field order, falling back to encounter order so that same-number
+                // siblings - the elements of a list value - keep the order they were written
+                // in; List<T>.Sort is not stable.
+                options.Sort((x, y) =>
+                {
+                    int byNumber = (x.Field?.Number ?? 0).CompareTo(y.Field?.Number ?? 0);
+                    return byNumber != 0 ? byNumber : x.Ordinal.CompareTo(y.Ordinal);
+                });
             }
         }
         private static void AppendOption(FileDescriptorProto file, ref ProtoWriter.State state, ParserContext ctx, string extendee, OptionHive option, bool resolveOnly, int depth, bool messageSet)
@@ -3016,6 +3031,12 @@ namespace ProtoBuf.Reflection
     internal class ParserContext : IDisposable
     {
         public AbortState AbortState { get; set; }
+
+        /// <summary>
+        /// Supplies <see cref="UninterpretedOption.NamePart.RepeatIndex"/> values. Unique per
+        /// list element for the whole parse, so elements never collide across statements.
+        /// </summary>
+        private int nextRepeatIndex;
         private void ReadOne<T>(T obj) where T : class, ISchemaObject
         {
             AbortState oldState = AbortState;
@@ -3135,10 +3156,13 @@ namespace ProtoBuf.Reflection
                 // for a repeated message field. Each element is tagged with its position so
                 // that the option hive keeps the elements apart rather than merging them by name.
                 obj ??= new T();
-                int repeatIndex = 0;
                 while (!tokens.ConsumeIf(TokenType.Symbol, "]"))
                 {
-                    var elementParts = WithRepeatIndex(nameParts, repeatIndex++);
+                    // Indexes come from a parse-wide counter rather than restarting per
+                    // statement, so that two list statements for the same field append to it
+                    // instead of colliding. Statements *inside* one element share an index,
+                    // which is what lets the hive merge them into a single value.
+                    var elementParts = WithRepeatIndex(nameParts, nextRepeatIndex++);
                     if (tokens.ConsumeIf(TokenType.Symbol, "{"))
                     {
                         bool anyElement = false;

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -1524,11 +1524,12 @@ namespace Google.Protobuf.Reflection
 
         private class OptionHive
         {
-            public OptionHive(string name, bool isExtension, Token token)
+            public OptionHive(string name, bool isExtension, Token token, int? repeatIndex = null)
             {
                 Name = name;
                 IsExtension = isExtension;
                 Token = token;
+                RepeatIndex = repeatIndex;
             }
             public override string ToString()
             {
@@ -1555,6 +1556,7 @@ namespace Google.Protobuf.Reflection
             }
             public bool IsExtension { get; }
             public string Name { get; }
+            public int? RepeatIndex { get; }
             public Token Token { get; }
             public List<UninterpretedOption> Options { get; } = new List<UninterpretedOption>();
             public List<OptionHive> Children { get; } = new List<OptionHive>();
@@ -1571,10 +1573,11 @@ namespace Google.Protobuf.Reflection
                     OptionHive nextLevel = null;
                     foreach (var name in option.Names)
                     {
-                        nextLevel = level.Children.Find(x => x.Name == name.name_part && x.IsExtension == name.IsExtension);
+                        nextLevel = level.Children.Find(x => x.Name == name.name_part
+                            && x.IsExtension == name.IsExtension && x.RepeatIndex == name.RepeatIndex);
                         if (nextLevel == null)
                         {
-                            nextLevel = new OptionHive(name.name_part, name.IsExtension, name.Token);
+                            nextLevel = new OptionHive(name.name_part, name.IsExtension, name.Token, name.RepeatIndex);
                             level.Children.Add(nextLevel);
                         }
                         level = nextLevel;
@@ -2562,6 +2565,14 @@ namespace Google.Protobuf.Reflection
             /// <inheritdoc/>
             public override string ToString() => IsExtension ? ("(" + name_part + ")") : name_part;
             internal Token Token { get; set; }
+
+            /// <summary>
+            /// Position of this element within an explicit list value (`foo: [a, b]`), or
+            /// null when the name did not come from a list. Elements of a list are separate
+            /// values of a repeated field, so they must not be merged together the way
+            /// same-named parts otherwise are.
+            /// </summary>
+            internal int? RepeatIndex { get; set; }
         }
         internal bool Applied { get; set; }
         internal Token Token { get; set; }
@@ -3118,6 +3129,52 @@ namespace ProtoBuf.Reflection
                     obj.UninterpretedOptions.Add(newOption);
                 }
             }
+            else if (tokens.ConsumeIf(TokenType.Symbol, "["))
+            {
+                // a list value, i.e. the repeated form `foo: [a, b]`, or `foo: [{..}, {..}]`
+                // for a repeated message field. Each element is tagged with its position so
+                // that the option hive keeps the elements apart rather than merging them by name.
+                obj ??= new T();
+                int repeatIndex = 0;
+                while (!tokens.ConsumeIf(TokenType.Symbol, "]"))
+                {
+                    var elementParts = WithRepeatIndex(nameParts, repeatIndex++);
+                    if (tokens.ConsumeIf(TokenType.Symbol, "{"))
+                    {
+                        bool anyElement = false;
+                        while (!tokens.ConsumeIf(TokenType.Symbol, "}"))
+                        {
+                            ReadOption(ref obj, parent, elementParts);
+                            anyElement = true;
+
+                            // comma between elements is optional; semicolons work too
+                            if (!tokens.ConsumeIf(TokenType.Symbol, ","))
+                            {
+                                tokens.ConsumeIf(TokenType.Symbol, ";");
+                            }
+                        }
+                        if (!anyElement)
+                        {
+                            var emptyOption = new UninterpretedOption();
+                            emptyOption.Names.AddRange(elementParts);
+                            obj.UninterpretedOptions.Add(emptyOption);
+                        }
+                    }
+                    else
+                    {
+                        var scalarOption = new UninterpretedOption
+                        {
+                            AggregateValue = tokens.ConsumeString(true),
+                            Token = tokens.Previous
+                        };
+                        scalarOption.Names.AddRange(elementParts);
+                        obj.UninterpretedOptions.Add(scalarOption);
+                    }
+
+                    // comma between elements is optional
+                    tokens.ConsumeIf(TokenType.Symbol, ",");
+                }
+            }
             else
             {
                 var field = parent as FieldDescriptorProto;
@@ -3157,6 +3214,29 @@ namespace ProtoBuf.Reflection
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Clones the given name parts, marking the final part with its position within a
+        /// list value. Only the final part is marked: it names the repeated field whose
+        /// elements need to stay separate.
+        /// </summary>
+        private static List<UninterpretedOption.NamePart> WithRepeatIndex(
+            List<UninterpretedOption.NamePart> nameParts, int repeatIndex)
+        {
+            var clone = new List<UninterpretedOption.NamePart>(nameParts);
+            if (clone.Count != 0)
+            {
+                var last = clone[clone.Count - 1];
+                clone[clone.Count - 1] = new UninterpretedOption.NamePart
+                {
+                    IsExtension = last.IsExtension,
+                    name_part = last.name_part,
+                    Token = last.Token,
+                    RepeatIndex = repeatIndex,
+                };
+            }
+            return clone;
         }
 
         private void ParseDefault(Token token, FieldDescriptorProto.Type type, ref string defaultValue)


### PR DESCRIPTION
protoc accepts an explicit list as the value of a repeated field inside an aggregate                                                                                              
  option, but protobuf-net's parser does not:                                                                                                                                       
                                                                                                                                                                                    
  ```proto                                                                                                                                                                          
  message Order {                                                                                                                                                                   
    string id = 1 [(confluent.field_meta) = {                                                                                                                                       
      tags: [ "PII", "SENSITIVE" ]                                                                                                                                                  
      rules: [                                                                                                                                                                      
        { name: "a", expr: "size(this.id) > 0" },                                                                                                                                   
        { name: "b", expr: "this.id.startsWith('X')" }                                                                                                                              
      ]                                                                                                                                                                             
    }];                                                                                                                                                                             
  }                                                                                                                                                                                 
  ```                                                                                                                                                                               
                                                                                                                                                                                    
  `ReadOption<T>` handles only `{` (a nested aggregate) or a scalar after the `:`                                                                                                   
  separator, so `[` falls through to `ConsumeString` and errors. Because this happens                                                                                               
  while parsing an option, the failure takes out the surrounding parse rather than                                                                                                  
  producing a targeted diagnostic — for a real-world consumer the symptom is a message                                                                                              
  that silently comes back with no fields at all.                                                                                                                                                                    
                                                                                                                                                                                    
   ## The fix                                                                                                                                                                        
                                                                                                                                                                                    
  Three parts, all in `Parsers.cs`:                                                                                                                                                 
                                                                                                                                                                                    
  1. **`ReadOption` gains a `[` branch** that walks the list, treating each element as                                                                                              
     either a `{...}` aggregate or a scalar, with the usual optional comma (and a                                                                                                   
     trailing one).                                                                                                                                                                 
                                                                                                                                                                                    
  2. **List elements are kept distinct.** `OptionHive.Build` reassembles the parsed                                                                                                 
     `UninterpretedOption`s into a tree by **merging children by name**, which would                                                                                                
     have collapsed a list straight back into a single value.                                                                                                                       
     `UninterpretedOption.NamePart` gains an `internal int? RepeatIndex`; `ReadOption`                                                                                              
     stamps it on the final name part of each list element, and `Build` includes it in                                                                                              
     its match key.                                                                                                                                                                 
                                                                                                                                                                                    
     The indexes come from a counter on `ParserContext` rather than restarting per                                                                                                  
     statement, so two list statements for the same field append to it instead of                                                                                                   
     colliding:                                                                                                                                                                     
                                                                                                                                                                                    
     ```proto                                                                                                                                                                       
     option (foo) = { rules: [ { name: "a" } ] rules: [ { name: "b" } ] };  // two rules                                                                                            
     ```                                                                                                                                                                            
                                                                                                                                                                                    
     Statements *inside* one element still share an index, which is what lets `Build`                                                                                               
     merge them into a single value.       

 3. **The sub-field sort is no longer order-dependent.** `AppendOptions` sorts a                                                                                                   
     node's children by field number. Before this change same-named parts merged, so                                                                                                
     siblings at one level effectively always had distinct numbers and ties never arose;                                                                                            
     every element of a list is now a same-number sibling. `List<T>.Sort` is introsort —                                                                                            
     stable only below its 16-element insertion-sort cutoff — so a list of 17+ elements                                                                                             
     could be silently reordered on the wire. `OptionHive` gains an `Ordinal` (its                                                                                                  
     encounter position among its siblings) and the comparator falls back to it:                                                                                                    
                                                                                                                                                                                    
     ```csharp                                                                                                                                                                      
     options.Sort((x, y) =>                                                                                                                                                         
     {                                                                                                                                                                              
         int byNumber = (x.Field?.Number ?? 0).CompareTo(y.Field?.Number ?? 0);                                                                                                     
         return byNumber != 0 ? byNumber : x.Ordinal.CompareTo(y.Ordinal);                                                                                                          
     });                                                                                                                                                                            
     ```                                                                                                                                                                            
                                                                                                                                                                                    
     A captured ordinal rather than `RepeatIndex`, so the tie-break covers any                                                                                                      
     same-number siblings and doesn't depend on `RepeatIndex` being set.                                                                                                            
                                                                                                                                                                                    
  `RepeatIndex` is null on every path that isn't an explicit list, so existing parsing                                                                                              
  and merge behaviour is unchanged. Both new `NamePart`/`OptionHive` members are                                                                                                    
  internal or private, so there is no public API surface change. 
                                                                         
 ## Tests                                                                                                                                                                          
                                                                                                                                                                                    
  `protobuf-net.Reflection.Test/AggregateListOptions.cs`, 10 facts, asserting on the                                                                                                
  *resolved extension data* (so they cover the hive and the emit order as well as the                                                                                               
  parser): list of aggregates, list of scalars, single-element list, empty list, trailing                                                                                           
  comma, a list alongside other fields, a list on message-level options, a repeated block                                                                                           
  followed by a list, two separate list statements for one field, two separate scalar list                                                                                          
  statements, and a 20-element list.                                                                                                                                                
                                                                                                                                                                                    
  The last three pin the parts that a short list can't reach. Reverting the individual                                                                                              
  fixes makes them fail as expected:                                                                                                                                                
                                                                                                                                                                                    
  - drop the sort tie-break → `LongListsKeepTheirWrittenOrder`: *differs at index 1,                                                                                                
    expected "r1", actual "r17"*                                                                                                                                                    
  - restart the counter per statement → `SeparateListStatementsAppendRatherThanCollide`:                                                                                            
    one rule with `name` written twice (*expected "a", actual "b"*), and                                                                                                            
    `SeparateScalarListStatementsKeepTheirWrittenOrder` interleaves to `a, c, b`                             
                 