### PR TITLE
Add a copy constructor to SchemaGenerationOptions

### DIFF
--- a/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
+++ b/src/protobuf-net.Core/Meta/SchemaGenerationOptions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ProtoBuf.Internal;
+using System;
 using System.Collections.Generic;
 
 namespace ProtoBuf.Meta
@@ -9,6 +10,42 @@ namespace ProtoBuf.Meta
     public sealed class SchemaGenerationOptions
     {
         internal static readonly SchemaGenerationOptions Default = new SchemaGenerationOptions();
+
+        /// <summary>
+        /// Create a new instance
+        /// </summary>
+        public SchemaGenerationOptions() { }
+
+        /// <summary>
+        /// Create a new instance, copying the state of an existing instance
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The collections are copied by <em>content</em>, not by reference, so the two instances can
+        /// be mutated independently - which is the entire point: callers that hold configuration on a
+        /// long-lived object need a per-operation copy to add to, and sharing the lists would simply
+        /// move the problem.
+        /// </para>
+        /// <para>
+        /// This exists because the alternative is a hand-rolled copy in the caller, which silently
+        /// stops being complete the moment a property is added here. <c>SchemaGenerationOptionsTests</c>
+        /// guards that by reflecting over the properties rather than trusting this to be updated.
+        /// </para>
+        /// </remarks>
+        /// <param name="source">The instance to copy.</param>
+        public SchemaGenerationOptions(SchemaGenerationOptions source)
+        {
+            if (source is null) ThrowHelper.ThrowArgumentNullException(nameof(source));
+
+            Syntax = source.Syntax;
+            Flags = source.Flags;
+            Package = source.Package;
+            Origin = source.Origin;
+
+            // via the backing fields, so copying an untouched instance does not allocate the lists
+            if (source.HasServices) Services.AddRange(source._services);
+            if (source.HasTypes) Types.AddRange(source._types);
+        }
 
         /// <summary>
         /// Indiate the variant of the protobuf .proto DSL syntax to use

--- a/src/protobuf-net.Core/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/protobuf-net.Core/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+ProtoBuf.Meta.SchemaGenerationOptions.SchemaGenerationOptions(ProtoBuf.Meta.SchemaGenerationOptions source) -> void

--- a/src/protobuf-net.Test/SchemaGenerationOptionsTests.cs
+++ b/src/protobuf-net.Test/SchemaGenerationOptionsTests.cs
@@ -1,0 +1,122 @@
+using ProtoBuf.Meta;
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace ProtoBuf
+{
+    public class SchemaGenerationOptionsTests
+    {
+        [Fact]
+        public void CopyConstructorCopiesEverySettableProperty()
+        {
+            var source = new SchemaGenerationOptions
+            {
+                Syntax = ProtoSyntax.Proto2,
+                Flags = SchemaGenerationFlags.PreserveSubType | SchemaGenerationFlags.MultipleNamespaceSupport,
+                Package = "some.package",
+                Origin = "some/origin.proto",
+            };
+
+            var clone = new SchemaGenerationOptions(source);
+
+            Assert.Equal(source.Syntax, clone.Syntax);
+            Assert.Equal(source.Flags, clone.Flags);
+            Assert.Equal(source.Package, clone.Package);
+            Assert.Equal(source.Origin, clone.Origin);
+        }
+
+        /// <summary>
+        /// Fails when a property is added to <see cref="SchemaGenerationOptions"/> without being
+        /// taught to the copy constructor.
+        /// </summary>
+        /// <remarks>
+        /// The point of the copy constructor is that callers stop hand-rolling an incomplete copy; it
+        /// would be poor if the copy constructor itself then became the incomplete one, silently, with
+        /// nothing failing. So this asserts by reflection rather than by an enumerated list.
+        /// </remarks>
+        [Fact]
+        public void CopyConstructorHandlesEveryPublicProperty()
+        {
+            var properties = typeof(SchemaGenerationOptions)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            var source = new SchemaGenerationOptions();
+            var untouched = new SchemaGenerationOptions();
+
+            // give every settable property a value that differs from the default
+            foreach (var property in properties.Where(static x => x.GetSetMethod() is not null))
+            {
+                property.SetValue(source, DistinctValue(property, property.GetValue(untouched)));
+            }
+            // ...and put something in every collection
+            source.Services.Add(new Service { Name = "SomeService" });
+            source.Types.Add(typeof(SchemaGenerationOptionsTests));
+
+            var clone = new SchemaGenerationOptions(source);
+
+            foreach (var property in properties)
+            {
+                var expected = property.GetValue(source);
+                var actual = property.GetValue(clone);
+
+                if (expected is System.Collections.ICollection expectedItems)
+                {
+                    var actualItems = Assert.IsAssignableFrom<System.Collections.ICollection>(actual);
+                    Assert.True(expectedItems.Count == actualItems.Count,
+                        $"{property.Name} was not copied ({expectedItems.Count} vs {actualItems.Count} items)");
+                    Assert.True(expectedItems.Cast<object>().SequenceEqual(actualItems.Cast<object>()),
+                        $"{property.Name} contents differ");
+                    Assert.False(ReferenceEquals(expected, actual),
+                        $"{property.Name} is shared by reference; the two instances must be independently mutable");
+                }
+                else
+                {
+                    Assert.True(Equals(expected, actual), $"{property.Name} was not copied");
+                }
+            }
+
+            static object DistinctValue(PropertyInfo property, object current)
+            {
+                var type = property.PropertyType;
+                if (type == typeof(string)) return property.Name + "-value";
+                if (type.IsEnum)
+                {
+                    // any value other than whatever the default happens to be
+                    return Enum.GetValues(type).Cast<object>().First(x => !Equals(x, current));
+                }
+                if (type == typeof(bool)) return !(bool)current;
+                if (type == typeof(int)) return (int)current + 1;
+                throw new NotSupportedException(
+                    $"{property.Name} is a {type.Name}; teach this test how to vary it, and check the copy constructor handles it");
+            }
+        }
+
+        [Fact]
+        public void CopyingAnUntouchedInstanceDoesNotAllocateTheCollections()
+        {
+            // laziness is worth preserving: SchemaGenerationOptions.Default exists and is copied often
+            var clone = new SchemaGenerationOptions(new SchemaGenerationOptions());
+            Assert.Empty(clone.Services);
+            Assert.Empty(clone.Types);
+        }
+
+        [Fact]
+        public void CollectionsAreIndependentAfterCopying()
+        {
+            var source = new SchemaGenerationOptions();
+            source.Services.Add(new Service { Name = "First" });
+
+            var clone = new SchemaGenerationOptions(source);
+            clone.Services.Add(new Service { Name = "Second" });
+
+            Assert.Single(source.Services);
+            Assert.Equal(2, clone.Services.Count);
+        }
+
+        [Fact]
+        public void CopyingNullThrows()
+            => Assert.Throws<ArgumentNullException>(static () => new SchemaGenerationOptions(null));
+    }
+}


### PR DESCRIPTION
Enables protobuf-net/protobuf-net.Grpc#355 to be done properly.

## Why

`SchemaGenerationOptions.Services` is **cumulative**, so a caller holding schema configuration on a long-lived object cannot reuse one instance across operations — each call's services leak into the next. It needs a per-operation copy.

Without a copy constructor, the only option is a hand-rolled copy in the caller, which silently stops being complete the moment a property is added here. That is exactly what protobuf-net.Grpc's `SchemaGenerator` is reduced to in #355, where it already misses `Types`.

I checked the alternative — "just reuse the options object" — against protobuf-net.Grpc's own `FileDescriptorSetFactory`, which creates one `SchemaGenerator` and calls `GetSchema` in a loop, once per service contract:

```
fresh instance per call ->  Passed
reuse the options object -> FAILED
   Assert.DoesNotContain() Failure: "AlphaOp" found in the second schema
```

So a per-call instance is load-bearing, and cloning belongs here rather than in every caller.

## What

```csharp
public SchemaGenerationOptions() { }
public SchemaGenerationOptions(SchemaGenerationOptions source) { … }
```

- **Collections copy by content, not by reference** — the two instances must be independently mutable, or the problem just moves.
- The copy goes via the **backing fields**, so copying an untouched instance still doesn't allocate the lists; `SchemaGenerationOptions.Default` is copied often.
- The explicit parameterless constructor keeps the implicit one from disappearing now that another is declared — that would have been a silent source break for everyone.

## Tests

Five, and the important one asserts by **reflection over the public properties** rather than an enumerated list: a newly-added property then fails the build instead of being quietly dropped. It would be a poor outcome if the copy constructor itself became the incomplete copy — silently — given that removing one is the entire point.

It's known to be able to fail: commenting out a single assignment gives

```
Origin was not copied
```

The reflection test also refuses to guess at unfamiliar property types — it throws with *"teach this test how to vary it, and check the copy constructor handles it"* rather than silently passing over one it can't generate a value for.

Also covered: collection independence after copying, laziness preserved for an untouched source, and `ArgumentNullException` on a null source.

1056 tests pass; `protobuf-net.BuildTools.Legacy` still builds; public API entry added.