### PR TITLE
AOT diagnostics move to PBN3000+: they were colliding with the gRPC analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ src/Benchmark/DalSerializer.dll
 .idea/
 profile.arm.json
 .DS_Store
+# transient BenchmarkDotNet artifact dirs (NanoBench runs)
+bench-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,12 +187,12 @@ Design constraints that are settled, and should not be quietly relaxed:
   the enum by looking the field up on the symbol — since `Convert.ToUInt16("green")` throws and the
   member was previously dropped. `nint`/`nuint` need a cast rather than a suffix, having no literal
   form of their own.
-- Every dropped contract must **say why**: `PBN2001` unsupported member, `PBN2002` unsupported
-  declaration, `PBN2003` unsupported protobuf-net option, `PBN2004` dropped by cascade. All are
+- Every dropped contract must **say why**: `PBN3001` unsupported member, `PBN3002` unsupported
+  declaration, `PBN3003` unsupported protobuf-net option, `PBN3004` dropped by cascade. All are
   **warnings**, not errors — an incomplete model still builds, and the runtime "no serializer" throw
   is the backstop; erroring would make the generator unusable while coverage is partial. Anyone
   wanting strictness can escalate via `WarningsAsErrors`.
-- **C# 12 is a hard floor.** Below it the generator reports `PBN2000` and emits nothing, rather than
+- **C# 12 is a hard floor.** Below it the generator reports `PBN3000` and emits nothing, rather than
   emitting code that won't compile. Do not add down-level fallbacks: supporting multiple language
   versions multiplies every emitted construct for no benefit to anyone doing AOT. (netstandard2.0
   and net4x default to C# 7.3, so those consumers must set `<LangVersion>` — accepted deliberately.)
@@ -215,7 +215,7 @@ honouring the switch completely rather than about cost.
 
 ### The migration analyzer
 
-`AotMigrationAnalyzer` (`PBN2010`/`PBN2011`) exists because turning the generator on **moves no
+`AotMigrationAnalyzer` (`PBN3010`/`PBN3011`) exists because turning the generator on **moves no
 existing code onto it**: `Serializer.Serialize(...)` and friends go through `RuntimeTypeModel.Default`,
 which reflects. Worse, those call sites keep working under JIT, so the failure lands at publish time.
 
@@ -226,13 +226,13 @@ Three decisions worth keeping:
   would be turned off by everyone.
 - **The announcements are reported from a *symbol* action, and that is load-bearing.** A diagnostic
   reported from `RegisterCompilationEndAction` is "non-local", and Roslyn will not offer a code fix
-  for one however good its location is — which defeats the point, since `PBN2012`'s value is the
+  for one however good its location is — which defeats the point, since `PBN3012`'s value is the
   lightbulb that writes the model. They are anchored on the ordinal-first `[ProtoContract]` in the
   compilation (deterministic, so the squiggle does not wander) and fire exactly once because the
   action tests for that one symbol. The first cut used `Location.None` and an end action, and both
   had to go.
-- **Two diagnostics, split on whether the contract type is knowable.** `PBN2010` is the generic case,
-  where the fix is mechanical (name the model). `PBN2011` is the `object`/`Type` API, where nothing —
+- **Two diagnostics, split on whether the contract type is knowable.** `PBN3010` is the generic case,
+  where the fix is mechanical (name the model). `PBN3011` is the `object`/`Type` API, where nothing —
   analyzer or generator — can tell what will be serialized. That one is deliberately *reported rather
   than passed over*: a call site nobody can resolve statically is exactly the kind that fails only
   once ILC has trimmed.
@@ -246,7 +246,7 @@ verified in a real build; that dependency is gone with the move.) The unit tests
 stub dodges the `[Experimental]` gate, and the test harness references Core (through BuildTools),
 which has `TypeModel` but not the other two.
 
-`UseAotModelCodeFixProvider` fixes `PBN2010` by swapping the receiver. It offers anything of the
+`UseAotModelCodeFixProvider` fixes `PBN3010` by swapping the receiver. It offers anything of the
 model's type already in scope (field, property, local, parameter), and then the generated
 **`Model.Instance`** — which is why that accessor exists: a codebase part-way through migrating has
 no model in scope *anywhere*, so without it the fixer would be useless in exactly the situation it
