### PR TITLE
PBN0024 / PBN0025: declared defaults that do not do what they look like (re-target to main)

### DIFF
--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
@@ -125,6 +125,200 @@ namespace BuildToolsUnitTests
                 || x.Descriptor == DataContractAnalyzer.ShouldDeclareIsRequired));
         }
 
+        // A member equal to its declared default is not written, and deserialization only assigns
+        // fields that are present - so with nothing to restore the value, the two ends disagree
+        // about what "absent" means and the sender's value is lost
+        [Theory]
+        [InlineData("string", "\"abc\"")]
+        [InlineData("int", "5")]
+        [InlineData("bool", "true")]
+        [InlineData("double", "2.5")]
+        [InlineData("DayOfWeek", "DayOfWeek.Monday")]
+        public async Task ReportsDeclaredDefaultCannotRoundTrip(string type, string attributeValue)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    [ProtoMember(1), DefaultValue({attributeValue})] public {type} FieldBar;
+                    [ProtoMember(2), DefaultValue({attributeValue})] public {type} PropertyBar {{ get; set; }}
+                }}
+            ");
+
+            var diags = diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip).ToList();
+            Assert.All(diags, diag => Assert.Equal(DiagnosticSeverity.Warning, diag.Severity));
+            Assert.Equal(2, diags.Count);
+        }
+
+        // the shapes where something *does* restore the value, or where the declared default is not
+        // load-bearing in the first place; every one of these is a pattern protogen emits or a
+        // deliberate opt-out, and reporting on any of them would be noise
+        [Theory]
+        // the correct pairing: an initializer restores it
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        // ...and protogen writes that assignment into a constructor instead
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                      public Foo() { Bar = ""abc""; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                      public Foo() { this.Bar = ""abc""; }")]
+        // explicit presence: this is protogen's proto2-optional shape, [DefaultValue("")] and all
+        [InlineData(@"[ProtoMember(1), DefaultValue("""")] public string Bar { get; set; }
+                      public bool ShouldSerializeBar() => Bar != null;")]
+        [InlineData(@"[ProtoMember(1), DefaultValue("""")] public string Bar { get; set; }
+                      public bool BarSpecified { get; set; }")]
+        // a null declared default means "no declared default" at all
+        [InlineData(@"[ProtoMember(1), DefaultValue(null)] public string Bar { get; set; }")]
+        // not a kind whose declared default we can reason about
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public int? Bar { get; set; }")]
+        // a declared default equal to the type's own default needs nothing to restore it - the CLR
+        // already hands it over. This is the shape protogen emits for a proto2 enum field whose
+        // default is the zero member, and CustomOptions.cs in this repo is full of it
+        [InlineData(@"public enum Kind { None = 0, Other = 1 }
+                      [ProtoMember(1), DefaultValue(Kind.None)] public Kind Bar { get; set; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(0)] public int Bar { get; set; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(false)] public bool Bar { get; set; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue("""")] public string Bar { get; set; }")]
+        public async Task DoesNotReportDeclaredDefaultCannotRoundTrip(string body)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    {body}
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip));
+        }
+
+        // under SkipConstructor neither a constructor nor a field initializer runs, so the fix this
+        // diagnostic implies would not fix anything - it stays quiet rather than give bad advice
+        [Fact]
+        public async Task DoesNotReportDeclaredDefaultCannotRoundTripUnderSkipConstructor()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract(SkipConstructor = true)]
+                public class Foo {
+                    [ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                }
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip));
+        }
+
+        // ValueMember.BuildSerializer only reaches the DefaultValueDecorator for a non-repeated,
+        // non-required member, so in these two shapes the declared default is simply inert
+        [Theory]
+        [InlineData(@"[ProtoMember(1, IsRequired = true), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public System.Collections.Generic.List<int> Bar { get; set; } = new();")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public int[] Bar { get; set; }")]
+        public async Task ReportsDeclaredDefaultIgnored(string body)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    {body}
+                }}
+            ");
+
+            var diag = Assert.Single(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultIgnored));
+            Assert.Equal(DiagnosticSeverity.Warning, diag.Severity);
+        }
+
+        [Theory]
+        // bytes are a scalar to protobuf-net, not a repeated member, so the default is applied
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public byte[] Bar { get; set; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public System.ReadOnlyMemory<byte> Bar { get; set; }")]
+        // a string is IEnumerable but is a scalar
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        // ShouldSerialize overriding the declared default is protogen's intended composition
+        [InlineData(@"[ProtoMember(1), DefaultValue("""")] public string Bar { get; set; }
+                      public bool ShouldSerializeBar() => Bar != null;")]
+        // a null declared default is not a declared default
+        [InlineData(@"[ProtoMember(1, IsRequired = true), DefaultValue(null)] public string Bar { get; set; }")]
+        public async Task DoesNotReportDeclaredDefaultIgnored(string body)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {{
+                    {body}
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultIgnored));
+        }
+
+        // the whole shape protogen emits for a proto2 optional field with a default, which must be
+        // clean: it is the single largest body of code these two diagnostics could have shouted at
+        [Fact]
+        public async Task ProtogenPresenceTrackingShapeIsClean()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract]
+                public class Foo {
+                    [ProtoMember(1)]
+                    [DefaultValue("""")]
+                    public string Name
+                    {
+                        get => __pbn__Name ?? """";
+                        set => __pbn__Name = value;
+                    }
+                    public bool ShouldSerializeName() => __pbn__Name != null;
+                    public void ResetName() => __pbn__Name = null;
+                    private string __pbn__Name;
+                }
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip
+                || x.Descriptor == DataContractAnalyzer.DeclaredDefaultIgnored));
+        }
+
+        // lifted verbatim from CustomOptions.cs, which protogen generated: a proto2 enum field whose
+        // declared default is the zero member, carrying no initializer because it does not need one
+        [Fact]
+        public async Task ProtogenZeroEnumDefaultShapeIsClean()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                public enum MessageKind { None = 0, Service = 1 }
+
+                [ProtoContract]
+                public partial class ProtogenMessageOptions {
+                    [ProtoMember(5, Name = @""messageKind"")]
+                    [DefaultValue(MessageKind.None)]
+                    public MessageKind MessageKind { get; set; }
+                }
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip
+                || x.Descriptor == DataContractAnalyzer.DeclaredDefaultIgnored));
+        }
+
         // a collection member has no wire presence to force - an empty collection writes nothing,
         // and IsRequired is only observable for value-type scalars - so initializing one (the
         // standard pattern, including getter-only) must not trigger the IsRequired nag

