### PR TITLE
NodaTime: LocalDate and LocalTime reach the compile-time model too

### DIFF
--- a/src/AotNodaTimeSmoke/Program.cs
+++ b/src/AotNodaTimeSmoke/Program.cs
@@ -7,8 +7,9 @@ using System.IO;
 namespace ProtoBuf.AotNodaTimeSmoke;
 
 /// <summary>
-/// A consumer that only knows it is using NodaTime. It declares no surrogates: the pairings come
-/// from protobuf-net.NodaTime's assembly-level [ProtoSurrogate] declarations.
+/// A consumer that only knows it is using NodaTime. It declares no surrogates and calls no
+/// AddNodaTime: the pairings come from protobuf-net.NodaTime's assembly-level [ProtoSurrogate]
+/// declarations. IsoDayOfWeek needs no pairing at all - it is an enum.
 /// </summary>
 [ProtoContract]
 public class Appointment
@@ -16,6 +17,9 @@ public class Appointment
     [ProtoMember(1)] public string Title { get; set; }
     [ProtoMember(2)] public Instant Starts { get; set; }
     [ProtoMember(3)] public Duration Runs { get; set; }
+    [ProtoMember(4)] public LocalDate Day { get; set; }
+    [ProtoMember(5)] public LocalTime Time { get; set; }
+    [ProtoMember(6)] public IsoDayOfWeek Dow { get; set; }
 }
 
 [ProtoModel]
@@ -35,22 +39,13 @@ internal static class Program
             Title = "standup",
             Starts = Instant.FromUtc(2020, 1, 2, 3, 4),
             Runs = Duration.FromMinutes(15),
+            Day = new LocalDate(2020, 1, 2),
+            Time = new LocalTime(3, 4, 5).PlusNanoseconds(123456789),
+            Dow = IsoDayOfWeek.Thursday,
         };
 
         using var ms = new MemoryStream();
-        try
-        {
-            model.Serialize(ms, original);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // the pairings *are* found - see the PBN3003/PBN3004 chain at build time - but the
-            // well-known types they point at declare [ProtoContract(Serializer = ...)] naming the
-            // internal PrimaryTypeProvider, which a consumer's generated code cannot name. Exposing
-            // a public serializer for those types is what would finish this off.
-            Console.WriteLine($"NodaTime surrogate smoke test BLOCKED: {ex.Message}");
-            return 0;
-        }
+        model.Serialize(ms, original);
         var bytes = ms.ToArray();
         Console.WriteLine($"serialized {bytes.Length} bytes: {BitConverter.ToString(bytes)}");
 
@@ -60,6 +55,9 @@ internal static class Program
         Check(ref failures, "Title", original.Title, clone.Title);
         Check(ref failures, "Starts", original.Starts, clone.Starts);
         Check(ref failures, "Runs", original.Runs, clone.Runs);
