### PR TITLE
PBN0026: a declared default that SkipConstructor puts out of reach

### DIFF
--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.DefaultValueAttribute.cs
@@ -319,6 +319,131 @@ namespace BuildToolsUnitTests
                 || x.Descriptor == DataContractAnalyzer.DeclaredDefaultIgnored));
         }
 
+        // SkipConstructor deserializes via GetUninitializedObject, so neither the constructor nor a
+        // field initializer runs - and a declared default is only restored by one of those. There
+        // is no way to write the member that makes it round-trip, so the pairing itself is reported
+        [Theory]
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(5)] public int Bar { get; set; } = 5;")]
+        [InlineData(@"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                      public Foo() { Bar = ""abc""; }")]
+        public async Task ReportsDeclaredDefaultUnderSkipConstructor(string body)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract(SkipConstructor = true)]
+                public class Foo {{
+                    {body}
+                }}
+            ");
+
+            var diag = Assert.Single(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor));
+            Assert.Equal(DiagnosticSeverity.Warning, diag.Severity);
+            Assert.Contains("'Bar'", diag.GetMessage(CultureInfo.InvariantCulture));
+        }
+
+        // one report per contract, not per member, and it names every member it covers
+        [Fact]
+        public async Task ReportsDeclaredDefaultUnderSkipConstructorOncePerType()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract(SkipConstructor = true)]
+                public class Foo {
+                    [ProtoMember(1), DefaultValue(""abc"")] public string First { get; set; } = ""abc"";
+                    [ProtoMember(2), DefaultValue(5)] public int Second { get; set; } = 5;
+                    [ProtoMember(3)] public string Untouched { get; set; }
+                }
+            ");
+
+            var diag = Assert.Single(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor));
+            var message = diag.GetMessage(CultureInfo.InvariantCulture);
+            Assert.Contains("'First'", message);
+            Assert.Contains("'Second'", message);
+            Assert.DoesNotContain("Untouched", message);
+        }
+
+        // the report points at `SkipConstructor = true`, which is the thing to decide about
+        [Fact]
+        public async Task ReportsDeclaredDefaultUnderSkipConstructorAtTheOption()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract(SkipConstructor = true)]
+                public class Foo {
+                    [ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";
+                }
+            ");
+
+            var diag = Assert.Single(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor));
+            var span = diag.Location.SourceSpan;
+            var text = (await diag.Location.SourceTree!.GetTextAsync()).ToString().Substring(span.Start, span.Length);
+            Assert.Equal("SkipConstructor = true", text);
+        }
+
+        [Theory]
+        // no SkipConstructor, no problem
+        [InlineData(@"[ProtoContract]", @"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        [InlineData(@"[ProtoContract(SkipConstructor = false)]", @"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; } = ""abc"";")]
+        // nothing declares a default
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1)] public string Bar { get; set; }")]
+        // explicit presence replaces the declared-default guard, so the value still reaches the wire
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                      public bool ShouldSerializeBar() => Bar != null;")]
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                      public bool BarSpecified { get; set; }")]
+        // a default equal to the type's own default is supplied by the CLR, constructor or not
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1), DefaultValue(0)] public int Bar { get; set; }")]
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1), DefaultValue(null)] public string Bar { get; set; }")]
+        // a default that is never applied cannot be lost - that is PBN0025's business
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1, IsRequired = true), DefaultValue(""abc"")] public string Bar { get; set; }")]
+        [InlineData(@"[ProtoContract(SkipConstructor = true)]", @"[ProtoMember(1), DefaultValue(5)] public System.Collections.Generic.List<int> Bar { get; set; } = new();")]
+        public async Task DoesNotReportDeclaredDefaultUnderSkipConstructor(string contract, string body)
+        {
+            var diagnostics = await AnalyzeAsync($@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                {contract}
+                public class Foo {{
+                    {body}
+                }}
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor));
+        }
+
+        // PBN0024 stands down under SkipConstructor - its advice would not work there - so the two
+        // never both fire on the same member
+        [Fact]
+        public async Task SkipConstructorReportSupersedesTheRoundTripNag()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+                using ProtoBuf;
+                using System;
+                using System.ComponentModel;
+
+                [ProtoContract(SkipConstructor = true)]
+                public class Foo {
+                    [ProtoMember(1), DefaultValue(""abc"")] public string Bar { get; set; }
+                }
+            ");
+
+            Assert.Empty(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultCannotRoundTrip));
+            Assert.Single(diagnostics.Where(x => x.Descriptor == DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor));
+        }
+
         // a collection member has no wire presence to force - an empty collection writes nothing,
         // and IsRequired is only observable for value-type scalars - so initializing one (the
         // standard pattern, including getter-only) must not trigger the IsRequired nag

