### PR TITLE
CI: cache the NuGet package folder

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,14 @@ jobs:
         dotnet-version: |
           8.0.x
           10.0.x
+    # Restore dominates the cold-runner build time, and the package set changes rarely; the
+    # same treatment measurably helped SE.Redis (StackExchange/StackExchange.Redis@74bfe78).
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('src/Directory.Packages.props', 'global.json', '**/*.csproj') }}
+        restore-keys: ${{ runner.os }}-nuget-
     - name: Restore dependencies
       run: dotnet restore Build.csproj
     - name: Build


### PR DESCRIPTION
Restore is a noticeable chunk of every CI run on a cold runner, and the package set changes rarely. This caches `~/.nuget/packages` keyed on `src/Directory.Packages.props` + `global.json` + the csproj set, with an os-scoped fallback key so even a partial hit skips most of the download. Same treatment as [StackExchange.Redis@74bfe78](https://github.com/StackExchange/StackExchange.Redis/commit/74bfe7847d58a4a20a62afc79592c4ae32c37cc2), where it measurably helped.

Deliberately *only* the cache from that commit: the analyzer-once-per-TFM trick there is a behavioural change that deserves its own consideration, and the StyleCop scoping has no equivalent here.