+        Check(ref failures, "Day", original.Day, clone.Day);
+        Check(ref failures, "Time", original.Time, clone.Time);
+        Check(ref failures, "Dow", original.Dow, clone.Dow);
 
         Console.WriteLine(failures == 0
             ? "NodaTime surrogate smoke test PASSED"

--- a/src/protobuf-net.NodaTime/NodaTimeSurrogates.cs
+++ b/src/protobuf-net.NodaTime/NodaTimeSurrogates.cs
@@ -1,0 +1,105 @@
+using NodaTime;
+using System;
+
+namespace ProtoBuf.Meta
+{
+    /// <summary>
+    /// Wire-shape surrogates for the NodaTime types that protobuf-net serializes through a custom
+    /// serializer rather than a contract; this type is not intended to be used directly and should
+    /// be considered an implementation detail.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="NodaTimeSerializers"/> is what <see cref="NodaTimeExtensions.AddNodaTime"/>
+    /// installs on a <see cref="RuntimeTypeModel"/>; a compile-time model cannot use it, because a
+    /// generated model has no way to reach a serializer that was chosen at runtime. These types say
+    /// the same thing as ordinary contracts, so the generator can emit them, and they are paired to
+    /// the NodaTime types by the assembly-level <c>[ProtoSurrogate]</c> declarations in
+    /// <c>ProtoSurrogates.cs</c>.
+    /// </para>
+    /// <para>
+    /// The field numbers and the omit-when-zero behaviour match <see cref="NodaTimeSerializers"/>
+    /// exactly - the two must produce identical bytes, and <c>NodaTimeSurrogateTests</c> asserts it.
+    /// They are deliberately not named as <c>.google.type.*</c>: schema generation from a
+    /// compile-time model is not implemented, so a name here would describe nothing.
+    /// </para>
+    /// </remarks>
+    public static class NodaTimeSurrogates
+    {
+        /// <summary>
+        /// The wire shape of <see cref="LocalDate"/>, matching <c>google.type.Date</c>.
+        /// </summary>
+        [ProtoContract]
+        public sealed class Date
+        {
+            /// <summary>The year.</summary>
+            [ProtoMember(1)] public int Year { get; set; }
+
+            /// <summary>The month, 1-12.</summary>
+            [ProtoMember(2)] public int Month { get; set; }
+
+            /// <summary>The day of the month.</summary>
+            [ProtoMember(3)] public int Day { get; set; }
+
+            /// <summary>Convert from <see cref="LocalDate"/>.</summary>
+            public static implicit operator Date(LocalDate value)
+            {
+                // parity with NodaTimeSerializers: the same two refusals, with the same messages
+                if (value.Calendar != CalendarSystem.Iso)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Non-ISO dates cannot be converted to Protobuf Date messages. Actual calendar ID: {value.Calendar.Id}");
+                }
+                if (value.Year < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value),
+                        $"Dates earlier than 1AD cannot be converted to Protobuf Date messages. Year: {value.Year}");
+                }
+                return new Date { Year = value.Year, Month = value.Month, Day = value.Day };
+            }
+
+            /// <summary>Convert to <see cref="LocalDate"/>.</summary>
+            public static implicit operator LocalDate(Date value)
+            {
+                // an absent field is a zero here, where the reader in NodaTimeSerializers starts
+                // from the components of a default LocalDate - which are 1, 1, 1
+                if (value is null) return default;
+                return new LocalDate( // ISO calendar is implicit
+                    value.Year == 0 ? 1 : value.Year,
+                    value.Month == 0 ? 1 : value.Month,
+                    value.Day == 0 ? 1 : value.Day);
+            }
+        }
+
+        /// <summary>
+        /// The wire shape of <see cref="LocalTime"/>, matching <c>google.type.TimeOfDay</c>.
+        /// </summary>
+        [ProtoContract]
+        public sealed class TimeOfDay
+        {
+            /// <summary>The hour, 0-23.</summary>
+            [ProtoMember(1)] public int Hours { get; set; }
+
+            /// <summary>The minute, 0-59.</summary>
+            [ProtoMember(2)] public int Minutes { get; set; }
+
+            /// <summary>The second, 0-59.</summary>
+            [ProtoMember(3)] public int Seconds { get; set; }
+
+            /// <summary>The nanosecond within the second.</summary>
+            [ProtoMember(4)] public int Nanos { get; set; }
+
+            /// <summary>Convert from <see cref="LocalTime"/>.</summary>
+            public static implicit operator TimeOfDay(LocalTime value) => new TimeOfDay
+            {
+                Hours = value.Hour,
+                Minutes = value.Minute,
+                Seconds = value.Second,
+                Nanos = value.NanosecondOfSecond,
+            };
+
+            /// <summary>Convert to <see cref="LocalTime"/>.</summary>
+            public static implicit operator LocalTime(TimeOfDay value)
+                => value is null ? default : new LocalTime(value.Hours, value.Minutes, value.Seconds).PlusNanoseconds(value.Nanos);
+        }
+    }
+}

--- a/src/protobuf-net.NodaTime/ProtoSurrogates.cs
+++ b/src/protobuf-net.NodaTime/ProtoSurrogates.cs
@@ -16,3 +16,13 @@ using ProtoBuf;
     Converter = typeof(ProtoBuf.Meta.NodaTimeExtensions),
     ToSurrogate = nameof(ProtoBuf.Meta.NodaTimeExtensions.ToProtoBufTimestamp),
     ToType = nameof(ProtoBuf.Meta.NodaTimeExtensions.ToNodaTimeInstant))]
+
+// LocalDate and LocalTime have no well-known-type equivalent to pair with, so the shapes live in
+// this package too - see NodaTimeSurrogates. No Converter: the surrogates carry conversion
+// operators, which is what ProtoSurrogate uses when none is named.
+//
+// IsoDayOfWeek deliberately has no entry: it is an enum, which needs no help - AddNodaTime only
+// names it, and naming is a schema concern.
+[assembly: ProtoSurrogate(typeof(NodaTime.LocalDate), typeof(ProtoBuf.Meta.NodaTimeSurrogates.Date))]
+
+[assembly: ProtoSurrogate(typeof(NodaTime.LocalTime), typeof(ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay))]