--- a/src/BuildToolsUnitTests/DataContractAnalyzerTests.cs
+++ b/src/BuildToolsUnitTests/DataContractAnalyzerTests.cs
@@ -88,7 +88,12 @@ public partial class Foo
     }
     public Foo (){}
 } "});
-            Assert.Empty(diagnostics);
+            // this fixture pairs SkipConstructor with [DefaultValue(3)], which PBN0026 reports and
+            // is right to: the instance is built without running a constructor, so Bar arrives as 0
+            // while a sender holding 3 writes nothing. Asserted as the *only* diagnostic, so the
+            // test still fails if a partial declaration provokes anything else - which is its point
+            var diag = Assert.Single(diagnostics);
+            Assert.Equal(DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor, diag.Descriptor);
         }
 
 

--- a/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
+++ b/src/protobuf-net.BuildTools/AnalyzerReleases.Unshipped.md
@@ -34,6 +34,7 @@ PBN0022  | Usage    | Warning  | Member should declare `IsRequired`
 PBN0023  | Usage    | Warning  | `[ProtoContract]` on an interface is not recommended
 PBN0024  | Usage    | Warning  | Member declares `[DefaultValue]` but nothing initializes it to that value
 PBN0025  | Usage    | Warning  | Member declares a `[DefaultValue]` that protobuf-net will not apply
+PBN0026  | Usage    | Warning  | `SkipConstructor` leaves a declared `[DefaultValue]` with no way to round-trip
 PBN2001  | Usage    | Error    | gRPC: invalid member kind on a service contract
 PBN2002  | Usage    | Error    | gRPC: invalid payload type
 PBN2003  | Usage    | Error    | gRPC: invalid return type

--- a/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/DataContractAnalyzer.cs
@@ -223,6 +223,15 @@ internal static readonly DiagnosticDescriptor DeclaredAndIgnored = new(
             isEnabledByDefault: true,
             helpLinkUri: "https://stackoverflow.com/a/3162253/1882616");
 
+        internal static readonly DiagnosticDescriptor DeclaredDefaultUnderSkipConstructor = new(
+            id: "PBN0026",
+            title: nameof(DataContractAnalyzer) + "." + nameof(DeclaredDefaultUnderSkipConstructor),
+            messageFormat: "SkipConstructor means no constructor or field initializer runs on deserialize, so nothing can restore a declared default; {0} will not round-trip.",
+            category: Literals.CategoryUsage,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://stackoverflow.com/a/3162253/1882616");
+
         internal static readonly DiagnosticDescriptor ProtoContractOnInterface = new(
             id: "PBN0023",
             title: nameof(DataContractAnalyzer) + "." + nameof(ProtoContractOnInterface),

--- a/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
+++ b/src/protobuf-net.BuildTools/Internal/DataContractContext.cs
@@ -400,6 +400,27 @@ namespace ProtoBuf.BuildTools.Internal
                         ));
                     }
                 }
