### PR TITLE
Don't re-resolve `object` on every non-generic serialize (2.3 KB/call, ~40x)

### DIFF
--- a/src/protobuf-net.Test/ObjectSerializerLookupTests.cs
+++ b/src/protobuf-net.Test/ObjectSerializerLookupTests.cs
@@ -1,0 +1,154 @@
+using ProtoBuf;
+using ProtoBuf.Meta;
+using System;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf.Test
+{
+    /// <summary>
+    /// The non-generic (<c>object</c>-typed) API must not re-run the serializer lookup on every
+    /// call.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>RuntimeTypeModel</c> caches serializer lookups, but only <b>positive</b> ones: the cache
+    /// is a <c>Hashtable</c>, so a miss and a cached null are indistinguishable, and
+    /// <c>GetServicesSlow</c> stores a result only <c>if (service is not null)</c>. A type with no
+    /// service therefore re-runs the whole slow path — a lock, the repeated-provider probe, and
+    /// <c>FindOrAddAuto</c> — every single time it is asked for.
+    /// </para>
+    /// <para>
+    /// <c>typeof(object)</c> is exactly such a type, and the non-generic API asks for it on every
+    /// call: the typed lookup misses, and only then does the dynamic path resolve the concrete
+    /// type. Measured before the fix at <b>~2.3 KB allocated and ~2.9 µs per call</b>, against
+    /// ~72 ns and zero allocation for the same serialization reached generically — a 40× penalty on
+    /// a call shape a great deal of pre-generic code still uses.
+    /// </para>
+    /// </remarks>
+    public class ObjectSerializerLookupTests
+    {
+        [ProtoContract]
+        public class Payload
+        {
+            [ProtoMember(1)] public int Id { get; set; }
+            [ProtoMember(2)] public string Name { get; set; }
+        }
+
+        private static RuntimeTypeModel CreateModel()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.Add(typeof(Payload), true);
+            return model;
+        }
+
+        /// <summary>
+        /// The shortcut is safe precisely because this throws — <c>object</c> cannot acquire a
+        /// serializer later, so a permanent "no" cannot become wrong.
+        /// </summary>
+        /// <remarks>
+        /// Pinned as a test rather than trusted as a comment: if this restriction were ever lifted,
+        /// the shortcut would silently start returning the wrong answer, and nothing else in the
+        /// suite would notice.
+        /// </remarks>
+        [Fact]
+        public void ObjectCannotBeAddedToAModel()
+        {
+            var model = CreateModel();
+            var ex = Assert.Throws<ArgumentException>(() => model.Add(typeof(object), true));
+            Assert.Contains("cannot reconfigure", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>The object-typed API still produces the same bytes as the typed one.</summary>
+        [Fact]
+        public void ObjectTypedSerializeMatchesTheTypedForm()
+        {
+            var model = CreateModel();
+            var value = new Payload { Id = 42, Name = "hello" };
+
+            using var viaObject = new MemoryStream();
+            model.Serialize<object>(viaObject, value);
+
+            using var viaTyped = new MemoryStream();
+            model.Serialize(viaTyped, value);
+
+            Assert.Equal(
+                BitConverter.ToString(viaTyped.ToArray()),
+                BitConverter.ToString(viaObject.ToArray()));
+            Assert.NotEmpty(viaObject.ToArray());
+        }
+
+        /// <summary>...and still round-trips through the object-typed API in both directions.</summary>
+        [Fact]
+        public void ObjectTypedRoundTrips()
+        {
+            var model = CreateModel();
+            using var ms = new MemoryStream();
+            model.Serialize<object>(ms, new Payload { Id = 7, Name = "world" });
+            ms.Position = 0;
+            var clone = (Payload)model.Deserialize(ms, null, typeof(Payload));
+            Assert.Equal(7, clone.Id);
+            Assert.Equal("world", clone.Name);
+        }
+
+        /// <summary>
+        /// A type the model does NOT know still fails, rather than being silently swallowed by the
+        /// shortcut — the shortcut is for <c>object</c> alone, not for "anything unresolvable".
+        /// </summary>
+        [Fact]
+        public void AnUnknownTypeStillThrows()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoAddMissingTypes = false;
+            using var ms = new MemoryStream();
+            Assert.ThrowsAny<Exception>(() => model.Serialize<object>(ms, new NotAContract()));
+        }
+
+        public class NotAContract { public int Whatever { get; set; } }
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// The regression guard proper: repeated object-typed serialization must not allocate per
+        /// call.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>GC.GetAllocatedBytesForCurrentThread</c> is exact and per-thread, so this needs no
+        /// profiler and does not depend on collection timing — but it is net5.0+, which is why this
+        /// one test is guarded while the semantic tests above run on every TFM.
+        /// </para>
+        /// <para>
+        /// The threshold is deliberately loose. Before the fix this was <b>2272 bytes per call</b>,
+        /// flat from one call to a thousand; after it, zero. Anything under a few hundred bytes
+        /// distinguishes those two beyond argument, and a loose bound will not turn into a flaky
+        /// test the first time an unrelated allocation appears somewhere in the path.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ObjectTypedSerializeDoesNotAllocatePerCall()
+        {
+            var model = CreateModel();
+            var value = new Payload { Id = 42, Name = "hello" };
+            using var ms = new MemoryStream();
+
+            void Serialize()
+            {
+                ms.Position = 0;
+                ms.SetLength(0);
+                model.Serialize<object>(ms, value);
+            }
+
+            for (int i = 0; i < 200; i++) Serialize();   // settle every one-off cache first
+
+            const int Iterations = 500;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < Iterations; i++) Serialize();
+            var perCall = (GC.GetAllocatedBytesForCurrentThread() - before) / (double)Iterations;
+
+            Assert.True(perCall < 256,
+                $"object-typed serialize allocated {perCall:F1} B/call; it was 2272 B/call when the "
+                + "serializer lookup for `object` was re-run on every call");
+        }
+#endif
+    }
+}