--- a/src/protobuf-net.NodaTime/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/protobuf-net.NodaTime/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,23 @@
+ProtoBuf.Meta.NodaTimeSurrogates
+ProtoBuf.Meta.NodaTimeSurrogates.Date
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Date() -> void
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Day.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Day.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Month.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Month.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Year.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.Date.Year.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Hours.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Hours.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Minutes.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Minutes.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Nanos.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Nanos.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Seconds.get -> int
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.Seconds.set -> void
+ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.TimeOfDay() -> void
+static ProtoBuf.Meta.NodaTimeSurrogates.Date.implicit operator NodaTime.LocalDate(ProtoBuf.Meta.NodaTimeSurrogates.Date value) -> NodaTime.LocalDate
+static ProtoBuf.Meta.NodaTimeSurrogates.Date.implicit operator ProtoBuf.Meta.NodaTimeSurrogates.Date(NodaTime.LocalDate value) -> ProtoBuf.Meta.NodaTimeSurrogates.Date
+static ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.implicit operator NodaTime.LocalTime(ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay value) -> NodaTime.LocalTime
+static ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay.implicit operator ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay(NodaTime.LocalTime value) -> ProtoBuf.Meta.NodaTimeSurrogates.TimeOfDay

--- a/src/protobuf-net.Test/NodaTimeSurrogateTests.cs
+++ b/src/protobuf-net.Test/NodaTimeSurrogateTests.cs
@@ -1,0 +1,129 @@
+using NodaTime;
+using ProtoBuf.Meta;
+using System;
+using System.IO;
+using Xunit;
+
+namespace ProtoBuf.Test
+{
+    /// <summary>
+    /// LocalDate and LocalTime reach the wire two ways: NodaTimeSerializers, which AddNodaTime
+    /// installs on a RuntimeTypeModel, and NodaTimeSurrogates, which is what a compile-time model
+    /// can use. They must agree byte-for-byte, or data written by one is misread by the other.
+    /// </summary>
+    public class NodaTimeSurrogateTests
+    {
+        [ProtoContract]
+        public class HazLocalDate
+        {
+            [ProtoMember(1)] public LocalDate Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazLocalTime
+        {
+            [ProtoMember(1)] public LocalTime Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazDateSurrogate
+        {
+            [ProtoMember(1)] public NodaTimeSurrogates.Date Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazTimeSurrogate
+        {
+            [ProtoMember(1)] public NodaTimeSurrogates.TimeOfDay Value { get; set; }
+        }
+
+        private static RuntimeTypeModel NodaModel()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            return model.AddNodaTime();
+        }
+
+        private static RuntimeTypeModel PlainModel()
+        {
+            var model = RuntimeTypeModel.Create();
+            model.AutoCompile = false;
+            return model;
+        }
+
+        private static string Hex<T>(RuntimeTypeModel model, T value)
+        {
+            using var ms = new MemoryStream();
+            model.Serialize(ms, value);
+            return BitConverter.ToString(ms.ToArray());
+        }
+
+        [Theory]
+        [InlineData(2020, 1, 2)]
+        [InlineData(1, 1, 1)]
+        [InlineData(9999, 12, 31)]
+        public void DateSurrogateMatchesTheCustomSerializer(int year, int month, int day)
+        {
+            var value = new LocalDate(year, month, day);
+            var viaSerializer = Hex(NodaModel(), new HazLocalDate { Value = value });
+            var viaSurrogate = Hex(PlainModel(), new HazDateSurrogate { Value = value });
+            Assert.Equal(viaSerializer, viaSurrogate);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(3, 4, 5, 0)]
+        [InlineData(23, 59, 59, 123456789)]
+        public void TimeSurrogateMatchesTheCustomSerializer(int hour, int minute, int second, int nanos)
+        {
+            var value = new LocalTime(hour, minute, second).PlusNanoseconds(nanos);
+            var viaSerializer = Hex(NodaModel(), new HazLocalTime { Value = value });
+            var viaSurrogate = Hex(PlainModel(), new HazTimeSurrogate { Value = value });
+            Assert.Equal(viaSerializer, viaSurrogate);
+        }
+
+        [Theory]
+        [InlineData(2020, 1, 2)]
+        [InlineData(1, 1, 1)]
+        public void DateSurrogateRoundTrips(int year, int month, int day)
+        {
+            var value = new LocalDate(year, month, day);
+            NodaTimeSurrogates.Date surrogate = value;
+            LocalDate back = surrogate;
+            Assert.Equal(value, back);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(23, 59, 59, 123456789)]
+        public void TimeSurrogateRoundTrips(int hour, int minute, int second, int nanos)
+        {
+            var value = new LocalTime(hour, minute, second).PlusNanoseconds(nanos);
+            NodaTimeSurrogates.TimeOfDay surrogate = value;
+            LocalTime back = surrogate;
+            Assert.Equal(value, back);
+        }
+
+        [Fact]
+        public void AnAbsentDateReadsAsTheDefault()
+        {
+            // every field omitted: the custom serializer starts from a default LocalDate's
+            // components (1, 1, 1), and the surrogate has to land in the same place
+            LocalDate viaSurrogate = new NodaTimeSurrogates.Date();
+            Assert.Equal(default(LocalDate), viaSurrogate);
+
+            using var ms = new MemoryStream();
+            var clone = NodaModel().Deserialize<HazLocalDate>(ms);
+            Assert.Equal(default(LocalDate), clone.Value);
+        }
+
+        [Fact]
+        public void NonIsoDatesAreRefusedTheSameWay()
+        {
+            var julian = new LocalDate(2020, 1, 2, CalendarSystem.Julian);
+            var viaSerializer = Assert.Throws<ArgumentOutOfRangeException>(() => Hex(NodaModel(), new HazLocalDate { Value = julian }));
+            var viaSurrogate = Assert.Throws<ArgumentOutOfRangeException>(() => { NodaTimeSurrogates.Date _ = julian; });
+            Assert.Equal(viaSerializer.Message, viaSurrogate.Message);
+        }
+    }
+}


### PR DESCRIPTION
Closes the gap found while writing the package readmes (protobuf-net/protobuf-net#1291): `Instant` and `Duration` self-wire for a compile-time model, but the other types `AddNodaTime` handles did not.

## The gap

`LocalDate` and `LocalTime` are served by `NodaTimeSerializers`, a custom `ISerializer` that `AddNodaTime` installs on a `RuntimeTypeModel`. A generated model has no way to reach a serializer chosen at runtime, so:

```
warning PBN3001: Contract 'Wider' is omitted from the AOT model: member 'Day' has unsupported
type 'NodaTime.LocalDate' … [ProtoSurrogate] on the model is the way to serialize a type you
do not own.
```

…followed by `InvalidOperationException: Type is not expected` at serialize. Note the blast radius: the diagnostic omits the **whole contract**, so a single `LocalDate` took every other member with it.

`IsoDayOfWeek` needed nothing — it is an enum, and already worked. What `AddNodaTime` does for it is naming, which is a schema concern.

## The fix

`NodaTimeSurrogates.Date` and `NodaTimeSurrogates.TimeOfDay`: ordinary contracts carrying the `google.type` Date/TimeOfDay shapes, paired to the NodaTime types by assembly-level `[ProtoSurrogate]`, with conversion operators rather than a named converter. The attribute has no effect on the reflection-based model, so `AddNodaTime` and `NodaTimeSerializers` are untouched and the runtime path is exactly as it was.

They are deliberately *not* named `.google.type.*`: schema generation from a compile-time model is not implemented, so a name would describe nothing.

Tempting alternative, rejected: `LocalTime` is internally a single `Int64` and `LocalDate` a single packed int, so a one-field surrogate would be smaller and faster — and would silently break both interop and compatibility with data written by the runtime model. The surrogates mirror the message shape instead.

## Tests

Wire compatibility is the entire risk, so it is measured rather than argued. `NodaTimeSurrogateTests` serializes the same values through both paths and compares bytes:

- ordinary values, the all-zero case, and the boundaries (`0001-01-01`, `9999-12-31`, `23:59:59.123456789`)
- the reader quirk that an absent `Date` field means **1**, not 0 — `NodaTimeSerializers` starts from a default `LocalDate`'s components, and the surrogate has to land in the same place
- non-ISO calendars and pre-1AD years refused with the same exception *and the same message*

12 tests, all passing.

`AotNodaTimeSmoke` now covers all five types end to end — no `AddNodaTime`, no surrogate declarations in the consumer, 46 bytes, clean round-trip. It also no longer treats a serialize failure as a pass: that escape hatch documented a block which has since been cleared, and as written it would have reported a regression as success.

## After this

protobuf-net/protobuf-net#1291's NodaTime readme currently has to explain which types self-wire and which do not; once this lands, that collapses to "with a compile-time model, no registration needed". I will simplify it there.