+
+                if (HasFlag(DataContractContextFlags.SkipConstructor) && OwnsSkipConstructorBlame(ref context))
+                {
+                    // no arrangement of the member makes this correct - the initializer PBN0024
+                    // would ask for is exactly what SkipConstructor skips - so it is the pairing
+                    // itself that gets reported, once, at the option responsible
+                    var lost = _members
+                        .Where(DeclaredDefaultLostToSkipConstructor)
+                        .Select(candidate => "'" + candidate.MemberName + "'")
+                        .ToList();
+                    if (lost.Count != 0)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            descriptor: DataContractAnalyzer.DeclaredDefaultUnderSkipConstructor,
+                            location: Utils.PickLocation(ref context, _skipConstructorBlame),
+                            messageArgs: new object[] { string.Join(", ", lost) },
+                            additionalLocations: null,
+                            properties: null
+                        ));
+                    }
+                }
             }
             static bool PropertyOrFieldExists(ITypeSymbol type, string name)
             {
@@ -675,12 +696,27 @@ namespace ProtoBuf.BuildTools.Internal
             if (HasShouldSerializeMethod(member) || HasSpecifiedProperty(member)) return false;
 
             // under SkipConstructor the instance is never constructed, so a field initializer would
-            // not run either; the fix this diagnostic implies would not actually fix anything
+            // not run either; the fix this diagnostic implies would not actually fix anything, and
+            // the pairing is reported once per contract as PBN0026 instead
             if (HasFlag(DataContractContextFlags.SkipConstructor)) return false;
 
             // protogen assigns the default in a constructor rather than in an initializer
             if (IsAssignedInInstanceConstructor(member)) return false;
 
+            return true;
+        }
+
+        // A declared default that SkipConstructor makes unreachable. Unlike PBN0024 this does not
+        // care whether an initializer is present: the initializer does not run either, so there is
+        // no way to write the member that restores the value. Explicit presence is the exception -
+        // it replaces the declared-default guard, so the value still goes to the wire - and a
+        // default that is never applied at all cannot be lost, which is PBN0025's territory.
+        private bool DeclaredDefaultLostToSkipConstructor(Member member)
+        {
+            if (!HasEffectiveDeclaredDefault(member)) return false;
+            if (member.SymbolSpecialType is not { } specialType || !HonoursDeclaredDefault(specialType)) return false;
+            if (HasShouldSerializeMethod(member) || HasSpecifiedProperty(member)) return false;
+            if (DeclaredDefaultIsIgnored(member, out _)) return false;
             return true;
         }
 
@@ -878,7 +914,13 @@ namespace ProtoBuf.BuildTools.Internal
             _ = blame;
             _flags |= DataContractContextFlags.IsProtoContract;
             if (attrib.TryGetBooleanByName(nameof(ProtoContractAttribute.SkipConstructor), out var val) && val)
+            {
                 _flags |= DataContractContextFlags.SkipConstructor;
+                // PBN0026 is a fact about the contract rather than about any one member, so it is
+                // reported once, against the option that causes it
+                _skipConstructorBlame = NamedArgumentLocation(attrib, nameof(ProtoContractAttribute.SkipConstructor))
+                    ?? attrib.GetLocation(blame);
+            }
             if (attrib.TryGetBooleanByName(nameof(ProtoContractAttribute.IgnoreUnknownSubTypes), out val) && val)
                 _flags |= DataContractContextFlags.IgnoreUnknownSubTypes;
             foreach (var named in attrib.NamedArguments)
@@ -888,6 +930,33 @@ namespace ProtoBuf.BuildTools.Internal
                     _flags |= DataContractContextFlags.HasSurrogate;
                 }
             }