@@ -280,7 +280,7 @@ at the call site; `Simplifier.Annotation` is what reduces it to `MyModel.Instanc
 leaves `global::` only where it is genuinely needed. That annotation lives in Workspaces — available
 here, see below.
 
-`PBN2011` is not fixable and never will be; the whole difficulty there is that nobody can tell what
+`PBN3011` is not fixable and never will be; the whole difficulty there is that nobody can tell what
 it serializes.
 
 **A note recorded because I got it wrong first:** there is no packaging obstacle to a fixer here.
@@ -292,13 +292,34 @@ is inert at compile time. Verified by building an analyzer and a fixer in one as
 the analyzer ran and there was no `CS8032`/`CS8034`. Do not pack the Workspaces dll; the IDE supplies
 it.
 
-AOT generator diagnostics use their own **`PBN2000+`** block: `PBN0001`–`PBN0023` belong to
-`DataContractAnalyzer` and `PBN1000+` to `ProtoFileGenerator`'s schema errors. `PBN2010`/`PBN2011` are
-the migration analyzer's, and are the only ones in the 2000 block that are *not* the generator's. New IDs should be
-added to `AnalyzerReleases.Unshipped.md` — note that release tracking is not actually *enforced*
-here (the `Microsoft.CodeAnalysis.Analyzers` RS2000 rules are not active), so the table is
-documentation rather than a build gate, and it *had* drifted; it is current as of this branch, which
-means nothing but review will keep it that way.
+**Every diagnostic id in this assembly, by owner — check this before claiming a block is free:**
+
+| block | owner |
+| --- | --- |
+| `PBN0001`–`PBN0023` | `DataContractAnalyzer` |
+| `PBN1000+` | `ProtoFileGenerator`'s schema errors |
+| **`PBN2001`–`PBN2010`** | **`ServiceContractAnalyzer`** (the gRPC analyzers, since #735) |
+| `PBN3000`–`PBN3004` | `ProtoModelGenerator` — the language floor and the four drop reasons |
+| `PBN3010`–`PBN3013` | `AotMigrationAnalyzer` |
+
+**The AOT block was `PBN2000+` until 2026-08-16 and collided with the gRPC analyzers on five ids**
+(`PBN2001`–`PBN2004`, `PBN2010`), which shipped that way in 3.3. They are one assembly, so a
+severity or suppression is by id and cannot tell the two apart: `dotnet_diagnostic.PBN2002.severity
+= none`, to quiet an AOT drop, also silenced *"The data parameter of a gRPC method must be…"* — an
+**error** downgraded to nothing. The whole AOT block moved to `PBN3000+` rather than only the five,
+keeping the last three digits, so `PBN2001`→`PBN3001` and the mapping needs no table.
+
+**The cause was this very paragraph**, which used to read "AOT generator diagnostics use their own
+`PBN2000+` block", enumerate `DataContractAnalyzer` and `ProtoFileGenerator`, and never mention
+`ServiceContractAnalyzer` at all — the file had zero occurrences of that name. A list of *some* of
+the owners reads exactly like a list of all of them, which is why the table above is exhaustive and
+names the assembly rather than the feature.
+
+New IDs should be added to `AnalyzerReleases.Unshipped.md` — note that release tracking is not
+actually *enforced* here (the `Microsoft.CodeAnalysis.Analyzers` RS2000 rules are not active), so
+the table is documentation rather than a build gate, and it *had* drifted: it listed only the AOT
+half, while `ServiceContractAnalyzer`'s ten shipped ids were recorded nowhere at all — which is the
+other half of how this happened.
 
 Separately, `PBN9001` is not an analyzer diagnostic at all: it is the `[Experimental]` id on
 `ProtoModelAttribute`/`ProtoSurrogateAttribute`, so it is an **error** by default and a consumer
@@ -546,7 +567,7 @@ The division of labour is the part worth remembering, and every clause was probe
 - aliasing **one** of a colliding pair is enough, since `global::` then names the other.
 
 When neither is aliased the type cannot be named by *any* C# syntax, so the contract is refused with
-`PBN2002` naming both assemblies and the `<Aliases>` fix. That is a limitation of C#, not of the
+`PBN3002` naming both assemblies and the `<Aliases>` fix. That is a limitation of C#, not of the
 generator — and refusing beats the alternative, which is CS0433 in a file the consumer never wrote.
 
 **The corpus cannot catch any of this**, which is why it needs its own test: `AotDifferential`
@@ -971,7 +992,7 @@ Fixture conventions:
 - `<Name>.input.cs` declares model type `<Name>Model`, and may declare `<Name>Samples.Values`
   (a `public static object[]`) supplying the values the differential tests exercise.
 - A sibling `<Name>.langver` file pins the parse language version for that fixture — used to prove
-  the `PBN2000` floor fires.
+  the `PBN3000` floor fires.
 - **A fixture member with `[DefaultValue(x)]` must also be initialised to `x`.** `[DefaultValue]`
   affects writing only, so without the initialiser an empty payload deserializes to the CLR default
   and the round-trip assertion fails — correctly. This has caught out two fixtures so far; it is a
@@ -1011,7 +1032,7 @@ available, and the property being pinned is *path of least surprise* —
 - a dropped contract then throws `InvalidOperationException` on use — `TypeModel`'s "no serializer"
   backstop — which the smoke test asserts, so the failure is loud rather than silent.
 
-Note the project needs `<LangVersion>12.0</LangVersion>` (net4x defaults to 7.3, below the `PBN2000`
+Note the project needs `<LangVersion>12.0</LangVersion>` (net4x defaults to 7.3, below the `PBN3000`
 floor) and its own `IsExternalInit` polyfill, since net472 cannot even *compile* `init` without one.
 
 An in-memory test was tried first and abandoned: the test process is net8.0, so its reference set
@@ -1053,7 +1074,7 @@ Two members earn their place for reasons that are not obvious from reading them:
   simplify it: source generators all run against the same input compilation and never see each
   other's output, so a `[ProtoModel]` in the same project as the `.proto` gets an *error symbol* for
   the seed — one with a name but no attributes, which used to be reported as "not marked
-  `[ProtoContract]`". `PBN2002` now recognises `TypeKind.Error` and names the fix.
+  `[ProtoContract]`". `PBN3002` now recognises `TypeKind.Error` and names the fix.
 
 The feature sweep is **complete** as of this branch: every generator feature that was listed as
 natively unexercised now has a member here — the immutable *reference* families, both callback

--- a/docs/aot-coverage.md
+++ b/docs/aot-coverage.md
@@ -12,40 +12,40 @@ of which dropped only by cascade: 28
 
 | count | reason |
 | ---: | --- |
-| 11 | PBN2002 there is no parameterless constructor and SkipConstructor is not set, which protobuf-net refuses too: "No parameterless constructor found" |
-| 9 | PBN2001 member '…' has unsupported type '…'; it is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own |
-| 7 | PBN2001 member '…' has unsupported type '…'; System.Type is deliberately not supported, because ref-emit serializes it through Type.GetType, which native AOT cannot do |
-| 7 | PBN2001 member '…' is not public |
-| 6 | PBN2002 member '…' has [NullWrappedValue] on a non-scalar, which protobuf-net refuses: "NullWrappedValue can only be used with scalar types, or in a collection" |
-| 4 | PBN2001 member '…' has unsupported type '…'; it has a ToString() and a static Parse(string), so [ProtoModel(AllowParseableTypes = true)] would include it - off by default, matching RuntimeTypeModel |
-| 3 | PBN2002 it is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" |
-| 3 | PBN2002 it is reached at more than one compatibility level, and protobuf-net refuses that too: "must use a single compatibility level ... this usually means it is being used in different contexts in the same model" |
-| 2 | PBN2002 the type could not be resolved. If it is produced by another source generator in this same project - a .proto compiled by protobuf-net.BuildTools, say - then it is not visible here: generators do not see each other's output. Move the generated types to a referenced project |
-| 2 | PBN2002 member '…' has [NullWrappedCollection] on a non-collection, which protobuf-net refuses: "NullWrappedCollection can only be used with collection types" |
-| 2 | PBN2003 [ProtoContract(Serializer = typeof(ProtoBuf.Internal.PrimaryTypeProvider))], because that serializer is not accessible here is not supported yet |
-| 1 | PBN2001 member '…' has unsupported type '…' |
-| 1 | PBN2002 it declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '…' is not recognized" |
-| 1 | PBN2002 member '…' declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '…' is not recognized" |
-| 1 | PBN2002 member '…' combines [NullWrappedValue] with [DefaultValue], which protobuf-net refuses |
-| 1 | PBN2002 member '…' combines [NullWrappedValue] with a DataFormat, which protobuf-net refuses: "NullWrappedValue can only be used with DataFormat.Default" |
-| 1 | PBN2002 member '…' combines [NullWrappedValue] with IsPacked, which protobuf-net refuses: "NullWrappedValue cannot be used with packed values" |
-| 1 | PBN2002 member '…' combines [NullWrappedValue] with IsRequired, which protobuf-net refuses: "NullWrappedValue cannot be used with required values" |
-| 1 | PBN2002 member '…' has [NullWrappedValue] on a non-nullable value, which protobuf-net refuses: "NullWrappedValue cannot be used with non-nullable values" |
-| 1 | PBN2002 Field 31 is reserved and cannot be used for data member '…' (iz 31), which protobuf-net refuses too |
-| 1 | PBN2002 Field 32 is reserved and cannot be used for data member '…' (iz 32), which protobuf-net refuses too |
-| 1 | PBN2002 Field '…' is reserved and cannot be used for data member 33 (iz B), which protobuf-net refuses too |
-| 1 | PBN2002 Field 31 is reserved and cannot be used for sub-type '…' (iz 31), which protobuf-net refuses too |
-| 1 | PBN2002 Field 32 is reserved and cannot be used for sub-type '…' (iz 32), which protobuf-net refuses too |
-| 1 | PBN2002 Field '…' is reserved and cannot be used for sub-type 33 (iz B), which protobuf-net refuses too |
-| 1 | PBN2003 this form of [ProtoAfterDeserialization] is not supported yet |
-| 1 | PBN2003 this form of [ProtoBeforeSerialization] is not supported yet |
-| 1 | PBN2001 member '…' has no public getter |
-| 1 | PBN2003 this form of [DefaultValue] is not supported yet |
-| 1 | PBN2001 member '…' has unsupported type '…'; its element '…' is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own |
-| 1 | PBN2002 member '…' has DataFormat.Group on a collection of scalars, which protobuf-net refuses too: "Operation is not valid due to the current state of the object" |
-| 1 | PBN2002 protobuf-net would serialize it as a collection rather than a message, ignoring its members; use [ProtoContract(IgnoreListHandling = true)] if it should be a message |
-| 1 | PBN2002 an interface contract needs [ProtoInclude] for its implementations |
-| 1 | PBN2002 member '…' and [ProtoInclude] share field number 2 |
+| 11 | PBN3002 there is no parameterless constructor and SkipConstructor is not set, which protobuf-net refuses too: "No parameterless constructor found" |
+| 9 | PBN3001 member '…' has unsupported type '…'; it is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own |
+| 7 | PBN3001 member '…' has unsupported type '…'; System.Type is deliberately not supported, because ref-emit serializes it through Type.GetType, which native AOT cannot do |
+| 7 | PBN3001 member '…' is not public |
+| 6 | PBN3002 member '…' has [NullWrappedValue] on a non-scalar, which protobuf-net refuses: "NullWrappedValue can only be used with scalar types, or in a collection" |
+| 4 | PBN3001 member '…' has unsupported type '…'; it has a ToString() and a static Parse(string), so [ProtoModel(AllowParseableTypes = true)] would include it - off by default, matching RuntimeTypeModel |
+| 3 | PBN3002 it is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" |
+| 3 | PBN3002 it is reached at more than one compatibility level, and protobuf-net refuses that too: "must use a single compatibility level ... this usually means it is being used in different contexts in the same model" |
+| 2 | PBN3002 the type could not be resolved. If it is produced by another source generator in this same project - a .proto compiled by protobuf-net.BuildTools, say - then it is not visible here: generators do not see each other's output. Move the generated types to a referenced project |
+| 2 | PBN3002 member '…' has [NullWrappedCollection] on a non-collection, which protobuf-net refuses: "NullWrappedCollection can only be used with collection types" |
+| 2 | PBN3003 [ProtoContract(Serializer = typeof(ProtoBuf.Internal.PrimaryTypeProvider))], because that serializer is not accessible here is not supported yet |
+| 1 | PBN3001 member '…' has unsupported type '…' |
+| 1 | PBN3002 it declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '…' is not recognized" |
+| 1 | PBN3002 member '…' declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '…' is not recognized" |
+| 1 | PBN3002 member '…' combines [NullWrappedValue] with [DefaultValue], which protobuf-net refuses |
+| 1 | PBN3002 member '…' combines [NullWrappedValue] with a DataFormat, which protobuf-net refuses: "NullWrappedValue can only be used with DataFormat.Default" |
+| 1 | PBN3002 member '…' combines [NullWrappedValue] with IsPacked, which protobuf-net refuses: "NullWrappedValue cannot be used with packed values" |
+| 1 | PBN3002 member '…' combines [NullWrappedValue] with IsRequired, which protobuf-net refuses: "NullWrappedValue cannot be used with required values" |
+| 1 | PBN3002 member '…' has [NullWrappedValue] on a non-nullable value, which protobuf-net refuses: "NullWrappedValue cannot be used with non-nullable values" |
+| 1 | PBN3002 Field 31 is reserved and cannot be used for data member '…' (iz 31), which protobuf-net refuses too |
+| 1 | PBN3002 Field 32 is reserved and cannot be used for data member '…' (iz 32), which protobuf-net refuses too |
+| 1 | PBN3002 Field '…' is reserved and cannot be used for data member 33 (iz B), which protobuf-net refuses too |
+| 1 | PBN3002 Field 31 is reserved and cannot be used for sub-type '…' (iz 31), which protobuf-net refuses too |
+| 1 | PBN3002 Field 32 is reserved and cannot be used for sub-type '…' (iz 32), which protobuf-net refuses too |
+| 1 | PBN3002 Field '…' is reserved and cannot be used for sub-type 33 (iz B), which protobuf-net refuses too |
+| 1 | PBN3003 this form of [ProtoAfterDeserialization] is not supported yet |
+| 1 | PBN3003 this form of [ProtoBeforeSerialization] is not supported yet |
+| 1 | PBN3001 member '…' has no public getter |
+| 1 | PBN3003 this form of [DefaultValue] is not supported yet |
+| 1 | PBN3001 member '…' has unsupported type '…'; its element '…' is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own |
+| 1 | PBN3002 member '…' has DataFormat.Group on a collection of scalars, which protobuf-net refuses too: "Operation is not valid due to the current state of the object" |
+| 1 | PBN3002 protobuf-net would serialize it as a collection rather than a message, ignoring its members; use [ProtoContract(IgnoreListHandling = true)] if it should be a message |
+| 1 | PBN3002 an interface contract needs [ProtoInclude] for its implementations |
+| 1 | PBN3002 member '…' and [ProtoInclude] share field number 2 |
 
 Member types we could not handle:
 

--- a/docs/aot-findings.md
+++ b/docs/aot-findings.md
@@ -590,7 +590,7 @@ Two things came out of it.
 generators run against the same input compilation, so a `[ProtoModel]` seeded with a type that
 `ProtoFileGenerator` produces from a `.proto` in the *same* project finds nothing. Worse, the seed
 arrives as an **error symbol with a name but no attributes**, so the old diagnostic said "it is not
-marked `[ProtoContract]`" about a type whose generated source says exactly that. `PBN2002` now
+marked `[ProtoContract]`" about a type whose generated source says exactly that. `PBN3002` now
 recognises `TypeKind.Error` and says what is really wrong, naming the project-layout fix. Probed by
 building it that way, not assumed.
 
@@ -643,9 +643,9 @@ survives, not as a commitment.
 
    The binary grew 3,727,688 → 4,032,072 bytes (linux-x64) across both rounds, which is the cost of
    the new generic instantiations rather than a regression; the immutable pair alone was 225 KB of it.
-2. ~~**Turning the generator on does not make existing code use it.**~~ **Done** — `PBN2010`/`PBN2011`
+2. ~~**Turning the generator on does not make existing code use it.**~~ **Done** — `PBN3010`/`PBN3011`
    flag the call sites, `UseAotModelCodeFixProvider` rewrites the fixable ones onto `Model.Instance`,
-   and `PBN2012`/`PBN2013` announce the feature to a project that has contracts and no model, with
+   and `PBN3012`/`PBN3013` announce the feature to a project that has contracts and no model, with
    `AddProtoModelCodeFixProvider` offering to write the stub. The reasoning behind the severity split
    is under "Future ideas".
 3. ~~**Ship `protobuf-net.BuildTools` by default.**~~ **Done** — packed into `protobuf-net.Core` as
@@ -682,8 +682,8 @@ survives, not as a commitment.
    Note the generator itself is not exercised by this: those projects have no `[ProtoModel]`, so
    `ForAttributeWithMetadataName` never fires. That is the right thing to have measured, since a
    consumer who has not opted in is exactly who pays by default.
-4. ~~**An "announce" diagnostic for discoverability.**~~ **Done** — `PBN2012` (warning, for a project
-   that has asked for AOT) and `PBN2013` (info, on cold-start grounds, for everyone else).
+4. ~~**An "announce" diagnostic for discoverability.**~~ **Done** — `PBN3012` (warning, for a project
+   that has asked for AOT) and `PBN3013` (info, on cold-start grounds, for everyone else).
 5. ~~**The sibling sub-type stack overflow.**~~ **Fixed** — it was a four-line guard once the
    ping-pong was understood; see item 1.
 6. ~~**Establish whether CI is actually red on `main`.**~~ **Done: it is green**, and the corpus
@@ -730,7 +730,7 @@ only, and a subprocess timeout is exactly what contention in a full run would tr
 
 ## Future ideas
 
-### ~~An "announce" diagnostic~~ — built, as `PBN2012`/`PBN2013`
+### ~~An "announce" diagnostic~~ — built, as `PBN3012`/`PBN3013`
 
 Kept for the reasoning, since the severity split is the whole design and it is not the one I first
 proposed.
@@ -740,33 +740,33 @@ The generator is invisible: nothing tells a consumer it exists. The obvious answ
 What makes this defensible is that **there are two different statements to make, and only one of them
 is an offer**:
 
-- **`PBN2012`, a warning.** The project has contracts, asks for AOT or trimming (`PublishAot`,
+- **`PBN3012`, a warning.** The project has contracts, asks for AOT or trimming (`PublishAot`,
   `PublishTrimmed`, `IsAotCompatible`, `IsTrimmable`, read through `CompilerVisibleProperty` in
   `protobuf-net.BuildTools.props`), and declares no `[ProtoModel]`. That is not an advertisement, it
   is a **defect report**: they have asked for AOT and their serializers are going to be built by
   reflection. Info would be under-calling it; an error is arguable, and a consumer who wants that can
   escalate. The default stays a warning so that switching `PublishAot` on does not break a build on
   the spot.
-- **`PBN2013`, info.** Everyone else. And the argument here is *not* AOT, which is what makes it
+- **`PBN3013`, info.** Everyone else. And the argument here is *not* AOT, which is what makes it
   worth making at all: the runtime model inspects metadata and emits IL on **first use** of each
   contract, and that cold-start cost is real enough to time CI out. So there is something in it for a
   consumer who will never publish native, and the offer is honest.
 
 Both are reported **once per compilation** at `Location.None` — this is a property of the project, not
 of any one line, and a squiggle on an arbitrarily-chosen contract would be worse than none. Neither
-fires once a `[ProtoModel]` exists. `dotnet_diagnostic.PBN2013.severity = none` dismisses the quiet
+fires once a `[ProtoModel]` exists. `dotnet_diagnostic.PBN3013.severity = none` dismisses the quiet
 one permanently, in the standard way.
 
 Verified in a real build rather than only in tests, because the property plumbing is the part that
 could silently do nothing: a project with `PublishAot=true`, a contract and no model reports
-`PBN2012` naming `PublishAot`; with it false, nothing appears in normal build output.
+`PBN3012` naming `PublishAot`; with it false, nothing appears in normal build output.
 
-Still open: pairing `PBN2012` with a fix that writes the `[ProtoModel]` stub. That is what would turn
+Still open: pairing `PBN3012` with a fix that writes the `[ProtoModel]` stub. That is what would turn
 it from a notification into an action, and it is the obvious next piece.
 
 ### Cold start, measured: 51 ms → 17 ms → 0.4 ms
 
-`PBN2013` tells a non-AOT consumer that compile-time serializers help cold start. That claim was
+`PBN3013` tells a non-AOT consumer that compile-time serializers help cold start. That claim was
 being made on reasoning alone, so `src/AotColdStart` measures it — a three-horse race over the
 `descriptor.proto` contract closure, median of 30 **process launches**:
 
@@ -783,7 +783,7 @@ equivalent work rather than one of them cheating.
 
 Read net of the baseline: first serialize costs **51.6 ms** vanilla, **16.3 ms** generated on the same
 runtime, **0.5 ms** native. So the claim holds — **~3× on an ordinary JIT build, ~100× native** — and
-B is the number that matters for `PBN2013`, since that consumer is not publishing native at all.
+B is the number that matters for `PBN3013`, since that consumer is not publishing native at all.
 
 Why B is not near-zero: it still pays **JIT for the generated serializer code**. What it no longer
 pays is metadata inspection and ref-emit. C removes the remaining JIT as well, which is why it is

--- a/docs/aot.md
+++ b/docs/aot.md
@@ -81,7 +81,7 @@ If you want none of this — no analyzers, no generators — one property turns 
 
 ## Requirements
 
-- **C# 12 or later.** Below that the generator reports `PBN2000` and emits nothing, rather than
+- **C# 12 or later.** Below that the generator reports `PBN3000` and emits nothing, rather than
   emitting code that will not compile. Note `netstandard2.0` and `net4x` projects default to C# 7.3,
   so those need an explicit `<LangVersion>12.0</LangVersion>`.
 - **net8.0 or later** for a few member shapes — `init`-only setters, non-public setters, getter-only
@@ -110,22 +110,29 @@ So **the build warnings are your inventory**. If you want the model to be comple
 fail, escalate them:
 
 ``` xml
