### PR TITLE
Experimental APIs get a help link, and PBN9001 gets a page telling people how to opt in

### DIFF
--- a/docs/exp/PBN9001.md
+++ b/docs/exp/PBN9001.md
@@ -35,5 +35,5 @@ or more granularly / locally in C#:
 ## Where to go next
 
 - [Compile-time serializers, for native AOT and trimming](../aot) — the serializer half.
-- [Native AOT and trimming, in protobuf-net.Grpc](https://protobuf-net.github.io/protobuf-net.Grpc/aot)
+- [Native AOT and trimming, in protobuf-net.Grpc](https://grpc.protobuf-net.dev/aot)
   — the gRPC half.

--- a/docs/exp/PBN9001.md
+++ b/docs/exp/PBN9001.md
@@ -1,0 +1,39 @@
+`[ProtoModel]`, `[ProtoSerializable]` and `[ProtoSurrogate]` build serializers at **compile time**
+instead of by reflection and IL emission at runtime. That is what makes protobuf-net work under
+**native AOT**, and it is worth a look under trimming, or purely for cold start, even if you never
+publish native.
+
+The same id also covers protobuf-net.Grpc's `[ProtoGrpc]` and `[ProtoService]`, which do the
+equivalent for code-first gRPC contracts. **That is deliberate: the two halves are opted into
+together in practice**, and generated gRPC proxies still marshal through the *reflective* runtime
+model unless you name a `[ProtoModel]` — so one entry opting into both is a feature rather than an
+accident.
+
+The feature is in preview, and the shape may still change:
+
+1. The attributes and their properties may be renamed, moved, or gain and lose members.
+2. The generated API surface — `Instance`, the constructor the generator emits, the services type —
+   may change shape.
+3. Diagnostics may be added, renumbered, or change severity as coverage grows.
+
+None of that affects the **wire format**, which is ordinary protobuf either way: a contract
+serialized by a generated model is byte-for-byte what the runtime model produces, and CI compares
+them on every build. You can go back to the runtime model by deleting the model type.
+
+If you acknowledge this, you can suppress this warning by adding the following to your `csproj` file:
+
+```xml
+<NoWarn>$(NoWarn);PBN9001</NoWarn>
+```
+
+or more granularly / locally in C#:
+
+``` c#
+#pragma warning disable PBN9001
+```
+
+## Where to go next
+
+- [Compile-time serializers, for native AOT and trimming](../aot) — the serializer half.
+- [Native AOT and trimming, in protobuf-net.Grpc](https://protobuf-net.github.io/protobuf-net.Grpc/aot)
+  — the gRPC half.

--- a/src/protobuf-net.Core/Internal/Experiments.cs
+++ b/src/protobuf-net.Core/Internal/Experiments.cs
@@ -1,0 +1,25 @@
+namespace ProtoBuf.Internal
+{
+    // example usage:
+    // [Experimental(Experiments.SomeFeature, UrlFormat = Experiments.UrlFormat)]
+    // where the id has a corresponding /docs/exp/{id}.md page telling people how to opt in
+    internal static class Experiments
+    {
+        // note: {0} is substituted with the DiagnosticId by the compiler, e.g. .../exp/PBN9001
+        //
+        // the page name must match the id's *case* - GitHub Pages paths are case-sensitive, so
+        // docs/exp/PBN9001.md, not docs/exp/pbn9001.md
+        public const string UrlFormat = "https://docs.protobuf-net.dev/exp/{0}";
+
+        /// <summary>
+        /// Compile-time serializers: <c>[ProtoModel]</c>, <c>[ProtoSerializable]</c>,
+        /// <c>[ProtoSurrogate]</c>.
+        /// </summary>
+        /// <remarks>
+        /// protobuf-net.Grpc's <c>[ProtoGrpc]</c> deliberately shares this id: the two halves are
+        /// opted into together in practice, so one <c>NoWarn</c> covering both is a feature rather
+        /// than an accident. Do not reuse it for anything unrelated.
+        /// </remarks>
+        public const string CompileTimeModel = "PBN9001";
+    }
+}

--- a/src/protobuf-net.Core/ProtoModelAttributes.cs
+++ b/src/protobuf-net.Core/ProtoModelAttributes.cs
@@ -1,4 +1,5 @@
 using System;
+using ProtoBuf.Internal;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ProtoBuf
@@ -13,13 +14,13 @@ namespace ProtoBuf
     /// a diagnostic rather than being guessed at.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    [Experimental(ProtoModelAttribute.DiagnosticId)]
+    [Experimental(Experiments.CompileTimeModel, UrlFormat = Experiments.UrlFormat)]
     public sealed class ProtoModelAttribute : Attribute
     {
         /// <summary>
         /// The diagnostic reported for use of the compile-time model APIs while they are experimental.
         /// </summary>
-        public const string DiagnosticId = "PBN9001";
+        public const string DiagnosticId = Experiments.CompileTimeModel;
 
         /// <summary>
         /// Whether types with a <c>ToString()</c> and a <c>Parse(string)</c> should be serialized as
@@ -37,7 +38,7 @@ namespace ProtoBuf
     /// root is included in the model automatically.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    [Experimental(ProtoModelAttribute.DiagnosticId)]
+    [Experimental(Experiments.CompileTimeModel, UrlFormat = Experiments.UrlFormat)]
     public sealed class ProtoSerializableAttribute : Attribute
     {
         /// <summary>

--- a/src/protobuf-net.Core/ProtoSurrogateAttribute.cs
+++ b/src/protobuf-net.Core/ProtoSurrogateAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using ProtoBuf.Internal;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ProtoBuf
@@ -21,7 +22,7 @@ namespace ProtoBuf
     /// </para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
-    [Experimental(ProtoModelAttribute.DiagnosticId)]
+    [Experimental(Experiments.CompileTimeModel, UrlFormat = Experiments.UrlFormat)]
     public sealed class ProtoSurrogateAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
`PBN9001` is an **error** by default, so the compiler's help link is exactly what whoever hits it needs — and the IDE surfaces it directly, which is the point of doing this at all.

Adds `UrlFormat` to all three experimental attributes (`[ProtoModel]`, `[ProtoSerializable]`, `[ProtoSurrogate]`), following the convention from StackExchange.Redis: an `Experiments` constants class holding the id and the format, and one `/docs/exp/{id}.md` page per experimental id, written to say why the API is gated and how to suppress it — in `csproj` and via `#pragma`.

`ProtoModelAttribute.DiagnosticId` stays public, now defined from `Experiments.CompileTimeModel`, so there is one source of truth and nothing breaks.

### One experiment, one page

The page covers **both** halves, because `PBN9001` is genuinely one experiment: protobuf-net.Grpc's `[ProtoGrpc]` shares the id, deliberately — build-time gRPC proxies still marshal through the *reflective* runtime model unless a `[ProtoModel]` is named, so the two are opted into together and one `NoWarn` covering both is a feature.

So protobuf-net.Grpc's `UrlFormat` for that id points **here** rather than at a second copy (protobuf-net/protobuf-net.Grpc#365). A duplicate page would fork the guidance and guarantee the two drift.

### Verified, not assumed

    200  https://stackexchange.github.io/StackExchange.Redis/exp/SER001
    404  https://stackexchange.github.io/StackExchange.Redis/exp/ser001
    200  https://docs.protobuf-net.dev/aot

So `exp/{0}` resolves on GitHub Pages, extensionless URLs already work on our site — and **paths are case-sensitive**. Since `{0}` substitutes the id verbatim, the page must be `PBN9001.md` and not `pbn9001.md`; getting that wrong is a silent 404 in a link nobody clicks until they are already stuck, so it is recorded in the `Experiments` comment rather than left to be rediscovered.

326 tests pass; `protobuf-net.BuildTools.Legacy` still builds.