### PR TITLE
Give each shipping package its own readme, and fix the package metadata

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageIcon>protobuf-net.png</PackageIcon>
         <Product>protobuf-net ($(TargetFramework))</Product>
-        <PackageReleaseNotes>https://docs.protobuf-net.dev/releasenotes#$(VersionPrefix)</PackageReleaseNotes>
+        <PackageReleaseNotes>https://github.com/protobuf-net/protobuf-net/releases</PackageReleaseNotes>
 
         <PackageTags>binary;serialization;protobuf</PackageTags>
 
@@ -31,6 +31,10 @@
 
         <LibSysValueTuple>4.5.0</LibSysValueTuple>
         <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <!-- the readme is included explicitly below; pack reads its items from the OUTER build of a
+             multi-targeting project, where the SDK's default item globs do not run, so the glob must
+             not be the only thing that finds it - and must not claim it twice -->
+        <DefaultItemExcludes>$(DefaultItemExcludes);readme.md</DefaultItemExcludes>
         <CheckEolTargetFramework>False</CheckEolTargetFramework>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Release' or '$(Configuration)'=='VS'">
@@ -60,6 +64,10 @@
 
     <ItemGroup>
         <None Include="../../protobuf-net.png" Pack="true" PackagePath="/" Visible="false" />
-        <None Include="../../readme.md" Link="readme.md" Pack="true" PackagePath="/" Visible="false" />
+        <!-- each shipping package carries its own readme.md - it is what nuget.org shows on the
+             package page, so it should describe THAT package; anything without one falls back to
+             the repo readme -->
+        <None Include="readme.md" Pack="true" PackagePath="/" Condition="Exists('$(MSBuildProjectDirectory)/readme.md')" />
+        <None Include="../../readme.md" Link="readme.md" Pack="true" PackagePath="/" Visible="false" Condition="!Exists('$(MSBuildProjectDirectory)/readme.md')" />
     </ItemGroup>
 </Project>

