### PR TITLE
Make protobuf-net.dev findable, and point release notes at GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [![.NET](https://github.com/protobuf-net/protobuf-net/actions/workflows/dotnet.yml/badge.svg)](https://github.com/protobuf-net/protobuf-net/actions/workflows/dotnet.yml)
 
+Recent changes are on [the releases page](https://github.com/protobuf-net/protobuf-net/releases); older
+history is in [the release notes](https://docs.protobuf-net.dev/releasenotes).
+
 ## Online tools: [protobuf-net.dev](https://protobuf-net.dev/)
 
 Free, browser-based, and nothing to install — and **it all runs locally**: it is a static site, so your
@@ -14,14 +17,6 @@ schemas and payloads never leave your machine. You can:
 - **decode a raw protobuf payload**, without needing the schema that produced it
 
 Documentation is at [docs.protobuf-net.dev](https://docs.protobuf-net.dev/).
-
-## Release Notes
-
-[v3 is here!](https://docs.protobuf-net.dev/3_0)
-
-[Change history and pending changes are here](https://docs.protobuf-net.dev/releasenotes).
-
----
 
 ## Supported Runtimes
 - .NET 6.0+ (.NET 5 etc will use .NET Standard 2.1)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 [![.NET](https://github.com/protobuf-net/protobuf-net/actions/workflows/dotnet.yml/badge.svg)](https://github.com/protobuf-net/protobuf-net/actions/workflows/dotnet.yml)
 
+## Online tools: [protobuf-net.dev](https://protobuf-net.dev/)
+
+Free, browser-based, and nothing to install — and **it all runs locally**: it is a static site, so your
+schemas and payloads never leave your machine. You can:
+
+- **generate C#/VB types from a `.proto` schema** — the same code generation as the
+  [`protogen` global tool](https://www.nuget.org/packages/protobuf-net.Protogen)
+- **decode a raw protobuf payload**, without needing the schema that produced it
+
+Documentation is at [docs.protobuf-net.dev](https://docs.protobuf-net.dev/).
+
 ## Release Notes
 
 [v3 is here!](https://docs.protobuf-net.dev/3_0)
@@ -115,7 +126,7 @@ There is no special significance in the 7 above; it is an integer key, just like
 
 As an alternative to writing your classes and decorating them, you can generate your types from a .proto schema using the `protogen` tool,
 [available as a multi-platform "global tool"](https://www.nuget.org/packages/protobuf-net.Protogen), or in your browser at
-[protobuf-net.dev](https://protobuf-net.dev/) - which also decodes raw protobuf payloads without needing a schema.
+[protobuf-net.dev](https://protobuf-net.dev/) (see [Online tools](#online-tools-protobuf-netdev), above).
 
 ### Alternative to attributes
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+**From v4 onwards, [the GitHub releases page](https://github.com/protobuf-net/protobuf-net/releases) is the
+primary source of release notes** — that is where each release is described, as it happens. The notes below
+remain as the history for v3 and earlier.
+
 Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/protobuf-net), or it can be built [from source](https://github.com/protobuf-net/protobuf-net/tree/main/src)
 
 ## Roadmap


### PR DESCRIPTION
Two readme-shaped things, one commit each.

### Promote the online tools

`protobuf-net.dev` was only mentioned under **Advanced subjects → .proto file**, four screens down, inside a paragraph about `.proto` codegen — so the payload decoder in particular was effectively invisible to anyone who did not read the whole file.

It now gets its own section directly under the build badge: what it does, and that it is a static site, so schemas and payloads never leave the visitor's machine. The `.proto` section keeps its mention (it is the right place for someone reading linearly) but links back rather than re-describing the decoder.

### Release notes

The `## Release Notes` section led with *"v3 is here!"*, which has not been news for a while. The section is gone; the links are one line under the badge, releases first:

> Recent changes are on [the releases page](https://github.com/protobuf-net/protobuf-net/releases); older history is in [the release notes](https://docs.protobuf-net.dev/releasenotes).

And, since GitHub releases become the primary source from v4, `docs/releasenotes.md` now says so at the top, with the page below it standing as the v3-and-earlier history.

### Not done here

The `## unreleased` section in `docs/releasenotes.md` is left as-is — whether those entries move to a GitHub release rather than shipping in that file is a separate call.
