### PR TITLE
PBN0022: don't nag about initializers that only restate the type's default

### DIFF
--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
@@ -69,6 +69,62 @@ namespace BuildToolsUnitTests
             Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
         }
 
+        // [DefaultValue("abc")] on a member left at null is a contract that loses data: protobuf-net
+        // omits a member equal to its declared default, so a sender holding "abc" writes nothing and
+        // the receiver - which has no initializer to fall back on - ends up with null. The two sides
+        // disagree, which is exactly what PBN0021 is for; it must not be mistaken for the IsRequired nag
+        [Theory]
+        [InlineData("string", "\"abc\"", "null")]
+        [InlineData("string", "\"abc\"", "null!")]
+        [InlineData("string", "\"abc\"", "default")]
+        [InlineData("string", "\"abc\"", "default!")]
+        [InlineData("string", "\"abc\"", "(string)null")]
+        public async Task ReportsShouldUpdateDefaultForNullInitializer(string type, string attributeValue, string propertyValue)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    [ProtoMember(1), DefaultValue({attributeValue})] public {type} FieldBar = {propertyValue};
+                    [ProtoMember(2), DefaultValue({attributeValue})] public {type} PropertyBar {{ get; set; }} = {propertyValue};
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
+
+            var diags = diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldUpdateDefault).ToList();
+            Assert.All(diags, diag => Assert.Equal(DiagnosticSeverity.Warning, diag.Severity));
+            Assert.Equal(2, diags.Count);
+        }
+
+        // ...but when both sides say "default", they agree, and there is nothing to report
+        [Theory]
+        [InlineData("string", "null", "null")]
+        [InlineData("string", "null", "default!")]
+        [InlineData("string", "(string)null", "default")]
+        [InlineData("object", "null", "null")]
+        public async Task DoesNotReportWhenAttributeAndInitializerAreBothNull(string type, string attributeValue, string propertyValue)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    [ProtoMember(1), DefaultValue({attributeValue})] public {type} FieldBar = {propertyValue};
+                    [ProtoMember(2), DefaultValue({attributeValue})] public {type} PropertyBar {{ get; set; }} = {propertyValue};
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldUpdateDefault
+                || x.Descriptor == DataContractAnalyzer.ShouldDeclareDefault
+                || x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
+        }
+
         // a collection member has no wire presence to force - an empty collection writes nothing,
         // and IsRequired is only observable for value-type scalars - so initializing one (the
         // standard pattern, including getter-only) must not trigger the IsRequired nag

--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
@@ -42,6 +42,33 @@ namespace BuildToolsUnitTests
             );
         }
 
+        // an initializer that only restates the type's own default - `= default`, `= null`, and the
+        // `= default!` / `= null!` forms that nullable-reference-types makes routine - changes nothing
+        // about what goes on the wire, so it must not trigger the IsRequired nag
+        [Theory]
+        [InlineData("string", "default")]
+        [InlineData("string", "default!")]
+        [InlineData("string", "null")]
+        [InlineData("string", "null!")]
+        [InlineData("string", "(string)null")]
+        [InlineData("object", "default")]
+        [InlineData("object", "null")]
+        public async Task DoesNotReportShouldDeclareIsRequiredForImplicitDefaults(string type, string value)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+
+                [ProtoContract]
+                public class Foo {{
+                    [ProtoMember(1)] public {type} FieldBar = {value};
+                    [ProtoMember(2)] public {type} PropertyBar {{ get; set; }} = {value};
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
+        }
+
         // a collection member has no wire presence to force - an empty collection writes nothing,
         // and IsRequired is only observable for value-type scalars - so initializing one (the
         // standard pattern, including getter-only) must not trigger the IsRequired nag

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -317,6 +317,9 @@ namespace ProtoBuf.BuildTools.Internal
                                     break;
 
                                 case MemberInitValueKind.ConstantExpression:
+                                    // `null` is one of the constants we can land on, and it is the one
+                                    // value that has no ToString() to offer the code fix
+                                    var memberInitValueText = memberInitValue?.ToString() ?? "null";
                                     if (ShouldDeclareDefault(member, memberInitValue))
                                     {
                                         context.ReportDiagnostic(Diagnostic.Create(
@@ -326,7 +329,7 @@ namespace ProtoBuf.BuildTools.Internal
                                             additionalLocations: null,
                                             properties: DiagnosticPropertiesBuilder.Create()
                                                             .Add(DefaultValueCodeFixProviderBase.DefaultValueStringRepresentationArgKey, memberValueStringRepresentation)
-                                                            .Add(DefaultValueCodeFixProviderBase.DefaultValueCalculatedArgKey, memberInitValue!.ToString())
+                                                            .Add(DefaultValueCodeFixProviderBase.DefaultValueCalculatedArgKey, memberInitValueText)
                                                             .Add(DefaultValueCodeFixProviderBase.MemberSpecialTypeArgKey, member.SymbolSpecialType.ToString())
                                                             .Build()
                                         ));
@@ -340,7 +343,7 @@ namespace ProtoBuf.BuildTools.Internal
                                             additionalLocations: null,
                                             properties: DiagnosticPropertiesBuilder.Create()
                                                             .Add(DefaultValueCodeFixProviderBase.DefaultValueStringRepresentationArgKey, memberValueStringRepresentation)
-                                                            .Add(DefaultValueCodeFixProviderBase.DefaultValueCalculatedArgKey, memberInitValue!.ToString())
+                                                            .Add(DefaultValueCodeFixProviderBase.DefaultValueCalculatedArgKey, memberInitValueText)
                                                             .Add(DefaultValueCodeFixProviderBase.MemberSpecialTypeArgKey, member.SymbolSpecialType.ToString())
                                                             .Build()
                                         ));
