### PR TITLE
Switching framing is only a wire break for other implementations

### DIFF
--- a/docs/editions.md
+++ b/docs/editions.md
@@ -267,8 +267,14 @@ in a deep graph is true of every outer level:
 - **Skipping is cheaper with a length prefix.** A reader that wants to ignore a field can jump over a
   length-prefixed one; a delimited one has to be walked to find its matching end tag. If your readers skip a
   lot of what they receive, the prefix earns its keep.
-- **Changing the framing changes the bytes.** It is a wire-breaking change, like changing a field number:
-  both ends have to agree.
+- **Changing the framing changes the bytes** - though what that costs you depends entirely on who reads
+  them. protobuf-net itself is relaxed: its reader dispatches on the wire type actually present, not on how
+  the member is declared, so a protobuf-net consumer deserializes either framing either way round. Other
+  implementations are generally not - `protoc`-generated parsers match on the whole tag, field number *and*
+  wire type together, so a field that arrives in the framing they were not generated for falls through to
+  their unknown-field set: it reads back as unset rather than as an error. Treat the switch as a wire break
+  as soon as anything other than protobuf-net is reading, and as a rolling upgrade you can take at leisure
+  when it is protobuf-net at both ends.
 - **Not every consumer is willing.** The wire types are core protobuf and every complete implementation reads
   them, but a consumer generating from a proto3 schema has no way to *declare* the field, so they would be
   stuck hand-writing it. Editions is what fixes that - which is rather the point of this page.


### PR DESCRIPTION
`docs/editions.md` claimed that changing between length-prefixed and delimited is a wire-breaking change "like changing a field number: both ends have to agree". That is not true of protobuf-net, and overstates the cost of the thing the page is recommending.

**We read either.** `ProtoReader.State.StartSubItem()` switches on the wire type actually present — `StartGroup` or `String` — and never consults the member's declared `DataFormat`. So a protobuf-net consumer deserializes both framings whichever way its contract declares the member; the declaration governs what gets *written*. That has been the shape since the reader and writer sides were separated, and the old commit message that did it says so in as many words: *"allowing (for example) us to read objects from either a group or length-prefix, but always serialize as one of them"*.

**It is a break as soon as anything else reads it**, and quietly so. `protoc`-generated parsers switch on the whole tag — field number and wire type together — so a field arriving in the framing they were not generated for matches no case arm and falls to the unknown-field set. It reads back as unset rather than throwing, which is the worse of the two failure modes.

So the bullet now separates the two cases: a wire break when anything other than protobuf-net is reading, and a rolling upgrade you can take at leisure when protobuf-net is at both ends.

Both halves are checked against the source rather than assumed — ours in `ProtoReader.State.ReadMethods.cs`, theirs in the generated parser the benchmark already carries (`src/Benchmark/Codegen/Delimited.cs`), where the length-prefixed field is `case 18:` and the delimited one would be `case 19:`, with `default:` merging into `_unknownFields`.

Docs only; no code change.