--- a/src/protobuf-net/Meta/RuntimeTypeModel.cs
+++ b/src/protobuf-net/Meta/RuntimeTypeModel.cs
@@ -1011,6 +1011,24 @@ namespace ProtoBuf.Meta
         private object GetServicesSlow(Type type, CompatibilityLevel ambient)
         {
             if (type is null) return null; // GIGO
+
+            // `object` never has a service, and this is the ONE type for which that is guaranteed
+            // rather than merely true today: Add(typeof(object)) is refused outright ("You cannot
+            // reconfigure System.Object"), so it can never acquire one.
+            //
+            // It earns a shortcut because the cache below stores POSITIVE results only - a
+            // Hashtable miss and a cached null are indistinguishable - so a type with no service
+            // re-runs this whole method on every call: a lock, TryGetRepeatedProvider, and
+            // FindOrAddAuto. Every non-generic Serialize/Deserialize asks for `object` (the typed
+            // lookup misses, then the dynamic path resolves the concrete type), so that repeated
+            // for nothing was measured at ~2.3 KB allocated and ~2.9us per call, against ~72ns and
+            // zero for the typed form.
+            //
+            // Deliberately NOT generalised to "cache every negative": a type that is unknown now
+            // may be added later, and ResetServiceCache is only invoked from a couple of MetaType
+            // paths, so memoising misses in general would need invalidation this does not.
+            if (type == typeof(object)) return null;
+
             object service;
             lock (_serviceCache)
             {   // once more, with feeling


### PR DESCRIPTION
`RuntimeTypeModel` caches serializer lookups, but only **positive** ones. The cache is a `Hashtable`, so a miss and a cached null are indistinguishable, and `GetServicesSlow` stores a result only `if (service is not null)`. A type with no service therefore re-runs the entire slow path — a lock, the repeated-provider probe, and `FindOrAddAuto` — **every time it is asked for**.

`typeof(object)` is exactly such a type, and the non-generic API asks for it on every call: the typed lookup misses, and only then does the dynamic path resolve the concrete type.

## Measured

`GC.GetAllocatedBytesForCurrentThread`, so no profiler needed:

| | ns/call | B/call |
| --- | ---: | ---: |
| `RuntimeTypeModel`, generic | ~72 | 0 |
| `RuntimeTypeModel`, **`object`** | **~2951** | **2272** |
| generated model, generic | 58 | 0 |
| generated model, `object` | 76 | 0 |

Neither half is slow alone — it is the pair. Flat from 1 call to 1000, so a fixed per-call cost rather than a warm-up, and identical for a `Stream` and an `IBufferWriter`, so the destination is irrelevant.

For a service pushing 10k messages/sec through the non-generic API that is roughly **22 MB/s of GC pressure for no work**.

After this change: **2272 → 0 B/call.**

## The fix

One early return in `GetServicesSlow`. `object` is the one type where "has no service" is *guaranteed* rather than merely true today — `Add(typeof(object))` is refused outright (*"You cannot reconfigure System.Object"*), so it can never acquire one. A new test pins that restriction, because if it were ever lifted the shortcut would silently start answering wrongly and nothing else would notice.

It sits in the **slow path only**, so every other type pays nothing — in particular there is no `typeof(T)` test on any hot path, which would not have folded anyway, since all reference-type instantiations share one canonical JIT body.

## Deliberately not generalised

Caching *every* negative lookup is the bigger win — it would also help the auxiliary-type paths — but a type that is unknown now may be added later, and `ResetServiceCache` is only invoked from a couple of `MetaType` paths, so memoising misses in general needs invalidation that does not currently exist. Worth doing separately, with tests for that.

## Tests

New file, five tests, deliberately more than the allocation check:

- `ObjectCannotBeAddedToAModel` — pins the restriction the shortcut depends on
- `AnUnknownTypeStillThrows` — the shortcut is for `object` alone, not "anything unresolvable"
- byte-equality against the typed form, and a round-trip
- the allocation guard, **verified to fail without the fix** (2296 B/call). Guarded to net5.0+ since `GC.GetAllocatedBytesForCurrentThread` is; the four semantic tests run on both TFMs.

Full suites pass on this branch: `protobuf-net.Test` 1051, `Examples` 679.

## Notes

- No release-note entry included, to keep the commit trivially cherry-pickable — happy to add one if you'd like it in `unreleased`.
- Found while profiling the v4 writer work; `RuntimeTypeModel.cs` is byte-identical between `main` and that branch, so this is a pre-existing 3.x issue rather than anything v4-specific, which is why it is here rather than there.