### PR TITLE
Point the URLs we ship at docs.protobuf-net.dev

### DIFF
--- a/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
+++ b/src/BuildToolsUnitTests/CodeFixes/AddProtoModelCodeFixProviderTests.cs
@@ -50,7 +50,7 @@ using ProtoBuf.Meta;
 // reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
 // sub-types - is included automatically.
 //
-// See https://protobuf-net.github.io/protobuf-net/aot
+// See https://docs.protobuf-net.dev/aot
 [ProtoModel]
 [ProtoSerializable(typeof(global::Order))]
 internal partial class ProtoModel : TypeModel
@@ -98,7 +98,7 @@ using ProtoBuf.Meta;
 // reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
 // sub-types - is included automatically.
 //
-// See https://protobuf-net.github.io/protobuf-net/aot
+// See https://docs.protobuf-net.dev/aot
 namespace ConsoleApp11
 {
     [ProtoModel]
@@ -141,7 +141,7 @@ using ProtoBuf.Meta;
 // reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
 // sub-types - is included automatically.
 //
-// See https://protobuf-net.github.io/protobuf-net/aot
+// See https://docs.protobuf-net.dev/aot
 namespace Shop.Data
 {
     [ProtoModel]

--- a/src/Examples/Issues/Issue722.cs
+++ b/src/Examples/Issues/Issue722.cs
@@ -12,7 +12,7 @@ namespace ProtoBuf.Issues
         {
             var obj = new HazGoogleTypes();
             var ex = Assert.Throws<InvalidOperationException>(() => Serializer.DeepClone(obj));
-            Assert.Equal("Type 'Google.Protobuf.WellKnownTypes.FloatValue' looks like a Google.Protobuf type; it cannot be used directly with protobuf-net without manual configuration; it may be possible to generate a protobuf-net type instead; see https://protobuf-net.github.io/protobuf-net/contract_first", ex.Message);
+            Assert.Equal("Type 'Google.Protobuf.WellKnownTypes.FloatValue' looks like a Google.Protobuf type; it cannot be used directly with protobuf-net without manual configuration; it may be possible to generate a protobuf-net type instead; see https://docs.protobuf-net.dev/contract_first", ex.Message);
             var inner = Assert.IsType<InvalidOperationException>(ex.InnerException);
             Assert.Equal("No serializer defined for type: Google.Protobuf.WellKnownTypes.FloatValue", inner.Message);
         }

--- a/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
@@ -60,7 +60,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             title: "This project publishes AOT or trimmed, but has no AOT model",
             messageFormat: "This project has protobuf-net contracts and asks for {0}, but declares no "
                 + "[ProtoModel]; serializers will be built by reflection, which is exactly what will "
-                + "not survive. See https://protobuf-net.github.io/protobuf-net/aot",
+                + "not survive. See https://docs.protobuf-net.dev/aot",
             category: "ProtoBuf",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
@@ -74,7 +74,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             messageFormat: "This project has protobuf-net contracts and no [ProtoModel]. Compile-time "
                 + "serializers are not only for AOT: they skip the metadata inspection and IL emission "
                 + "the runtime model does on first use of each contract, which is typically several "
-                + "times faster to first serialize. See https://protobuf-net.github.io/protobuf-net/aot",
+                + "times faster to first serialize. See https://docs.protobuf-net.dev/aot",
             category: "ProtoBuf",
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true);

--- a/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
@@ -149,7 +149,7 @@ internal static readonly DiagnosticDescriptor DeclaredAndIgnored = new(
             id: "PBN0016",
             title: nameof(DataContractAnalyzer) + "." + nameof(MissingCompatibilityLevel),
             messageFormat: "It is recommended to declare a module or assembly level " + nameof(CompatibilityLevel) + " (or declare it for each contract type); new projects should use the highest currently available - old projects should use " + nameof(CompatibilityLevel.Level200) + " unless fully considered.",
-            helpLinkUri: "https://protobuf-net.github.io/protobuf-net/compatibilitylevel.html",
+            helpLinkUri: "https://docs.protobuf-net.dev/compatibilitylevel",
             category: Literals.CategoryUsage,
             defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true);

--- a/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
+++ b/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
@@ -93,7 +93,7 @@ namespace ProtoBuf.CodeFixes
 // reachable from those - member types, collection elements, map keys and values, [ProtoInclude]
 // sub-types - is included automatically.
 //
-// See https://protobuf-net.github.io/protobuf-net/aot
+// See https://docs.protobuf-net.dev/aot
 ";
             var source = string.IsNullOrEmpty(ns)
                 ? $@"using ProtoBuf;

--- a/src/protobuf-net.Core/Internal/ThrowHelper.cs
+++ b/src/protobuf-net.Core/Internal/ThrowHelper.cs
@@ -66,7 +66,7 @@ namespace ProtoBuf.Internal
                 try { throw ex; } // this is just to set the stack-trace
                 catch (Exception inner)
                 {
-                    ex = new InvalidOperationException($"Type '{type.NormalizeName()}' looks like a Google.Protobuf type; it cannot be used directly with protobuf-net without manual configuration; it may be possible to generate a protobuf-net type instead; see https://protobuf-net.github.io/protobuf-net/contract_first", inner);
+                    ex = new InvalidOperationException($"Type '{type.NormalizeName()}' looks like a Google.Protobuf type; it cannot be used directly with protobuf-net without manual configuration; it may be possible to generate a protobuf-net type instead; see https://docs.protobuf-net.dev/contract_first", inner);
                 }
             }
             // attempt to detect Google protobuf types, and give a suitable message