--- a/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
+++ b/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
@@ -32,6 +32,8 @@ PBN0020  | Usage    | Warning  | Member should declare `[DefaultValue]`
 PBN0021  | Usage    | Warning  | Member should update its `[DefaultValue]`
 PBN0022  | Usage    | Warning  | Member should declare `IsRequired`
 PBN0023  | Usage    | Warning  | `[ProtoContract]` on an interface is not recommended
+PBN0024  | Usage    | Warning  | Member declares `[DefaultValue]` but nothing initializes it to that value
+PBN0025  | Usage    | Warning  | Member declares a `[DefaultValue]` that protobuf-net will not apply
 PBN2001  | Usage    | Error    | gRPC: invalid member kind on a service contract
 PBN2002  | Usage    | Error    | gRPC: invalid payload type
 PBN2003  | Usage    | Error    | gRPC: invalid return type

--- a/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
@@ -205,6 +205,24 @@ internal static readonly DiagnosticDescriptor DeclaredAndIgnored = new(
             isEnabledByDefault: true,
             helpLinkUri: "https://stackoverflow.com/a/3162253/1882616");
 
+        internal static readonly DiagnosticDescriptor DeclaredDefaultCannotRoundTrip = new(
+            id: "PBN0024",
+            title: nameof(DataContractAnalyzer) + "." + nameof(DeclaredDefaultCannotRoundTrip),
+            messageFormat: "Field '{0}' declares [DefaultValue] but nothing initializes it to that value; a member equal to its declared default is not written, so the value is lost on the receiving end.",
+            category: Literals.CategoryUsage,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://stackoverflow.com/a/3162253/1882616");
+
+        internal static readonly DiagnosticDescriptor DeclaredDefaultIgnored = new(
+            id: "PBN0025",
+            title: nameof(DataContractAnalyzer) + "." + nameof(DeclaredDefaultIgnored),
+            messageFormat: "Field '{0}' declares [DefaultValue], but protobuf-net will not apply it: {1}.",
+            category: Literals.CategoryUsage,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://stackoverflow.com/a/3162253/1882616");
+
         internal static readonly DiagnosticDescriptor ProtoContractOnInterface = new(
             id: "PBN0023",
             title: nameof(DataContractAnalyzer) + "." + nameof(ProtoContractOnInterface),

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -723,6 +723,12 @@ namespace ProtoBuf.BuildTools.Internal
         private static bool IsTypeDefaultValue(SpecialType? specialType, object value) => specialType switch
         {
             SpecialType.System_Boolean => value.Equals(false),
+
+            // "" counts as the default for a string even though the CLR default is null, so
+            // [DefaultValue("")] never reports. Strictly it can lose data - a sender holding ""
+            // writes nothing and the receiver is left at null - but null and "" are treated as
+            // interchangeable often enough that a diagnostic here would confuse more than it
+            // helps. Deliberate; do not tighten this without a reason to.
             SpecialType.System_String => value is string text && text.Length == 0,
             _ => IsNumericZero(value),
         };

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -8,6 +8,7 @@ using ProtoBuf.BuildTools.Analyzers;
 using ProtoBuf.Internal.Models;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using ProtoBuf.CodeFixes.DefaultValue.Abstractions;
 using ProtoBuf.Internal;
@@ -310,10 +311,33 @@ namespace ProtoBuf.BuildTools.Internal
                             var memberDefaultValueState = CalculateMemberInitialValue(context, member, out var memberInitSyntaxNode, out var memberInitValue);
                             var memberValueStringRepresentation = memberInitSyntaxNode?.ToString() ?? string.Empty;
 
+                            if (DeclaredDefaultIsIgnored(member, out var ignoredReason))
+                            {
+                                // the declared default is inert here, so every nag below - each of
+                                // which assumes it is load-bearing - has nothing useful to say
+                                context.ReportDiagnostic(Diagnostic.Create(
+                                    descriptor: DataContractAnalyzer.DeclaredDefaultIgnored,
+                                    location: Utils.PickLocation(ref context, member.Blame),
+                                    messageArgs: new object[] { member.MemberName, ignoredReason! },
+                                    additionalLocations: null,
+                                    properties: null
+                                ));
+                                continue;
+                            }
+
                             switch (memberDefaultValueState)
                             {
                                 case MemberInitValueKind.NotSet:
-                                    // no diagnostic
+                                    if (DeclaredDefaultCannotRoundTrip(member))
+                                    {
+                                        context.ReportDiagnostic(Diagnostic.Create(
+                                            descriptor: DataContractAnalyzer.DeclaredDefaultCannotRoundTrip,
+                                            location: Utils.PickLocation(ref context, member.Blame),
+                                            messageArgs: new object[] { member.MemberName },
+                                            additionalLocations: null,
+                                            properties: null
+                                        ));
+                                    }
                                     break;
 
                                 case MemberInitValueKind.ConstantExpression:
@@ -604,6 +628,184 @@ namespace ProtoBuf.BuildTools.Internal
             return false;
         }
 
+        // protobuf-net applies a declared default by wrapping the member's serializer in a
+        // DefaultValueDecorator, and ValueMember.BuildSerializer only reaches that line for a
+        // non-repeated member:
+        //
+        //     if (_defaultValue is not null && !IsRequired && getSpecified is null)
+        //
+        // A repeated member never gets there at all - the decorator lives in the other arm of the
+        // branch - and IsRequired is called out in the condition itself. The getSpecified arm is
+        // deliberately NOT reported: pairing [DefaultValue("")] with a ShouldSerialize is precisely
+        // how protogen expresses explicit presence, and there the override is the whole point.
+        private bool DeclaredDefaultIsIgnored(Member member, out string? reason)
+        {
+            reason = null;
+            if (!HasEffectiveDeclaredDefault(member)) return false;
+
+            if (member.IsRequired)
+            {
+                reason = "the member declares IsRequired = true, so it is always written";
+                return true;
+            }
+
+            if (IsRepeatedLike(member.MemberType))
+            {
+                reason = "a declared default is not applied to a repeated member";
+                return true;
+            }
+
+            return false;
+        }
+
+        // The inverse of PBN0020/PBN0021: those ask whether an initializer needs a [DefaultValue],
+        // this asks whether a [DefaultValue] needs an initializer. A member equal to its declared
+        // default is not written, and deserialization only assigns fields that are present, so
+        // without something to restore the value the two ends disagree about what "absent" means.
+        private bool DeclaredDefaultCannotRoundTrip(Member member)
+        {
+            if (!HasEffectiveDeclaredDefault(member)) return false;
+
+            // only the kinds CalculateMemberInitialValue can reason about; for anything else we do
+            // not know what "initialized to the declared default" would even look like
+            if (member.SymbolSpecialType is not { } specialType || !HonoursDeclaredDefault(specialType)) return false;
+
+            // presence is tracked explicitly, so nothing rests on the initial value - this is the
+            // shape protogen emits for a proto2 optional field, [DefaultValue("")] and all
+            if (HasShouldSerializeMethod(member) || HasSpecifiedProperty(member)) return false;
+
+            // under SkipConstructor the instance is never constructed, so a field initializer would
+            // not run either; the fix this diagnostic implies would not actually fix anything
+            if (HasFlag(DataContractContextFlags.SkipConstructor)) return false;
+
+            // protogen assigns the default in a constructor rather than in an initializer
+            if (IsAssignedInInstanceConstructor(member)) return false;
+
+            return true;
+        }
+
+        // the set CalculateMemberInitialValue classifies as a constant expression: exactly the
+        // members where a declared default is honoured and an initializer is the remedy
+        private static bool HonoursDeclaredDefault(SpecialType specialType) => specialType switch
+        {
+            SpecialType.System_Boolean or SpecialType.System_Char or SpecialType.System_SByte
+            or SpecialType.System_Byte or SpecialType.System_Int16 or SpecialType.System_UInt16
+            or SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Int64
+            or SpecialType.System_UInt64 or SpecialType.System_Single or SpecialType.System_Double
+            or SpecialType.System_Enum or SpecialType.System_Decimal or SpecialType.System_String => true,
+            _ => false,
+        };
+
+        // Whether the member declares a default that actually declares anything.
+        //
+        // A null declared default means "no declared default" - ref-emit guards on
+        // `_defaultValue is not null`, and the AOT generator says so in as many words. A default
+        // equal to the member type's own default is inert for a different reason: the CLR already
+        // gives every field that value, so there is nothing to restore and nothing to suppress.
+        // protogen emits exactly that for a proto2 enum field defaulting to its zero member -
+        // [DefaultValue(MessageKind.None)] with no initializer - which is entirely correct.
+        private bool HasEffectiveDeclaredDefault(Member member)
+        {
+            var attr = GetDefaultValueAttributeData(member);
+            if (attr is null) return false;
+
+            var declared = attr.ConstructorArguments.Length switch
+            {
+                1 => attr.ConstructorArguments[0].Value,
+                2 => attr.ConstructorArguments[1].Value,
+                _ => null,
+            };
+            if (declared is null) return false;
+
+            return !IsTypeDefaultValue(member.SymbolSpecialType, declared);
+        }
+
+        private static bool IsTypeDefaultValue(SpecialType? specialType, object value) => specialType switch
+        {
+            SpecialType.System_Boolean => value.Equals(false),
+            SpecialType.System_String => value is string text && text.Length == 0,
+            _ => IsNumericZero(value),
+        };
+
+        // the declared value arrives boxed as whatever the attribute argument was - an enum comes
+        // through as its underlying type, which may be any integral width - so compare numerically
+        // rather than by Equals against a literal 0
+        private static bool IsNumericZero(object value)
+        {
+            try
+            {
+                return value switch
+                {
+                    float single => single == 0f,
+                    double dbl => dbl == 0d,
+                    decimal dec => dec == 0m,
+                    string or bool => false,
+                    _ => Convert.ToInt64(value, CultureInfo.InvariantCulture) == 0,
+                };
+            }
+            catch (Exception)
+            {
+                // not a number at all; whatever it is, it is not the type's default
+                return false;
+            }
+        }
+
+        // narrower than IsCollectionLike, and deliberately so: that one over-matches on purpose,
+        // because over-suppressing the IsRequired nag is harmless where over-claiming "your
+        // declared default is ignored" is a false positive. A bytes-like member is a scalar to
+        // protobuf-net - RepeatedSerializers.TryGetRepeatedProvider hands byte[] back as
+        // not-repeated - so it keeps its declared default.
+        private static bool IsRepeatedLike(ITypeSymbol? type)
+            => IsCollectionLike(type) && !IsBytesLike(type);
+
+        private static bool IsBytesLike(ITypeSymbol? type)
+        {
+            if (type is IArrayTypeSymbol { Rank: 1, ElementType.SpecialType: SpecialType.System_Byte }) return true;
+            return type is INamedTypeSymbol { TypeArguments.Length: 1 } named
+                && named.TypeArguments[0].SpecialType == SpecialType.System_Byte
+                && named.ConstructedFrom is { } definition
+                && definition.ContainingNamespace?.ToDisplayString() == "System"
+                && definition.MetadataName is "Memory`1" or "ReadOnlyMemory`1" or "ArraySegment`1";
+        }
+
+        // the runtime probes for these against the *member* name - MetaType uses
+        // member.Name + "Specified" where that member is the MemberInfo - which is why both use
+        // MemberName rather than the possibly-renamed proto Name
+        private static bool HasSpecifiedProperty(Member member)
+            => member.Symbol.ContainingType.GetMembers(member.MemberName + "Specified")
+                .OfType<IPropertySymbol>()
+                .Any(prop => prop.Type.SpecialType == SpecialType.System_Boolean);
+
+        private static bool HasShouldSerializeMethod(Member member)
+            => member.Symbol.ContainingType.GetMembers("ShouldSerialize" + member.MemberName)
+                .OfType<IMethodSymbol>()
+                .Any(method => method.ReturnType.SpecialType == SpecialType.System_Boolean);
+
+        // matched by name rather than by symbol: this only ever suppresses a warning, so a loose
+        // match costs nothing, where dragging a semantic model in per constructor is not free
+        private static bool IsAssignedInInstanceConstructor(Member member)
+        {
+            foreach (var ctor in member.Symbol.ContainingType.InstanceConstructors)
+            {
+                foreach (var reference in ctor.DeclaringSyntaxReferences)
+                {
+                    if (reference.GetSyntax() is not ConstructorDeclarationSyntax declaration) continue;
+                    foreach (var assignment in declaration.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+                    {
+                        switch (assignment.Left)
+                        {
+                            case IdentifierNameSyntax id when id.Identifier.ValueText == member.MemberName:
+                                return true;
+                            case MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax } access
+                                when access.Name.Identifier.ValueText == member.MemberName:
+                                return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
         /// <remarks>Ensure to validate member before (i.e. calculate default value of member)</remarks>
         private bool ShouldDeclareDefault(Member member, object? memberInitValue)
         {
@@ -618,15 +820,11 @@ namespace ProtoBuf.BuildTools.Internal
                 return false;
             }
 
-            if(HasDefaultAttribute() || HasShouldSerializeMethod())
+            if (GetDefaultValueAttributeData(member) is not null || HasShouldSerializeMethod(member))
             {
                 // we already have required attributes defined
                 return false;
             }
-            
-            bool HasDefaultAttribute() => GetDefaultValueAttributeData(member) is not null;
-            bool HasShouldSerializeMethod() => member.Symbol.ContainingType.GetMembers().OfType<IMethodSymbol>()
-                .FirstOrDefault(method => method.Name == "ShouldSerialize" + member.Name && method.ReturnType.SpecialType == SpecialType.System_Boolean) != null;
 
             if (memberInitValue is null)
             {


### PR DESCRIPTION
Part of #1295. Same content as #1296, re-targeted at `main`.

#1296 merged into its base branch `marc/analyzer-implicit-default` rather than into `main`, and
because #1294 had already squash-merged a few minutes earlier, that base was by then a dead end —
so this work never reached `main`. Nothing was lost; the commit replays onto today's `main`
cleanly, which is what this branch is.

No review changes from #1296. The commit is identical apart from being reparented, and the full
`BuildToolsUnitTests` suite is green at 370.

## Protogen impact, checked rather than reasoned about

Since #1296 was approved I ran the analyzer over actual generated output rather than inferring
from `CSharpCodeGenerator`:

- **proto2 with defaults** — every defaulted field comes out as `[DefaultValue(x)]` plus a backing
  field, `ShouldSerializeX()` and `ResetX()`, so the presence suppression covers all of them. A
  `required` field with a default gets no `[DefaultValue]` attribute at all
  (`suppressDefaultAttribute = !isOptional`), and neither does a `repeated` field — so PBN0025 has
  nothing to fire on either.
- **proto3** — `[DefaultValue("")] public string Name { get; set; } = "";` carries its own
  initializer; `optional` and `oneof` members get the `ShouldSerialize` treatment.
- **`Descriptor.cs` and `CustomOptions.cs`** — the two largest bodies of checked-in generated code
  in this repo.

All four come back completely clean, and not only of PBN0024/PBN0025: I filtered on every `PBN`
id and got nothing. That is on top of the four analyzer-consuming projects here — `AotColdStart`,
`AotSchemaDtos`, `AotSmoke`, `DownLevelSmoke` — which still rebuild clean.