@@ -450,11 +453,11 @@ namespace ProtoBuf.BuildTools.Internal
             if (constantValue.HasValue && constantValue.Value is null)
             {
                 // an initializer that only restates the type's own default - `= null`, `= default`,
-                // `= (string)null` - is a no-op: there is no [DefaultValue] worth declaring and no
-                // value that could be lost on the wire, so it is treated as no initializer at all
-                initialValueSyntaxNode = null;
+                // `= (string)null` - is a constant like any other, and specifically the one that
+                // makes IsRequired pointless: there is no value here that could be lost on the wire.
+                // It still gets compared against [DefaultValue], which may claim otherwise.
                 memberInitialValue = null;
-                return MemberInitValueKind.NotSet;
+                return MemberInitValueKind.ConstantExpression;
             }
 
             if (!constantValue.HasValue)
@@ -532,6 +535,10 @@ namespace ProtoBuf.BuildTools.Internal
                 if (constructorArg.IsNull && memberInitValue is not null) return true;
                 if (constructorArg.Value is null && memberInitValue is not null) return true;
                 if (constructorArg.Value is not null && memberInitValue is null) return true;
+
+                // both sides are the type's own default, so they agree; the comparisons below
+                // dereference the attribute value and must not be reached when it is null
+                if (constructorArg.Value is null && memberInitValue is null) return false;
                 
                 var memberSpecialType = member.SymbolSpecialType!.Value;
                 if (memberSpecialType.IsPrimitiveValueType())

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -435,10 +435,29 @@ namespace ProtoBuf.BuildTools.Internal
                 return MemberInitValueKind.NotSet;
             }
             
+            // `x!` is just x for our purposes; nullable-reference-types makes `= default!` and
+            // `= null!` the routine way of writing "I know, and I don't care" on a non-nullable
+            // member, and the suppression must not hide the initializer from us
+            while (initialValueSyntaxNode is PostfixUnaryExpressionSyntax postfix
+                && postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+            {
+                initialValueSyntaxNode = postfix.Operand;
+            }
+
             // calculating the member initial value using semantic model 
             var semanticModel = context.Compilation.GetSemanticModel(memberNode.SyntaxTree);
             var constantValue = semanticModel.GetConstantValue(initialValueSyntaxNode!);
-            if (!constantValue.HasValue || constantValue.Value is null)
+            if (constantValue.HasValue && constantValue.Value is null)
+            {
+                // an initializer that only restates the type's own default - `= null`, `= default`,
+                // `= (string)null` - is a no-op: there is no [DefaultValue] worth declaring and no
+                // value that could be lost on the wire, so it is treated as no initializer at all
+                initialValueSyntaxNode = null;
+                memberInitialValue = null;
+                return MemberInitValueKind.NotSet;
+            }
+
+            if (!constantValue.HasValue)
             {
                 // static fields are not considered as `constantValue`,
                 // so we can manually go over some known assignments (i.e. `string.Empty`)


### PR DESCRIPTION
Fixes #1286

## PBN0022 on `= default!`

`CalculateMemberInitialValue` folded two different things into one branch:

```csharp
if (!constantValue.HasValue || constantValue.Value is null)
```

*there is no constant value* and *the constant value is null* both fell through to
`NonConstantExpression`, which is the branch that raises PBN0022. So every `= null`,
`= default`, `= null!`, `= default!` and `= (string)null` on a `string` or `object` member
was nagged, even though it only restates the type's own default and nothing can be lost on
the wire. On the contract in the issue that is one warning on `Name`; `Name2` was already
quiet because of its explicit `IsRequired = true`, and `OtherValue` has no initializer at all.

A trailing `!` is now unwrapped before the expression is evaluated. `GetConstantValue` does
see through the suppression, so that is not what fixed this, but it also stops `= "abc"!`
being read as non-constant - and keeps the `!` out of the string the `[DefaultValue]` code
fix builds from the initializer's syntax, which would have emitted `[DefaultValue("abc"!)]`.

## `[DefaultValue("abc")]` against a null initializer

Falling out of the above: a null initializer never reached the `[DefaultValue]` comparison,
because it was classified as non-constant. That hid a real problem, and one worth a warning
in its own right:

```csharp
[ProtoMember(1), DefaultValue("abc")] public string X { get; set; } = null;
```

A member equal to its declared default is omitted, so a sender holding `"abc"` writes
nothing and the receiver - which has no initializer to fall back on - ends up with null.
The declaration and the member disagree, which is what PBN0021 exists to say; it now says it.

Two consequences of a null reaching that path, both handled: an attribute that *also* says
null short-circuits as agreement rather than reaching the comparison that would dereference
it, and the code fix's calculated-value property no longer calls `ToString()` on the null.
Neither was reachable before, since a null never got that far.

## Not covered

The same data loss exists with no initializer at all:

```csharp
[ProtoMember(1), DefaultValue("abc")] public string X { get; set; }
```

That is silent today and stays silent here - it is a distinct shape, it is not what the
issue is about, and turning it on would light up a lot of existing code in one go. Worth
its own discussion.

## Tests

`DoesNotReportShouldDeclareIsRequiredForImplicitDefaults`, `ReportsShouldUpdateDefaultForNullInitializer`
and `DoesNotReportWhenAttributeAndInitializerAreBothNull` - 16 cases, all of which fail
against `main`. Full `BuildToolsUnitTests` suite green at 343.