--- a/src/protobuf-net.AspNetCore/readme.md
+++ b/src/protobuf-net.AspNetCore/readme.md
@@ -1,0 +1,27 @@
+# protobuf-net.AspNetCore
+
+MVC formatters that let ASP.NET Core controllers accept and return protobuf payloads, using
+[protobuf-net](https://www.nuget.org/packages/protobuf-net) contracts. `application/protobuf`,
+`application/x-protobuf` and `application/vnd.google.protobuf` are all recognised.
+
+```csharp
+builder.Services.AddControllers().AddProtoBufNet();
+```
+
+Options are available on the same call — the `TypeModel` to serialize with, the buffering threshold for
+reads, and a maximum write length:
+
+```csharp
+builder.Services.AddControllers().AddProtoBufNet(options =>
+{
+    options.Model = MyCustomModel;
+});
+```
+
+This is for MVC / web API endpoints. For code-first gRPC services, see
+[protobuf-net.Grpc](https://grpc.protobuf-net.dev/).
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
+++ b/src/protobuf-net.BuildTools.Legacy/protobuf-net.BuildTools.Legacy.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>$(NoWarn);RS2007;NU5128</NoWarn>
+    <Title>protobuf-net.BuildTools.Legacy</Title>
     <Description>Analyzer and Generator support for protobuf-net, using build SDK 3</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/protobuf-net.BuildTools.Legacy/readme.md
+++ b/src/protobuf-net.BuildTools.Legacy/readme.md
@@ -6,8 +6,8 @@ current analyzers.
 
 **If your build is current, you do not need this package**: the same tooling ships inside
 [protobuf-net](https://www.nuget.org/packages/protobuf-net) and reaches every consumer by default. This one
-exists only for the older SDKs, and does not include the compile-time serializer generator (native AOT and
-trimming support), which requires a newer toolchain.
+exists only for the older SDKs, and does not include the compile-time serializer generator
+([native AOT and trimming](https://docs.protobuf-net.dev/aot) support), which requires a newer toolchain.
 
 ## More
 

--- a/src/protobuf-net.BuildTools.Legacy/readme.md
+++ b/src/protobuf-net.BuildTools.Legacy/readme.md
@@ -1,0 +1,16 @@
+# protobuf-net.BuildTools.Legacy
+
+The protobuf-net build-time tooling — contract analyzers, and code generation from `.proto` files listed as
+`<AdditionalFiles>` — built against Roslyn/build SDK 3, for projects on toolchains too old to load the
+current analyzers.
+
+**If your build is current, you do not need this package**: the same tooling ships inside
+[protobuf-net](https://www.nuget.org/packages/protobuf-net) and reaches every consumer by default. This one
+exists only for the older SDKs, and does not include the compile-time serializer generator (native AOT and
+trimming support), which requires a newer toolchain.
+
+## More
+
+- [Build tools](https://docs.protobuf-net.dev/build_tools)
+- [Working with `.proto` files](https://docs.protobuf-net.dev/contract_first)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.Core/protobuf-net.Core.csproj
+++ b/src/protobuf-net.Core/protobuf-net.Core.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyName>protobuf-net.Core</AssemblyName>
     <Title>protobuf-net.Core</Title>
-    <Description>Provides simple access to fast and efficient "Protocol Buffers" serialization from .NET applications</Description>
+    <Description>The protobuf-net serialization engine and build-time tooling; most projects should reference protobuf-net, which adds the runtime type model</Description>
     <!--<DefineConstants>$(DefineConstants);TRACK_USAGE</DefineConstants>-->
   </PropertyGroup>
 

--- a/src/protobuf-net.Core/readme.md
+++ b/src/protobuf-net.Core/readme.md
@@ -2,7 +2,8 @@
 
 The protobuf-net serialization engine: readers, writers, and the serializer contracts, without the
 reflection/ref-emit type model. It is also where the build-time tooling lives — the contract analyzers and
-the compile-time serializer generator that make native AOT and trimming work.
+the compile-time serializer generator that make [native AOT and trimming](https://docs.protobuf-net.dev/aot)
+work.
 
 **Most people should reference [protobuf-net](https://www.nuget.org/packages/protobuf-net) instead**, which
 brings this in and adds `Serializer` and `RuntimeTypeModel`. Reference this package directly only when the

--- a/src/protobuf-net.Core/readme.md
+++ b/src/protobuf-net.Core/readme.md
@@ -1,0 +1,18 @@
+# protobuf-net.Core
+
+The protobuf-net serialization engine: readers, writers, and the serializer contracts, without the
+reflection/ref-emit type model. It is also where the build-time tooling lives — the contract analyzers and
+the compile-time serializer generator that make native AOT and trimming work.
+
+**Most people should reference [protobuf-net](https://www.nuget.org/packages/protobuf-net) instead**, which
+brings this in and adds `Serializer` and `RuntimeTypeModel`. Reference this package directly only when the
+serializers are generated at compile time and you never need the runtime model.
+
+Opt out of the build tooling with `<ProtoBufDisableBuildTools>true</ProtoBufDisableBuildTools>`.
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Native AOT and trimming](https://docs.protobuf-net.dev/aot)
+- [Build tools](https://docs.protobuf-net.dev/build_tools)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
+++ b/src/protobuf-net.FSharp/protobuf-net.FSharp.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>ProtoBuf.FSharp</RootNamespace>
+    <Title>protobuf-net.FSharp</Title>
+    <Description>F# collection support for protobuf-net: serializes list, Map and Set</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.FSharp/readme.md
+++ b/src/protobuf-net.FSharp/readme.md
@@ -1,0 +1,22 @@
+# protobuf-net.FSharp
+
+Serializers that teach [protobuf-net](https://www.nuget.org/packages/protobuf-net) about the F# collection
+types — `list`, `Map` and `Set` — which otherwise have no usable .NET collection idiom to bind to.
+
+Register the ones you need against a model:
+
+```fsharp
+let model =
+    (RuntimeTypeModel.Create "fsharp")
+        .AddSerializer(typeof<_ list>, typeof<FSharpListFactory>)
+        .AddSerializer(typeof<Map<_,_>>, typeof<FSharpMapFactory>)
+        .AddSerializer(typeof<Set<_>>, typeof<FSharpSetFactory>)
+```
+
+Everything else about protobuf-net is unchanged: contracts, field numbers and the wire format all behave as
+they do from C#.
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.HybridCache/protobuf-net.HybridCache.csproj
+++ b/src/protobuf-net.HybridCache/protobuf-net.HybridCache.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net462;netstandard2.0;net8.0</TargetFrameworks>
     <RootNamespace>ProtoBuf</RootNamespace>
     <Nullable>enable</Nullable>
+    <Title>protobuf-net.HybridCache</Title>
+    <Description>HybridCache serialization using protobuf-net</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protobuf-net.HybridCache/readme.md
+++ b/src/protobuf-net.HybridCache/readme.md
@@ -1,0 +1,23 @@
+# protobuf-net.HybridCache
+
+A [`HybridCache`](https://learn.microsoft.com/aspnet/core/performance/caching/hybrid) serializer backed by
+[protobuf-net](https://www.nuget.org/packages/protobuf-net), so cached values are stored using your existing
+protobuf contracts rather than JSON.
+
+```csharp
+builder.Services.AddHybridCache();
+builder.Services.AddProtobufNetHybridCacheSerializer();
+```
+
+That handles every protobuf-net contract type. To use protobuf for one specific type only, or to supply the
+`TypeModel` to serialize with:
+
+```csharp
+builder.Services.AddProtobufNetHybridCacheSerializer<MyType>();
+builder.Services.AddProtobufNetHybridCachModel(MyCustomModel);
+```
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.NodaTime/readme.md
+++ b/src/protobuf-net.NodaTime/readme.md
@@ -4,9 +4,19 @@
 `Instant` and `Duration` serialize as the protobuf well-known types (`google.protobuf.Timestamp` and
 `google.protobuf.Duration`), so the payloads interoperate with other protobuf implementations.
 
+With a compile-time model (`[ProtoModel]`, as used for native AOT), those two need **no registration at
+all**: the pairings are declared at assembly level in this package, so any generated model in a project that
+references it picks them up.
+
+For the runtime model, register them:
+
 ```csharp
 RuntimeTypeModel.Default.AddNodaTime();
 ```
+
+`AddNodaTime` also covers `LocalDate`, `LocalTime` and `IsoDayOfWeek`, which map to the `google.type.*`
+schemas; those are not part of the automatic wiring, so a compile-time model that uses them still needs the
+runtime model.
 
 Conversions between the two worlds are also available directly, via `NodaTimeExtensions`.
 

--- a/src/protobuf-net.NodaTime/readme.md
+++ b/src/protobuf-net.NodaTime/readme.md
@@ -4,9 +4,10 @@
 `Instant` and `Duration` serialize as the protobuf well-known types (`google.protobuf.Timestamp` and
 `google.protobuf.Duration`), so the payloads interoperate with other protobuf implementations.
 
-With a compile-time model (`[ProtoModel]`, as used for native AOT), those two need **no registration at
-all**: the pairings are declared at assembly level in this package, so any generated model in a project that
-references it picks them up.
+With a compile-time model (`[ProtoModel]`, as used for
+[native AOT](https://docs.protobuf-net.dev/aot)), those two need **no registration at all**: the pairings are
+declared at assembly level in this package, so any generated model in a project that references it picks
+them up.
 
 For the runtime model, register them:
 

--- a/src/protobuf-net.NodaTime/readme.md
+++ b/src/protobuf-net.NodaTime/readme.md
@@ -1,23 +1,18 @@
 # protobuf-net.NodaTime
 
 [NodaTime](https://nodatime.org/) support for [protobuf-net](https://www.nuget.org/packages/protobuf-net):
-`Instant` and `Duration` serialize as the protobuf well-known types (`google.protobuf.Timestamp` and
-`google.protobuf.Duration`), so the payloads interoperate with other protobuf implementations.
+`Instant`, `Duration`, `LocalDate`, `LocalTime` and `IsoDayOfWeek` serialize as the matching protobuf
+well-known and `google.type` messages, so the payloads interoperate with other protobuf implementations.
 
 With a compile-time model (`[ProtoModel]`, as used for
-[native AOT](https://docs.protobuf-net.dev/aot)), those two need **no registration at all**: the pairings are
-declared at assembly level in this package, so any generated model in a project that references it picks
-them up.
+[native AOT](https://docs.protobuf-net.dev/aot)), there is **nothing to register**: this package declares the
+pairings at assembly level, so any generated model in a project that references it picks them up.
 
-For the runtime model, register them:
+For the runtime model, register them once:
 
 ```csharp
 RuntimeTypeModel.Default.AddNodaTime();
 ```
-
-`AddNodaTime` also covers `LocalDate`, `LocalTime` and `IsoDayOfWeek`, which map to the `google.type.*`
-schemas; those are not part of the automatic wiring, so a compile-time model that uses them still needs the
-runtime model.
 
 Conversions between the two worlds are also available directly, via `NodaTimeExtensions`.
 

--- a/src/protobuf-net.NodaTime/readme.md
+++ b/src/protobuf-net.NodaTime/readme.md
@@ -1,0 +1,16 @@
+# protobuf-net.NodaTime
+
+[NodaTime](https://nodatime.org/) support for [protobuf-net](https://www.nuget.org/packages/protobuf-net):
+`Instant` and `Duration` serialize as the protobuf well-known types (`google.protobuf.Timestamp` and
+`google.protobuf.Duration`), so the payloads interoperate with other protobuf implementations.
+
+```csharp
+RuntimeTypeModel.Default.AddNodaTime();
+```
+
+Conversions between the two worlds are also available directly, via `NodaTimeExtensions`.
+
+## More
+
+- [Using protobuf-net with Noda Time](https://docs.protobuf-net.dev/nodatime)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.Protogen/protobuf-net.Protogen.csproj
+++ b/src/protobuf-net.Protogen/protobuf-net.Protogen.csproj
@@ -8,7 +8,8 @@
     <AssemblyName>protogen</AssemblyName>
     <ToolCommandName>protogen</ToolCommandName>
     <PackageId>protobuf-net.Protogen</PackageId>
-    <Title>protobuf-net command-line "global tool" for .NET code-generation from .proto schema files</Title>
+    <Title>protobuf-net.Protogen</Title>
+    <Description>protobuf-net command-line "global tool" for .NET code-generation from .proto schema files</Description>
     <GrpcTools>true</GrpcTools>
     <ApplicationIcon>protobuf-net.ico</ApplicationIcon>
     <RollForward>LatestMajor</RollForward>

--- a/src/protobuf-net.Protogen/readme.md
+++ b/src/protobuf-net.Protogen/readme.md
@@ -1,0 +1,32 @@
+# protobuf-net.Protogen
+
+`protogen` is a cross-platform .NET global tool that generates C# or VB from `.proto` schemas, for use with
+[protobuf-net](https://www.nuget.org/packages/protobuf-net).
+
+```txt
+dotnet tool install --global protobuf-net.Protogen
+protogen --csharp_out=. -I=schemas schemas/person.proto
+```
+
+The calling convention deliberately mirrors `protoc`, so existing scripts mostly transfer as-is: `-IPATH` /
+`--proto_path=PATH` for imports, `--descriptor_set_out=FILE` to write a `FileDescriptorSet` instead of code,
+`--version`, `--help`, and `*.proto` / `**/*.proto` inputs. proto2, proto3 and the `google/protobuf/*.proto`
+imports are all supported, and the common imports are embedded, so they resolve without being on disk.
+
+protobuf-net-specific generator options are `+name=value` pairs, for example:
+
+```txt
+protogen --csharp_out=. +names=original +oneof=enum +services=grpc person.proto
+```
+
+Run `protogen --help` for the full list.
+
+Same generator, other packagings: build-time generation from `<AdditionalFiles>` (no tool to install — see
+[working with `.proto` files](https://docs.protobuf-net.dev/contract_first)), and in-browser at
+[protobuf-net.dev](https://protobuf-net.dev/), where nothing leaves your machine.
+
+## More
+
+- [Generating code from `.proto` files](https://docs.protobuf-net.dev/contract_first)
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.Reflection/readme.md
+++ b/src/protobuf-net.Reflection/readme.md
@@ -1,0 +1,29 @@
+# protobuf-net.Reflection
+
+The `.proto` schema tooling behind protobuf-net, as a library: parse proto2/proto3 schemas into a
+`FileDescriptorSet`, inspect or manipulate the descriptors, and generate C# or VB source from them.
+
+```csharp
+var set = new FileDescriptorSet();
+set.AddImportPath(".");
+set.Add("person.proto", includeInOutput: true);
+set.Process();
+
+foreach (var file in CSharpCodeGenerator.Default.Generate(set))
+{
+    Console.WriteLine(file.Name);
+    Console.WriteLine(file.Text);
+}
+```
+
+The common imports (`google/protobuf/*.proto` and friends) are embedded, so they resolve without being on
+disk. This is the same code generation used by the
+[protogen](https://www.nuget.org/packages/protobuf-net.Protogen) command-line tool and by
+[protobuf-net.dev](https://protobuf-net.dev/); if you just want generated types, prefer one of those, or the
+build-time generation described below.
+
+## More
+
+- [Generating code from `.proto` files](https://docs.protobuf-net.dev/contract_first)
+- [Schema analysis tools](https://docs.protobuf-net.dev/schemas)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
+++ b/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>protobuf-net.ServiceModel</AssemblyName>
     <RootNamespace>ProtoBuf</RootNamespace>
-    <Title>protobuf-net</Title>
+    <Title>protobuf-net.ServiceModel</Title>
     <Description>ServiceModel (WCF) extensions for protobuf-net</Description>
     <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/protobuf-net.ServiceModel/readme.md
+++ b/src/protobuf-net.ServiceModel/readme.md
@@ -1,0 +1,28 @@
+# protobuf-net.ServiceModel
+
+WCF (`System.ServiceModel`) integration for [protobuf-net](https://www.nuget.org/packages/protobuf-net):
+service operations serialize their messages with protobuf instead of `DataContractSerializer`, keeping the
+WCF programming model unchanged.
+
+Mark the operations that should use it (on both the client and the server):
+
+```csharp
+[ServiceContract]
+public interface IMyService
+{
+    [OperationContract, ProtoBehavior]
+    MyResponse Execute(MyRequest request);
+}
+```
+
+`ProtoEndpointBehavior` applies the same thing across a whole endpoint. Either way, the types being
+exchanged need to be protobuf-net contracts (`[ProtoContract]` / `[ProtoMember]`, or the equivalent runtime
+configuration).
+
+For new work over the network, code-first gRPC — [protobuf-net.Grpc](https://grpc.protobuf-net.dev/) — offers
+a very similar contract-based model on a modern transport.
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protobuf-net/readme.md
+++ b/src/protobuf-net/readme.md
@@ -24,8 +24,8 @@ Contract-first works too: generate C#/VB from a `.proto` schema at build time, f
 [protobuf-net.dev](https://protobuf-net.dev/).
 
 Build tools — analyzers that check your contracts, and the generator that emits serializers at compile time
-so native AOT and trimming work — ship with this package by default; opt out with
-`<ProtoBufDisableBuildTools>true</ProtoBufDisableBuildTools>`.
+so [native AOT and trimming](https://docs.protobuf-net.dev/aot) work — ship with this package by default;
+opt out with `<ProtoBufDisableBuildTools>true</ProtoBufDisableBuildTools>`.
 
 ## More
 

--- a/src/protobuf-net/readme.md
+++ b/src/protobuf-net/readme.md
@@ -1,0 +1,35 @@
+# protobuf-net
+
+A contract-based serializer for .NET that reads and writes Google's "protocol buffers" wire format.
+The API follows normal .NET patterns — broadly comparable to `XmlSerializer` or `DataContractSerializer` —
+so you annotate the types you already have:
+
+```csharp
+[ProtoContract]
+public class Person
+{
+    [ProtoMember(1)] public int Id { get; set; }
+    [ProtoMember(2)] public string Name { get; set; }
+}
+
+using var file = File.Create("person.bin");
+Serializer.Serialize(file, new Person { Id = 12345, Name = "Fred" });
+```
+
+Members are identified on the wire by number, not by name, so the numbers matter: pick them once and keep
+them stable. Everything the attributes do can also be configured at runtime, via `RuntimeTypeModel`.
+
+Contract-first works too: generate C#/VB from a `.proto` schema at build time, from the command line with
+[protobuf-net.Protogen](https://www.nuget.org/packages/protobuf-net.Protogen), or in your browser at
+[protobuf-net.dev](https://protobuf-net.dev/).
+
+Build tools — analyzers that check your contracts, and the generator that emits serializers at compile time
+so native AOT and trimming work — ship with this package by default; opt out with
+`<ProtoBufDisableBuildTools>true</ProtoBufDisableBuildTools>`.
+
+## More
+
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Native AOT and trimming](https://docs.protobuf-net.dev/aot)
+- [Working with `.proto` files](https://docs.protobuf-net.dev/contract_first)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)

--- a/src/protogen/protogen.csproj
+++ b/src/protogen/protogen.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <Configurations>Debug;Release;VS</Configurations>
     <AssemblyName>protogen</AssemblyName>
-    <Title>protobuf-net command-line "global tool" for .NET code-generation from .proto schema files</Title>
+    <Title>protogen</Title>
+    <Description>The protogen command-line generator (C#/VB from .proto schemas), as a plain package; for command-line use, prefer the protobuf-net.Protogen global tool</Description>
     <GrpcTools>false</GrpcTools>
     <ApplicationIcon>protobuf-net.ico</ApplicationIcon>
     <RollForward>LatestMajor</RollForward>

--- a/src/protogen/readme.md
+++ b/src/protogen/readme.md
@@ -1,0 +1,21 @@
+# protogen
+
+The `protogen` code generator — which turns `.proto` schemas into C# or VB for
+[protobuf-net](https://www.nuget.org/packages/protobuf-net) — shipped as a plain package containing the
+executable, for build scripts that want to consume it that way.
+
+**For command-line use, prefer [protobuf-net.Protogen](https://www.nuget.org/packages/protobuf-net.Protogen)**,
+which is the same generator as a .NET global tool:
+
+```txt
+dotnet tool install --global protobuf-net.Protogen
+protogen --csharp_out=. -I=schemas schemas/person.proto
+```
+
+Either way the calling convention mirrors `protoc`; run `protogen --help` for the options.
+
+## More
+
+- [Generating code from `.proto` files](https://docs.protobuf-net.dev/contract_first)
+- [Documentation](https://docs.protobuf-net.dev/)
+- [Release notes](https://github.com/protobuf-net/protobuf-net/releases)


### PR DESCRIPTION
Every package shipped the repo readme, so nuget.org showed the same code-first tutorial on the package pages for `protobuf-net.NodaTime`, `protogen` and the WCF bindings alike. Each shipping project now carries a `readme.md` describing *that* package — what it is, the one snippet that gets you going, and links out for the rest. Anything without one still falls back to the repo readme.

Deliberately short: the longer material belongs on [docs.protobuf-net.dev](https://docs.protobuf-net.dev/), which each readme links to.

The wiring lives in `src/Directory.Build.props` rather than `.targets` because pack reads its items from the **outer** build of a multi-targeting project, where the SDK's default item globs do not run — a `<None Update>` against the glob silently packs nothing and fails as NU5039. Hence the explicit `Include` plus a `DefaultItemExcludes` entry so the glob does not also claim the file.

While in here:

- **Release notes** point at the [releases page](https://github.com/protobuf-net/protobuf-net/releases). We stopped updating `docs/releasenotes.md` per release, and for `protogen` — which has no `VersionPrefix` of its own — the old value rendered as a bare `#` anchor.
- **Descriptions**: `protogen`, `protobuf-net.HybridCache` and `protobuf-net.FSharp` were all published with the literal string "Package Description". `protobuf-net.Core` was describing `protobuf-net`.
- **Titles** matched the package for some and not others: `ServiceModel` claimed to be "protobuf-net", both protogen packages used a whole sentence as their title, and `BuildTools.Legacy` had none.

Verified by `dotnet build` + `dotnet pack --no-build` over `Build.csproj` and reading back the nuspecs: all eleven packages carry their own readme, a title matching the package id, and a real description.