+        }
+
+        private Location? _skipConstructorBlame;
+
+        // A partial type is visited once per declaration, and this is a fact about the type rather
+        // than about any one part, so it must not be reported once per file. The part that actually
+        // writes `SkipConstructor` is the one that owns it; if there is no syntax to go on, report
+        // rather than stay silent, since a duplicate is a smaller failure than a miss.
+        private bool OwnsSkipConstructorBlame(ref SyntaxNodeAnalysisContext context)
+        {
+            if (_skipConstructorBlame is not { } blame || blame.SourceTree is null) return true;
+            return blame.SourceTree == context.Node.SyntaxTree
+                && context.Node.FullSpan.Contains(blame.SourceSpan);
+        }
+
+        // the whole attribute is a serviceable fallback, but `SkipConstructor = true` is the thing
+        // the reader has to decide about, so point at that argument where the syntax is available
+        private static Location? NamedArgumentLocation(AttributeData attrib, string name)
+        {
+            if (attrib.ApplicationSyntaxReference?.GetSyntax() is not AttributeSyntax syntax) return null;
+            var arguments = syntax.ArgumentList?.Arguments;
+            if (arguments is null) return null;
+            foreach (var argument in arguments)
+            {
+                if (argument.NameEquals?.Name.Identifier.ValueText == name) return argument.GetLocation();
+            }
+            return null;
         }
 
         public bool HasFlag(DataContractContextFlags flag)


### PR DESCRIPTION
Closes #1299. Stacked on #1297 — base is `marc/analyzer-defaultvalue-gaps-v2`, because this builds
on the helpers added there.

> **Merge order matters, and it bit us once already.** #1296 merged into a base branch that had
> already been squash-merged, so it never reached `main` and had to be replayed as #1297. Auto-delete
> is off on this repo, so the same trap is live here. Merge #1297 first, then re-target this to
> `main` before merging it — happy to do that re-target the moment #1297 lands.

## What it reports

`SkipConstructor` deserializes via `BclHelpers.GetUninitializedObject`, so the constructor never
runs — and the compiler emits field and property initializers *into* the constructor, so they do
not run either. A declared default is only ever restored by one of those, so under
`SkipConstructor` there is no way to write the member that makes it round-trip: the sender holding
the default writes nothing, and the receiver arrives at the CLR default.

`Blank` in AotSmoke already documents the mechanism — "comes back null, not `ctor`".

That is why PBN0024 stands down here (the initializer it would ask for is exactly what gets
skipped), and why this is a separate id rather than a wider PBN0024: the remedies differ. Drop
`SkipConstructor`, drop the `[DefaultValue]`, or add explicit presence, which replaces the
declared-default guard so the value still reaches the wire.

Reported **once per contract, at the `SkipConstructor = true` argument**, listing the members it
covers. Excluded: a member with explicit presence, one whose declared default is never applied at
all (PBN0025's territory), and one whose declared default is already the type's own.

## Two things worth a reviewer's attention

**A partial type is visited once per declaration**, so a type-level diagnostic reported naively
fires once per file. Mine did. It is now raised only from the part that writes the option, and
`DoesntReportOnPartialClassDefinition`'s `Assert.Single` is what pins that.

Separately: PBN0023 (`ProtoContractOnInterface`) is also type-level and appears to have the same
latent problem. Pre-existing, so untouched here, but somebody should look.

**An existing test changed its expectation.** That same fixture pairs `SkipConstructor = true` with
`[DefaultValue(3)]` and `= 3`, which is precisely the hazard — built via `GetUninitializedObject`,
`Bar` arrives as 0 while a sender holding 3 writes nothing. So it is a true positive, and the test
now expects one PBN0026 *as the only diagnostic* rather than none; it still fails if a partial
declaration provokes anything else, which is its actual point. If you would rather the fixture
dropped `SkipConstructor` and kept `Assert.Empty`, say so and I will swap it.

## Verification

15 new cases. I mutated the suppressions and the partial-type guard and confirmed the negative
tests and the partial-dedup test fail without them, so none passes vacuously. Full
`BuildToolsUnitTests` green at 386.

The four analyzer-consuming projects here rebuild clean — including `AotSmoke`, whose `Blank` uses
`SkipConstructor` but declares no default, so it correctly stays quiet.