-<WarningsAsErrors>$(WarningsAsErrors);PBN2001;PBN2002;PBN2003;PBN2004</WarningsAsErrors>
+<WarningsAsErrors>$(WarningsAsErrors);PBN3001;PBN3002;PBN3003;PBN3004</WarningsAsErrors>
 ```
 
 | id | meaning |
 | --- | --- |
-| `PBN2000` | the language version is below C# 12; nothing was generated |
-| `PBN2001` | a contract was dropped because of one of its members |
-| `PBN2002` | a contract was dropped because of how it is declared |
-| `PBN2003` | a contract was dropped because of a protobuf-net option not yet supported |
-| `PBN2004` | a contract was dropped because something it references was dropped |
-| `PBN2010` | a call site still goes through the runtime model — see below |
-| `PBN2011` | a call site takes its contract type as a value, so nothing can check it |
+| `PBN3000` | the language version is below C# 12; nothing was generated |
+| `PBN3001` | a contract was dropped because of one of its members |
+| `PBN3002` | a contract was dropped because of how it is declared |
+| `PBN3003` | a contract was dropped because of a protobuf-net option not yet supported |
+| `PBN3004` | a contract was dropped because something it references was dropped |
+| `PBN3010` | a call site still goes through the runtime model — see below |
+| `PBN3011` | a call site takes its contract type as a value, so nothing can check it |
 
-`PBN2004` matters more than it looks: dropping cascades. A contract whose member type was dropped
+`PBN3004` matters more than it looks: dropping cascades. A contract whose member type was dropped
 cannot be emitted either, so one unsupported type can take a subtree with it. Fix the ones that are
-*not* `PBN2004` first, and the cascade usually clears.
+*not* `PBN3004` first, and the cascade usually clears.
+
+> **Upgrading from 3.3?** These ids used to be `PBN2000`–`PBN2004` and `PBN2010`–`PBN2013`, which
+> collided with the gRPC service-contract analyzers in the same package — so silencing an AOT
+> warning could also silence a gRPC **error**. The whole block moved to `PBN3000+`, keeping the last
+> three digits, so `PBN2001` is now `PBN3001`. Update any `WarningsAsErrors`, `NoWarn` or
+> `dotnet_diagnostic.*` entry you copied from the old docs: the old ids still exist and still mean
+> something, just not this, so a stale entry fails quietly rather than loudly.
 
 ### Not every refusal is a gap
 
@@ -146,10 +153,10 @@ facade — go through `RuntimeTypeModel.Default`, which builds serializers **by 
 `[ProtoModel]` does not change that. And those call sites keep working on an ordinary JIT runtime, so
 nothing goes wrong until you publish for native AOT, a long way from the change.
 
-Once your project declares a `[ProtoModel]`, `PBN2010` flags each such call and names your model:
+Once your project declares a `[ProtoModel]`, `PBN3010` flags each such call and names your model:
 
 ``` c#