--- a/src/protobuf-net.Core/NullWrappedValueAttribute.cs
+++ b/src/protobuf-net.Core/NullWrappedValueAttribute.cs
@@ -6,7 +6,7 @@ namespace ProtoBuf
     /// is added, for compatibility with <c>wrappers.proto</c>, rather than
     /// "field presence";
     /// when used on a collection/dictionary, indicates  that the values can track nulls;
-    /// see https://protobuf-net.github.io/protobuf-net/nullwrappers for more information.
+    /// see https://docs.protobuf-net.dev/nullwrappers for more information.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
     public sealed class NullWrappedValueAttribute : Attribute
@@ -18,7 +18,7 @@ namespace ProtoBuf
     }
 
     /// <summary>Indicates that a collection can track the difference between a null and empty collection;
-    /// see https://protobuf-net.github.io/protobuf-net/nullwrappers for more information.
+    /// see https://docs.protobuf-net.dev/nullwrappers for more information.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
     public sealed class NullWrappedCollectionAttribute : Attribute


### PR DESCRIPTION
Follow-up to #1278, which covered `docs/` and `README.md`. These are the same links
embedded in **code** — strings users actually see.

| File | Where it surfaces |
| --- | --- |
| `BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs` | Writes `// See <url>` **into the user's own source file** |
| `BuildTools/Analyzers/DataContractAnalyzer.cs` | `helpLinkUri` — "Learn more" / F1 in the IDE |
| `BuildTools/Analyzers/AotMigrationAnalyzer.cs` (x2) | Diagnostic text in build output and the error list |
| `Core/Internal/ThrowHelper.cs` | Exception message |
| `Core/NullWrappedValueAttribute.cs` (x2) | XML docs — ships in the `.xml`, reaches IntelliSense |

The code fix is the one that most wanted doing: it stamps the URL into other people's
repositories, where it outlives our control of it.

Nothing here was broken — the old URLs 301 correctly — but they should not need to.

### Why this wasn't part of #1278

Four test expectations pin these strings exactly
(`AddProtoModelCodeFixProviderTests` x3, `Examples/Issues/Issue722`). Source and tests have
to move together or the build breaks, so this is a code change needing CI rather than a
link sweep.

### One consistency fix

`DataContractAnalyzer`'s `helpLinkUri` was the only link with a `.html` extension. Dropped,
to match every other link. Both forms resolve on the new host.

### Deliberately left alone

`src/protobuf-net.Test/NanoPBOptions.cs` carries `// generated using
https://protogen.marcgravell.com/`. That is a provenance record and it is *true* — the file
was generated there, by our own `CSharpCodeGenerator`, before the current site existed.
Rewriting it would make it inaccurate, and the URL redirects regardless.

---

Verified locally: full `build` of `Build.csproj` (0 errors), the `CodeFix` tests (42 passed)
and `Issue722` (passed, net8.0 and net472).

Targeting `main`.