-Serializer.Serialize(stream, order);   // PBN2010
+Serializer.Serialize(stream, order);   // PBN3010
 model.Serialize(stream, order);        // what it is asking for
 ```
 
@@ -157,11 +164,11 @@ Nothing is reported if you have no `[ProtoModel]` — the runtime model is a per
 protobuf-net, and this has nothing to say to anyone using it. Calls on a model *you* named, including
 a `RuntimeTypeModel.Create()` you configured deliberately, are left alone.
 
-`PBN2010` comes with a code fix. It offers anything of your model's type already in scope, and
+`PBN3010` comes with a code fix. It offers anything of your model's type already in scope, and
 otherwise the generated shared instance:
 
 ``` c#
-Serializer.Serialize(stream, order);        // PBN2010
+Serializer.Serialize(stream, order);        // PBN3010
 MyModel.Instance.Serialize(stream, order);  // what the fix writes
 ```
 
@@ -181,7 +188,7 @@ replaces the implicit public one and points you at `Instance`. Two consequences 
   and everything behaves as before — the generator only does this when you have expressed no
   intention about construction.
 
-`PBN2011` is the other half, and it has no mechanical fix: the non-generic APIs take the thing to
+`PBN3011` is the other half, and it has no mechanical fix: the non-generic APIs take the thing to
 serialize as an `object` or a `Type`, so neither the analyzer nor the generator can tell what will be
 serialized. Under AOT that call will take the reflection path. If it needs to work when published,
 move it to a generic overload.
@@ -196,7 +203,7 @@ put `[ProtoModel]` in the same project. Source generators all run against the sa
 and never see each other's output, so the model finds nothing to serialize.
 
 Put the `.proto` and its generated DTOs in one project, and reference it from the project holding the
-model. The generator reports `PBN2002` with this explanation if it cannot resolve a type you listed.
+model. The generator reports `PBN3002` with this explanation if it cannot resolve a type you listed.
 
 ### Two references that declare the same type
 
@@ -218,7 +225,7 @@ at the point of use:
 
 The generator honours an alias that exists — you do not need to do anything else. If *neither* of a
 colliding pair is aliased, no C# syntax can name the type at all, so the contract is refused with
-`PBN2002` naming both assemblies. Aliasing **one** of them is enough.
+`PBN3002` naming both assemblies. Aliasing **one** of them is enough.
 
 ### Types you do not own
 
@@ -279,7 +286,7 @@ Two things worth doing before you trust it:
   or cannot be determined, as is a **collection as a map key**. Both are reported with a diagnostic
   naming the reason rather than silently mis-emitted.
 - **`AppendValue` aside, anything the generator cannot handle is refused, not guessed.** If a contract
-  is missing from your model there is a `PBN2001`–`PBN2004` warning saying which and why.
+  is missing from your model there is a `PBN3001`–`PBN3004` warning saying which and why.
 
 ## What is supported
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -18,6 +18,13 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
 
 ## unreleased
 
+- **the AOT generator's diagnostic ids move from `PBN2000+` to `PBN3000+`**, keeping the last three
+  digits (`PBN2001` → `PBN3001`, `PBN2010` → `PBN3010`, and so on). They collided with the gRPC
+  service-contract analyzers, which have owned `PBN2001`–`PBN2010` since long before and ship in the
+  same package: because a severity or suppression is applied by id, `dotnet_diagnostic.PBN2002.severity
+  = none` to quiet an AOT drop **also silenced an unrelated gRPC error**. If you copied a
+  `WarningsAsErrors`, `NoWarn` or `.editorconfig` entry from the 3.3 AOT docs, update it — the old ids
+  are still live and still mean something, just not this, so a stale entry now fails quietly
 - **`protobuf-net.BuildTools` is no longer published** (last standalone version: 3.3.8, deprecated):
   the same tooling ships inside protobuf-net.Core and reaches every consumer by default;
   `protobuf-net.BuildTools.Legacy` (for very old SDKs) is unaffected
@@ -27,7 +34,7 @@ Packages are available on NuGet: [protobuf-net](https://www.nuget.org/packages/p
   `protobuf-net.BuildTools` package alongside remains harmless
 - **fix**: `protobuf-net.NodaTime` did not produce a package from a plain build (missing
   `GeneratePackageOnBuild`), and packed with a placeholder description
-- **fix**: `PBN2010`'s example now shows `Model.Instance.Serialize` — the generated accessor that
+- **fix**: `PBN3010`'s example now shows `Model.Instance.Serialize` — the generated accessor that
   actually exists — rather than an imaginary camel-cased local
 - **fix**: the "add an AOT model" code fix now generates the model as `internal` (a fixer should not
   add to the public surface) and inside the project's namespace (or the anchor contract's), rather

--- a/src/AotColdStart/Program.cs
+++ b/src/AotColdStart/Program.cs
@@ -1,4 +1,4 @@
-using Google.Protobuf.Reflection;
+﻿using Google.Protobuf.Reflection;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using System;
@@ -86,11 +86,11 @@ internal static class Program
     private static long RunSynthetic<T>(T value)
     {
         using var ms = new MemoryStream();
-        // PBN2010 is *correct* here and suppressed deliberately: the runtime model is the thing being
+        // PBN3010 is *correct* here and suppressed deliberately: the runtime model is the thing being
         // measured. Pleasingly, the analyzer found this by itself while the harness was being written.
-#pragma warning disable PBN2010
+#pragma warning disable PBN3010
         RuntimeTypeModel.Default.Serialize(ms, value);
-#pragma warning restore PBN2010
+#pragma warning restore PBN3010
         return ms.Length;
     }
 

--- a/src/AotCoverage/Program.cs
+++ b/src/AotCoverage/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using ProtoBuf.BuildTools.Generators;
 using System;
@@ -260,7 +260,7 @@ internal static class Program
             var subject = Regex.Match(message, @"Contract '([^']+)'");
             if (subject.Success) dropped.Add(subject.Groups[1].Value);
 
-            if (diagnostic.Id == "PBN2004")
+            if (diagnostic.Id == "PBN3004")
             {
                 cascades++;
                 continue; // derivative: something it references failed for its own reason

--- a/src/AotNodaTimeSmoke/Program.cs
+++ b/src/AotNodaTimeSmoke/Program.cs
@@ -1,4 +1,4 @@
-using NodaTime;
+﻿using NodaTime;
 using ProtoBuf;
 using ProtoBuf.Meta;
 using System;
@@ -44,7 +44,7 @@ internal static class Program
         }
         catch (InvalidOperationException ex)
         {
-            // the pairings *are* found - see the PBN2003/PBN2004 chain at build time - but the
+            // the pairings *are* found - see the PBN3003/PBN3004 chain at build time - but the
             // well-known types they point at declare [ProtoContract(Serializer = ...)] naming the
             // internal PrimaryTypeProvider, which a consumer's generated code cannot name. Exposing
             // a public serializer for those types is what would finish this off.

--- a/src/AotSchemaDtos/AotSchemaDtos.csproj
+++ b/src/AotSchemaDtos/AotSchemaDtos.csproj
@@ -6,7 +6,7 @@
        That separation is a requirement, not tidiness: source generators all run against the same
        input compilation and never observe each other's output, so a model seeded with a type
        generated from a .proto in the *same* project finds nothing. The generator says so now
-       (PBN2002), but the fix is this project layout. -->
+       (PBN3002), but the fix is this project layout. -->
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/BuildToolsUnitTests/Aot/Data/DateOnly.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/DateOnly.output.txt
@@ -1,3 +1,3 @@
 Generator produced 1 diagnostics:
-Warning PBN2001 Aot/Data/DateOnly.input.cs L20 C38
+Warning PBN3001 Aot/Data/DateOnly.input.cs L20 C38
 Contract 'AotFixtures.DateOnlyFixture.Days' is omitted from the AOT model: member 'Date' has unsupported type 'System.DateOnly'; protobuf-net serializes it through BclHelpers, but those methods are inside #if NET6_0_OR_GREATER - the referenced protobuf-net does not carry them.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/BadLevel.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/BadLevel.output.txt
@@ -1,5 +1,5 @@
 Generator produced 2 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/BadLevel.input.cs L13 C14
+Warning PBN3002 Aot/Data/Diagnostics/BadLevel.input.cs L13 C14
 Contract 'AotFixtures.BadLevel.BadOnType' is omitted from the AOT model: it declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '42' is not recognized".
-Warning PBN2002 Aot/Data/Diagnostics/BadLevel.input.cs L23 C16
+Warning PBN3002 Aot/Data/Diagnostics/BadLevel.input.cs L23 C16
 Contract 'AotFixtures.BadLevel.BadOnMember' is omitted from the AOT model: member 'Value' declares [CompatibilityLevel(42)], which protobuf-net refuses too: "Compatiblity level '42' is not recognized".

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Dropped.input.cs
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Dropped.input.cs
@@ -1,4 +1,4 @@
-using ProtoBuf;
+﻿using ProtoBuf;
 using ProtoBuf.Meta;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -14,7 +14,7 @@ public class HasUnsupportedMember
     [ProtoMember(1)]
     public int Id { get; set; }
 
-    // collections are not handled yet -> PBN2001
+    // collections are not handled yet -> PBN3001
     [ProtoMember(2)]
     public List<string> Tags { get; set; }
 }
@@ -22,7 +22,7 @@ public class HasUnsupportedMember
 [ProtoContract]
 public class ReferencesDropped
 {
-    // fine in itself, but its member type is dropped -> PBN2004
+    // fine in itself, but its member type is dropped -> PBN3004
     [ProtoMember(1)]
     public HasUnsupportedMember Child { get; set; }
 }
@@ -32,7 +32,7 @@ public class NoParameterlessConstructor
 {
     public NoParameterlessConstructor(int id) => Id = id;
 
-    // -> PBN2002
+    // -> PBN3002
     [ProtoMember(1)]
     public int Id { get; set; }
 }
@@ -40,7 +40,7 @@ public class NoParameterlessConstructor
 [ProtoContract]
 public class UsesMemberOptions
 {
-    // named arguments change the wire format -> PBN2003
+    // named arguments change the wire format -> PBN3003
     [ProtoMember(1, IsRequired = true)]
     public int Value { get; set; }
 }
@@ -64,7 +64,7 @@ public class HasCallback
 }
 
 // a *closed* generic is an ordinary contract; only an open one is refused, since the services type
-// is a single non-generic class with nowhere to put the type parameter -> PBN2002
+// is a single non-generic class with nowhere to put the type parameter -> PBN3002
 [ProtoContract]
 public class OpenGeneric<T>
 {

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Dropped.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Dropped.output.txt
@@ -1,5 +1,5 @@
 Generator produced 2 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/Dropped.input.cs L31 C14
+Warning PBN3002 Aot/Data/Diagnostics/Dropped.input.cs L31 C14
 Contract 'AotFixtures.Dropped.NoParameterlessConstructor' is omitted from the AOT model: there is no parameterless constructor and SkipConstructor is not set, which protobuf-net refuses too: "No parameterless constructor found".
-Warning PBN2002 Aot/Data/Diagnostics/Dropped.input.cs L69 C14
+Warning PBN3002 Aot/Data/Diagnostics/Dropped.input.cs L69 C14
 Contract 'AotFixtures.Dropped.OpenGeneric<>' is omitted from the AOT model: open generic types are not supported.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ExtensibleUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ExtensibleUnsupported.output.txt
@@ -1,5 +1,5 @@
 Generator produced 2 diagnostics:
-Warning PBN2003 Aot/Data/Diagnostics/ExtensibleUnsupported.input.cs L9 C15
+Warning PBN3003 Aot/Data/Diagnostics/ExtensibleUnsupported.input.cs L9 C15
 Contract 'AotFixtures.ExtensibleUnsupported.ExtensibleStruct' is omitted from the AOT model: IExtensible on a struct is not supported yet.
-Warning PBN2003 Aot/Data/Diagnostics/ExtensibleUnsupported.input.cs L22 C14
+Warning PBN3003 Aot/Data/Diagnostics/ExtensibleUnsupported.input.cs L22 C14
 Contract 'AotFixtures.ExtensibleUnsupported.UntypedBase' is omitted from the AOT model: IExtensible without ITypedExtensible on a type with inheritance is not supported yet.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/FieldUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/FieldUnsupported.output.txt
@@ -1,7 +1,7 @@
 Generator produced 3 diagnostics:
-Warning PBN2001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L11 C42
+Warning PBN3001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L11 C42
 Contract 'AotFixtures.FieldUnsupported.ReadOnlyField' is omitted from the AOT model: member 'Value' is read-only.
-Warning PBN2001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L17 C39
+Warning PBN3001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L17 C39
 Contract 'AotFixtures.FieldUnsupported.ConstField' is omitted from the AOT model: member 'Value' is a constant.
-Warning PBN2001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L23 C40
+Warning PBN3001 Aot/Data/Diagnostics/FieldUnsupported.input.cs L23 C40
 Contract 'AotFixtures.FieldUnsupported.StaticField' is omitted from the AOT model: member 'Value' is static.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/GroupedScalarList.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/GroupedScalarList.output.txt
@@ -1,3 +1,3 @@
 Generator produced 1 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/GroupedScalarList.input.cs L14 C70
+Warning PBN3002 Aot/Data/Diagnostics/GroupedScalarList.input.cs L14 C70
 Contract 'AotFixtures.GroupedScalarList.GroupedScalars' is omitted from the AOT model: member 'Numbers' has DataFormat.Group on a collection of scalars, which protobuf-net refuses too: "Operation is not valid due to the current state of the object".

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/InheritUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/InheritUnsupported.output.txt
@@ -1,7 +1,7 @@
 Generator produced 3 diagnostics:
-Warning PBN2003 Aot/Data/Diagnostics/InheritUnsupported.input.cs L30 C14
+Warning PBN3003 Aot/Data/Diagnostics/InheritUnsupported.input.cs L30 C14
 Contract 'AotFixtures.InheritUnsupported.ByNameBase' is omitted from the AOT model: this form of [ProtoInclude] is not supported yet.
-Warning PBN2004 Aot/Data/Diagnostics/InheritUnsupported.input.cs L44 C14
+Warning PBN3004 Aot/Data/Diagnostics/InheritUnsupported.input.cs L44 C14
 Contract 'AotFixtures.InheritUnsupported.GoodRoot' is omitted from the AOT model because 'AotFixtures.InheritUnsupported.BadLeaf', which it references, is also omitted.
-Warning PBN2001 Aot/Data/Diagnostics/InheritUnsupported.input.cs L52 C46
+Warning PBN3001 Aot/Data/Diagnostics/InheritUnsupported.input.cs L52 C46
 Contract 'AotFixtures.InheritUnsupported.BadLeaf' is omitted from the AOT model: member 'Unsupported' has unsupported type 'System.Exception'; it is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/InterfaceUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/InterfaceUnsupported.output.txt
@@ -1,13 +1,13 @@
 Generator produced 6 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L15 C18
+Warning PBN3002 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L15 C18
 Contract 'AotFixtures.InterfaceUnsupported.IShape' is omitted from the AOT model: 'AotFixtures.InterfaceUnsupported.Point' is declared as a [ProtoInclude] but is a value type, and protobuf-net refuses that too: "Unexpected sub-type".
-Warning PBN2004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L21 C14
+Warning PBN3004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L21 C14
 Contract 'AotFixtures.InterfaceUnsupported.HasShape' is omitted from the AOT model because 'AotFixtures.InterfaceUnsupported.IShape', which it references, is also omitted.
-Warning PBN2004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L28 C70
+Warning PBN3004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L28 C70
 Contract 'AotFixtures.InterfaceUnsupported.IFirst' is omitted from the AOT model because 'AotFixtures.InterfaceUnsupported.TwoFaced', which it references, is also omitted.
-Warning PBN2004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L29 C70
+Warning PBN3004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L29 C70
 Contract 'AotFixtures.InterfaceUnsupported.ISecond' is omitted from the AOT model because 'AotFixtures.InterfaceUnsupported.TwoFaced', which it references, is also omitted.
-Warning PBN2002 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L32 C14
+Warning PBN3002 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L32 C14
 Contract 'AotFixtures.InterfaceUnsupported.TwoFaced' is omitted from the AOT model: it is declared as a [ProtoInclude] of both 'AotFixtures.InterfaceUnsupported.IFirst' and 'AotFixtures.InterfaceUnsupported.ISecond', and protobuf-net refuses that too: "can only participate in one inheritance hierarchy".
-Warning PBN2004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L35 C14
+Warning PBN3004 Aot/Data/Diagnostics/InterfaceUnsupported.input.cs L35 C14
 Contract 'AotFixtures.InterfaceUnsupported.HasBoth' is omitted from the AOT model because 'AotFixtures.InterfaceUnsupported.IFirst', which it references, is also omitted.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ListLikeContract.input.cs
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ListLikeContract.input.cs
@@ -1,11 +1,11 @@
-using ProtoBuf;
+﻿using ProtoBuf;
 using ProtoBuf.Meta;
 using System.Collections;
 using System.Collections.Generic;
 
 // a [ProtoContract] that also looks like a list: protobuf-net would serialize it as a *collection*
 // and ignore Label entirely, so we refuse it rather than emit a message and disagree on the wire.
-// The referring contract then drops by cascade, which is what PBN2004 reports.
+// The referring contract then drops by cascade, which is what PBN3004 reports.
 namespace AotFixtures.ListLikeContract;
 
 [ProtoContract]

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ListLikeContract.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/ListLikeContract.output.txt
@@ -1,5 +1,5 @@
 Generator produced 2 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/ListLikeContract.input.cs L12 C14
+Warning PBN3002 Aot/Data/Diagnostics/ListLikeContract.input.cs L12 C14
 Contract 'AotFixtures.ListLikeContract.Basket' is omitted from the AOT model: protobuf-net would serialize it as a collection rather than a message, ignoring its members; use [ProtoContract(IgnoreListHandling = true)] if it should be a message.
-Warning PBN2004 Aot/Data/Diagnostics/ListLikeContract.input.cs L23 C14
+Warning PBN3004 Aot/Data/Diagnostics/ListLikeContract.input.cs L23 C14
 Contract 'AotFixtures.ListLikeContract.Holder' is omitted from the AOT model because 'AotFixtures.ListLikeContract.Basket', which it references, is also omitted.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/LowLangVer.input.cs
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/LowLangVer.input.cs
@@ -1,8 +1,8 @@
-using ProtoBuf;
+﻿using ProtoBuf;
 using ProtoBuf.Meta;
 
 // pinned below the generator's floor by the sidecar LowLangVer.langver; the generator should
-// report PBN2000 and emit no model. Fixtures under Diagnostics/ are golden-tested only - they are
+// report PBN3000 and emit no model. Fixtures under Diagnostics/ are golden-tested only - they are
 // deliberately not linked into AotRefGen or AotConformanceTests.
 namespace AotFixtures.LowLangVer;
 

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/LowLangVer.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/LowLangVer.output.txt
@@ -1,3 +1,3 @@
 Generator produced 1 diagnostics:
-Error PBN2000  L1 C1
+Error PBN3000  L1 C1
 The protobuf-net AOT generator requires C# 12.0 or later, but this project uses C# 11.0; set <LangVersion> to at least 12.0.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MapNestedUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MapNestedUnsupported.output.txt
@@ -1,3 +1,3 @@
 Generator produced 1 diagnostics:
-Warning PBN2001 Aot/Data/Diagnostics/MapNestedUnsupported.input.cs L15 C65
+Warning PBN3001 Aot/Data/Diagnostics/MapNestedUnsupported.input.cs L15 C65
 Contract 'AotFixtures.MapNestedUnsupported.NestedKey' is omitted from the AOT model: member 'Value' has unsupported type 'System.Collections.Generic.Dictionary<System.Collections.Generic.List<int>, System.Collections.Generic.List<string>>'.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MapUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MapUnsupported.output.txt
@@ -1,3 +1,3 @@
 Generator produced 1 diagnostics:
-Warning PBN2003 Aot/Data/Diagnostics/MapUnsupported.input.cs L44 C22
+Warning PBN3003 Aot/Data/Diagnostics/MapUnsupported.input.cs L44 C22
 Contract 'AotFixtures.MapUnsupported.NotADictionary' is omitted from the AOT model: [ProtoMap] on a non-dictionary member is not supported yet.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MemberTypeAdvice.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/MemberTypeAdvice.output.txt
@@ -1,9 +1,9 @@
 Generator produced 4 diagnostics:
-Warning PBN2001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L16 C39
+Warning PBN3001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L16 C39
 Contract 'AotFixtures.MemberTypeAdvice.NeedsOption' is omitted from the AOT model: member 'Address' has unsupported type 'System.Net.IPAddress'; it has a ToString() and a static Parse(string), so [ProtoModel(AllowParseableTypes = true)] would include it - off by default, matching RuntimeTypeModel.
-Warning PBN2001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L24 C34
+Warning PBN3001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L24 C34
 Contract 'AotFixtures.MemberTypeAdvice.UsesSystemType' is omitted from the AOT model: member 'Which' has unsupported type 'System.Type'; System.Type is deliberately not supported, because ref-emit serializes it through Type.GetType, which native AOT cannot do.
-Warning PBN2001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L30 C36
+Warning PBN3001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L30 C36
 Contract 'AotFixtures.MemberTypeAdvice.UsesSystemTypeArray' is omitted from the AOT model: member 'Several' has unsupported type 'System.Type[]'; System.Type is deliberately not supported, because ref-emit serializes it through Type.GetType, which native AOT cannot do.
-Warning PBN2001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L41 C75
+Warning PBN3001 Aot/Data/Diagnostics/MemberTypeAdvice.input.cs L41 C75
 Contract 'AotFixtures.MemberTypeAdvice.ListOfUndecorated' is omitted from the AOT model: member 'Items' has unsupported type 'System.Collections.Generic.List<AotFixtures.MemberTypeAdvice.IUndecorated>'; its element 'AotFixtures.MemberTypeAdvice.IUndecorated' is not marked [ProtoContract], [DataContract] or [XmlType] and is not a tuple, so protobuf-net has no serializer for it either: "No serializer defined for type" - [ProtoSurrogate] on the model is the way to serialize a type you do not own.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Reserved.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/Reserved.output.txt
@@ -1,9 +1,9 @@
 Generator produced 4 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/Reserved.input.cs L13 C14
+Warning PBN3002 Aot/Data/Diagnostics/Reserved.input.cs L13 C14
 Contract 'AotFixtures.Reserved.ReservedSingle' is omitted from the AOT model: Field 31 is reserved and cannot be used for data member 'B' (iz 31), which protobuf-net refuses too.
-Warning PBN2002 Aot/Data/Diagnostics/Reserved.input.cs L21 C14
+Warning PBN3002 Aot/Data/Diagnostics/Reserved.input.cs L21 C14
 Contract 'AotFixtures.Reserved.ReservedRange' is omitted from the AOT model: Field 32 is reserved and cannot be used for data member 'B' (iz 32), which protobuf-net refuses too.
-Warning PBN2002 Aot/Data/Diagnostics/Reserved.input.cs L29 C14
+Warning PBN3002 Aot/Data/Diagnostics/Reserved.input.cs L29 C14
 Contract 'AotFixtures.Reserved.ReservedName' is omitted from the AOT model: Field 'B' is reserved and cannot be used for data member 33 (iz B), which protobuf-net refuses too.
-Warning PBN2002 Aot/Data/Diagnostics/Reserved.input.cs L38 C14
+Warning PBN3002 Aot/Data/Diagnostics/Reserved.input.cs L38 C14
 Contract 'AotFixtures.Reserved.ReservedSubType' is omitted from the AOT model: Field 31 is reserved and cannot be used for sub-type 'AotFixtures.Reserved.ReservedSubTypeLeaf' (iz 31), which protobuf-net refuses too.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/TupleLevels.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/TupleLevels.output.txt
@@ -1,5 +1,5 @@
 Generator produced 2 diagnostics:
-Warning PBN2002  L1 C1
+Warning PBN3002  L1 C1
 Contract '(global::System.DateTime, global::System.TimeSpan)' is omitted from the AOT model: it is reached at more than one compatibility level, and protobuf-net refuses that too: "must use a single compatibility level ... this usually means it is being used in different contexts in the same model".
-Warning PBN2004 Aot/Data/Diagnostics/TupleLevels.input.cs L14 C14
+Warning PBN3004 Aot/Data/Diagnostics/TupleLevels.input.cs L14 C14
 Contract 'AotFixtures.TupleLevels.Conflicting' is omitted from the AOT model because '(global::System.DateTime, global::System.TimeSpan)', which it references, is also omitted.

--- a/src/BuildToolsUnitTests/Aot/Data/Diagnostics/WrappedUnsupported.output.txt
+++ b/src/BuildToolsUnitTests/Aot/Data/Diagnostics/WrappedUnsupported.output.txt
@@ -1,7 +1,7 @@
 Generator produced 3 diagnostics:
-Warning PBN2002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L20 C54
+Warning PBN3002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L20 C54
 Contract 'AotFixtures.WrappedUnsupported.WrappedMessage' is omitted from the AOT model: member 'Item' has [NullWrappedValue] on a non-scalar, which protobuf-net refuses: "NullWrappedValue can only be used with scalar types, or in a collection".
-Warning PBN2002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L26 C51
+Warning PBN3002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L26 C51
 Contract 'AotFixtures.WrappedUnsupported.WrappedNonNullable' is omitted from the AOT model: member 'Value' has [NullWrappedValue] on a non-nullable value, which protobuf-net refuses: "NullWrappedValue cannot be used with non-nullable values".
-Warning PBN2002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L32 C57
+Warning PBN3002 Aot/Data/Diagnostics/WrappedUnsupported.input.cs L32 C57
 Contract 'AotFixtures.WrappedUnsupported.WrappedBcl' is omitted from the AOT model: member 'When' has [NullWrappedValue] on a non-scalar, which protobuf-net refuses: "NullWrappedValue can only be used with scalar types, or in a collection".

--- a/src/BuildToolsUnitTests/Aot/ExternAliasTests.cs
+++ b/src/BuildToolsUnitTests/Aot/ExternAliasTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using ProtoBuf.BuildTools.Generators;
 using System.Collections.Immutable;
@@ -107,13 +107,13 @@ namespace BuildToolsUnitTests.Aot
                 extraReferences: new[] { a, b, work });
 
             var text = diagnostics.ToString();
-            Assert.Contains("PBN2002", text);
+            Assert.Contains("PBN3002", text);
             Assert.Contains("LibA", text);
             Assert.Contains("LibB", text);
             Assert.Contains("extern alias", text);
 
             // and the contract that reaches it goes too, by the usual cascade
-            Assert.Contains("PBN2004", text);
+            Assert.Contains("PBN3004", text);
             Assert.Equal(0, result.ErrorCount);
         }
 

--- a/src/BuildToolsUnitTests/AotMigrationAnalyzerTests.cs
+++ b/src/BuildToolsUnitTests/AotMigrationAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using ProtoBuf.BuildTools.Analyzers;
+﻿using ProtoBuf.BuildTools.Analyzers;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -77,7 +77,7 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            var hit = Assert.Single(diagnostics.Where(static x => x.Id == "PBN2010"));
+            var hit = Assert.Single(diagnostics.Where(static x => x.Id == "PBN3010"));
             Assert.Contains("MyModel", hit.GetMessage());
             // the example must name something that exists: the generated static accessor, not a
             // camel-cased local that was never declared
@@ -95,8 +95,8 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            Assert.Single(diagnostics.Where(static x => x.Id == "PBN2011"));
-            Assert.Empty(diagnostics.Where(static x => x.Id == "PBN2010"));
+            Assert.Single(diagnostics.Where(static x => x.Id == "PBN3011"));
+            Assert.Empty(diagnostics.Where(static x => x.Id == "PBN3010"));
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN2010" or "PBN2011"));
+            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN3010" or "PBN3011"));
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN2010" or "PBN2011"));
+            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN3010" or "PBN3011"));
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            Assert.Single(diagnostics.Where(static x => x.Id == "PBN2010"));
+            Assert.Single(diagnostics.Where(static x => x.Id == "PBN3010"));
         }
 
         /// <summary>
@@ -167,9 +167,9 @@ namespace BuildToolsUnitTests
         {
             var diagnostics = await AnalyzeAsync(Preamble);
 
-            var hit = Assert.Single(diagnostics.Where(static x => x.Id == "PBN2013"));
+            var hit = Assert.Single(diagnostics.Where(static x => x.Id == "PBN3013"));
             Assert.Equal(Microsoft.CodeAnalysis.DiagnosticSeverity.Info, hit.Severity);
-            Assert.Empty(diagnostics.Where(static x => x.Id == "PBN2012"));
+            Assert.Empty(diagnostics.Where(static x => x.Id == "PBN3012"));
         }
 
         /// <summary>...and nothing at all once a model exists, which is the point of announcing.</summary>
@@ -177,7 +177,7 @@ namespace BuildToolsUnitTests
         public async Task SaysNothingOnceAModelExists()
         {
             var diagnostics = await AnalyzeAsync(WithModel);
-            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN2012" or "PBN2013"));
+            Assert.Empty(diagnostics.Where(static x => x.Id is "PBN3012" or "PBN3013"));
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace BuildToolsUnitTests
                 }
                 """);
 
-            Assert.Equal(2, diagnostics.Count(static x => x.Id == "PBN2010"));
+            Assert.Equal(2, diagnostics.Count(static x => x.Id == "PBN3010"));
         }
     }
 }

--- a/src/BuildToolsUnitTests/CodeFixes/UseAotModelCodeFixProviderTests.cs
+++ b/src/BuildToolsUnitTests/CodeFixes/UseAotModelCodeFixProviderTests.cs
@@ -1,4 +1,4 @@
-using BuildToolsUnitTests.CodeFixes.Abstractions;
+﻿using BuildToolsUnitTests.CodeFixes.Abstractions;
 using Microsoft.CodeAnalysis.Testing;
 using ProtoBuf.BuildTools.Analyzers;
 using ProtoBuf.CodeFixes;
@@ -8,7 +8,7 @@ using Xunit;
 namespace BuildToolsUnitTests.CodeFixes
 {
     /// <summary>
-    /// The `PBN2010` fixer: swap the receiver for a model that is already in scope.
+    /// The `PBN3010` fixer: swap the receiver for a model that is already in scope.
     /// </summary>
     public class UseAotModelCodeFixProviderTests : CodeFixProviderTestsBase<UseAotModelCodeFixProvider>
     {

--- a/src/DownLevelSmoke/DownLevelSmoke.csproj
+++ b/src/DownLevelSmoke/DownLevelSmoke.csproj
@@ -5,7 +5,7 @@
          still plenty of .NET Framework out there, and it should get a smaller model rather than a
          broken build -->
     <TargetFramework>net472</TargetFramework>
-    <!-- net4x defaults to C# 7.3, and the generator has a hard C# 12 floor (PBN2000) -->
+    <!-- net4x defaults to C# 7.3, and the generator has a hard C# 12 floor (PBN3000) -->
     <LangVersion>12.0</LangVersion>
     <RootNamespace>ProtoBuf.DownLevelSmoke</RootNamespace>
     <AssemblyName>DownLevelSmoke</AssemblyName>

--- a/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
+++ b/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
@@ -1,4 +1,11 @@
-﻿### New Rules
+﻿; ServiceContractAnalyzer's PBN2001-PBN2010 (the gRPC analyzers) shipped in #735 and were
+; recorded here by NOBODY until 2026-08-16 - which is half of why the AOT generator was later
+; given a "PBN2000+ block of its own" that was nothing of the kind. They are listed below as
+; new rules because that is where a reader will look; they are not new, they are newly tracked.
+; Release tracking is not enforced in this repo (the RS2000 rules are inactive), so this table
+; is documentation - and the ONLY register of which ids are taken. Check it before adding one.
+
+### New Rules
 
 Rule ID  | Category | Severity | Notes
 ---------|----------|----------|--------------------
@@ -25,13 +32,23 @@ PBN0020  | Usage    | Warning  | Member should declare `[DefaultValue]`
 PBN0021  | Usage    | Warning  | Member should update its `[DefaultValue]`
 PBN0022  | Usage    | Warning  | Member should declare `IsRequired`
 PBN0023  | Usage    | Warning  | `[ProtoContract]` on an interface is not recommended
-PBN2000  | ProtoBuf | Error    | Language version too low for the AOT generator
-PBN2001  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported member
-PBN2002  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported declaration
-PBN2003  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported protobuf-net option
-PBN2004  | ProtoBuf | Warning  | Contract omitted from the AOT model: references an omitted contract
-PBN2010  | ProtoBuf | Warning  | Call uses the runtime model, not the AOT model
-PBN2011  | ProtoBuf | Warning  | Call resolves its contract type at run time
-PBN2012  | ProtoBuf | Warning  | Project publishes AOT or trimmed, but has no AOT model
-PBN2013  | ProtoBuf | Info     | Compile-time serializers are available
+PBN2001  | Usage    | Error    | gRPC: invalid member kind on a service contract
+PBN2002  | Usage    | Error    | gRPC: invalid payload type
+PBN2003  | Usage    | Error    | gRPC: invalid return type
+PBN2004  | Usage    | Error    | gRPC: generic method
+PBN2005  | Usage    | Error    | gRPC: generic service
+PBN2006  | Usage    | Error    | gRPC: invalid context type
+PBN2007  | Usage    | Error    | gRPC: invalid parameters
+PBN2008  | Usage    | Warning  | gRPC: payload possibly not serializable
+PBN2009  | Usage    | Info     | gRPC: prefer an async signature
+PBN2010  | Usage    | Error    | gRPC: streaming method declared synchronously
+PBN3000  | ProtoBuf | Error    | Language version too low for the AOT generator
+PBN3001  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported member
+PBN3002  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported declaration
+PBN3003  | ProtoBuf | Warning  | Contract omitted from the AOT model: unsupported protobuf-net option
+PBN3004  | ProtoBuf | Warning  | Contract omitted from the AOT model: references an omitted contract
+PBN3010  | ProtoBuf | Warning  | Call uses the runtime model, not the AOT model
+PBN3011  | ProtoBuf | Warning  | Call resolves its contract type at run time
+PBN3012  | ProtoBuf | Warning  | Project publishes AOT or trimmed, but has no AOT model
+PBN3013  | ProtoBuf | Info     | Compile-time serializers are available
 

--- a/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/AotMigrationAnalyzer.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -35,7 +35,7 @@ namespace ProtoBuf.BuildTools.Analyzers
     public sealed class AotMigrationAnalyzer : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor UsesRuntimeModel = new(
-            id: "PBN2010",
+            id: "PBN3010",
             title: "Call uses the runtime model, not the AOT model",
             messageFormat: "'{0}' serializes through the runtime model, which reflects and so does not "
                 + "work under native AOT; this project declares {1}, so call it on that instead "
@@ -45,7 +45,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor UnresolvableContractType = new(
-            id: "PBN2011",
+            id: "PBN3011",
             title: "Call resolves its contract type at run time",
             messageFormat: "'{0}' takes the type to serialize as a value rather than a type argument, "
                 + "so neither this analyzer nor the AOT generator can tell what it serializes; under "
@@ -56,7 +56,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor NoModelUnderAot = new(
-            id: "PBN2012",
+            id: "PBN3012",
             title: "This project publishes AOT or trimmed, but has no AOT model",
             messageFormat: "This project has protobuf-net contracts and asks for {0}, but declares no "
                 + "[ProtoModel]; serializers will be built by reflection, which is exactly what will "
@@ -66,7 +66,7 @@ namespace ProtoBuf.BuildTools.Analyzers
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor NoModel = new(
-            id: "PBN2013",
+            id: "PBN3013",
             title: "Compile-time serializers are available",
             // qualitative deliberately: the measured figure is ~3x on an ordinary build (see
             // docs/aot-findings.md), but a hard number in a diagnostic ages badly and varies by
@@ -161,7 +161,7 @@ namespace ProtoBuf.BuildTools.Analyzers
         /// argument there is **cold start**, not AOT: the runtime model inspects metadata and emits
         /// IL on first use of each contract, and that cost is real enough to time builds out. It is
         /// a genuine offer rather than an advertisement, which is why it is worth making at all —
-        /// and `dotnet_diagnostic.PBN2013.severity = none` dismisses it permanently.
+        /// and `dotnet_diagnostic.PBN3013.severity = none` dismisses it permanently.
         /// </para>
         /// <para>
         /// Location.None deliberately: this is about the project, not about any one line of it, and

--- a/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
+++ b/src/protobuf-net.BuildTools/CodeFixes/AddProtoModelCodeFixProvider.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -16,7 +16,7 @@ namespace ProtoBuf.CodeFixes
     /// Writes the <c>[ProtoModel]</c> stub for a project that has contracts and no model.
     /// </summary>
     /// <remarks>
-    /// This is what turns <c>PBN2012</c>/<c>PBN2013</c> from a notification into an action. The
+    /// This is what turns <c>PBN3012</c>/<c>PBN3013</c> from a notification into an action. The
     /// diagnostics are anchored on a contract purely so that this can be offered — a code fix has to
     /// attach to a document — and the new file is added to the project rather than edited into an
     /// existing one, since a model is a declaration about the whole project rather than about the

--- a/src/protobuf-net.BuildTools/CodeFixes/UseAotModelCodeFixProvider.cs
+++ b/src/protobuf-net.BuildTools/CodeFixes/UseAotModelCodeFixProvider.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -29,7 +29,7 @@ namespace ProtoBuf.CodeFixes
     /// decides where the instance should live.
     /// </para>
     /// <para>
-    /// Only <c>PBN2010</c> is fixable. <c>PBN2011</c> — the <c>object</c>/<c>Type</c> APIs — has no
+    /// Only <c>PBN3010</c> is fixable. <c>PBN3011</c> — the <c>object</c>/<c>Type</c> APIs — has no
     /// mechanical rewrite, because the whole difficulty is that nobody can tell what it serializes.
     /// </para>
     /// </remarks>

--- a/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.Diagnostics.cs
+++ b/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.Diagnostics.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.CodeAnalysis;
 using ProtoBuf.BuildTools.Internal.Aot;
 using System;
@@ -15,7 +15,7 @@ namespace ProtoBuf.BuildTools.Generators
         // wanting strictness can escalate these through WarningsAsErrors.
 
         internal static readonly DiagnosticDescriptor UnsupportedMember = new(
-            id: "PBN2001",
+            id: "PBN3001",
             title: "Contract omitted: unsupported member",
             messageFormat: "Contract '{0}' is omitted from the AOT model: member '{1}' {2}.",
             category: Category,
@@ -23,7 +23,7 @@ namespace ProtoBuf.BuildTools.Generators
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor UnsupportedContract = new(
-            id: "PBN2002",
+            id: "PBN3002",
             title: "Contract omitted: unsupported declaration",
             messageFormat: "Contract '{0}' is omitted from the AOT model: {1}.",
             category: Category,
@@ -31,7 +31,7 @@ namespace ProtoBuf.BuildTools.Generators
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor UnsupportedOption = new(
-            id: "PBN2003",
+            id: "PBN3003",
             title: "Contract omitted: unsupported protobuf-net option",
             messageFormat: "Contract '{0}' is omitted from the AOT model: {1} is not supported yet.",
             category: Category,
@@ -39,7 +39,7 @@ namespace ProtoBuf.BuildTools.Generators
             isEnabledByDefault: true);
 
         internal static readonly DiagnosticDescriptor OmittedCascade = new(
-            id: "PBN2004",
+            id: "PBN3004",
             title: "Contract omitted: references an omitted contract",
             messageFormat: "Contract '{0}' is omitted from the AOT model because '{1}', which it references, is also omitted.",
             category: Category,

--- a/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.Emit.cs
+++ b/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.Emit.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using Microsoft.CodeAnalysis.CSharp;
 using ProtoBuf.BuildTools.Internal.Aot;
 using System;
@@ -64,7 +64,7 @@ namespace ProtoBuf.BuildTools.Generators
 
             // A shared instance, because a TypeModel is a cache: it is meant to be built once and
             // reused, and without somewhere obvious to put it people write `new MyModel()` per call.
-            // It also gives PBN2010's fixer something to name when nothing is in scope, which is the
+            // It also gives PBN3010's fixer something to name when nothing is in scope, which is the
             // common case for a codebase part-way through migrating.
             //
             // Suppressed if the consumer's half of the partial already declares `Instance` (CS0102),

--- a/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.cs
+++ b/src/protobuf-net.BuildTools/Generators/ProtoModelGenerator.cs
@@ -54,7 +54,7 @@ namespace ProtoBuf.BuildTools.Generators
         internal const string DiagnosticTrackingName = "ProtoModelDiagnostics";
 
         internal static readonly DiagnosticDescriptor LanguageVersionTooLow = new(
-            id: "PBN2000",
+            id: "PBN3000",
             title: "Language version too low",
             messageFormat: "The protobuf-net AOT generator requires C# {0} or later, but this project uses C# {1}; set <LangVersion> to at least {0}.",
             category: "ProtoBuf",


### PR DESCRIPTION
`ServiceContractAnalyzer` has owned `PBN2001`–`PBN2010` since #735. #1254 gave the AOT generator *"its own `PBN2000+` block"*, which was nothing of the kind: `PBN2001`–`PBN2004` and `PBN2010` landed on top of it, in the **same assembly**, and shipped that way in 3.3.

A severity or a suppression is applied **by id**, so nothing can tell the two apart:

| id | ServiceContractAnalyzer (since #735) | AOT generator (since #1254) |
| --- | --- | --- |
| `PBN2001` | invalid member kind — **Error** | contract dropped: member — Warning |
| `PBN2002` | invalid payload type — **Error** | contract dropped: declaration — Warning |
| `PBN2003` | invalid return type — **Error** | contract dropped: option — Warning |
| `PBN2004` | generic method — **Error** | contract dropped: cascade — Warning |
| `PBN2010` | streaming method declared sync — **Error** | call site uses the runtime model — Warning |

So `dotnet_diagnostic.PBN2002.severity = none` — the obvious way to quiet an AOT drop — also silences *"The data parameter of a gRPC method must be…"*, downgrading an **error** to nothing. And `docs/aot.md` was recommending `<WarningsAsErrors>…PBN2001;PBN2002;PBN2003;PBN2004</WarningsAsErrors>`.

## What this does

Moves the **whole** AOT block, not just the five conflicts — a block split across `PBN2000` and `PBN2020` is what made the collision easy to miss. `+1000` with the last three digits kept, so `PBN2001` → `PBN3001` and the mapping needs no lookup table.

The gRPC ids do **not** move: they shipped years earlier, and consumers' `.editorconfig` and `NoWarn` entries point at them.

184 references across 39 files. The only surviving `PBN2001`–`PBN2010` references are `ServiceContractAnalyzer` itself, the release-tracking table, and the three documents explaining the move.

## The two things that let it happen, both fixed here

**`AGENTS.md` carried the cause.** It read *"AOT generator diagnostics use their own `PBN2000+` block"*, enumerated `DataContractAnalyzer` and `ProtoFileGenerator`… and never mentioned `ServiceContractAnalyzer` — the file had **zero** occurrences of that name. A list of *some* owners reads exactly like a list of all of them. It is now an exhaustive table keyed by assembly rather than by feature.

**`AnalyzerReleases.Unshipped.md` tracked only the AOT half**, and `ServiceContractAnalyzer`'s ten shipped ids were recorded nowhere at all. They are listed now, with a header saying they are not new — merely newly tracked — and that the table is the only register of which ids are taken.

## Consumer impact

Called out in `docs/aot.md` and the release notes, because the failure mode is **silence**: the old ids still exist and still mean something, just not this, so a stale `WarningsAsErrors` / `NoWarn` / `dotnet_diagnostic.*` entry copied from the 3.3 docs now does nothing rather than erroring.

## Also

Adds `bench-*/` to `.gitignore` — `main` lacked it and `v4` already has it, so this reduces merge friction rather than creating it. A `git add -A` swept twelve stray BenchmarkDotNet artefacts into the first cut of this commit, which is the argument for the rule.

## Gates

Traversal build 0 errors · BuildToolsUnitTests 326, **including the 47 `ServiceAnalyzerTests`** — the side that deliberately does *not* move · AotConformanceTests 655 · protobuf-net.Test 1051/1050 ×2 TFMs · AotDifferential 3022 at 100%, exit 0.

## Follow-up on `v4`

`v4`/`schema-breadth` add `PBN2020`–`PBN2023` (the schema front-end), which don't collide but would be left behind in the old block. They should move to `PBN3020`–`PBN3023` when this merges forward, so the block stays whole — which was the whole point of moving all of it.

https://claude.ai/code/session_01HotttZjp6rkD1xvenCXZfF
