### PR TITLE
NodaTime surrogates are structs, like the well-known types they sit beside

### DIFF
--- a/src/protobuf-net.NodaTime/NodaTimeSurrogates.cs
+++ b/src/protobuf-net.NodaTime/NodaTimeSurrogates.cs
@@ -21,7 +21,9 @@ namespace ProtoBuf.Meta
     /// The field numbers and the omit-when-zero behaviour match <see cref="NodaTimeSerializers"/>
     /// exactly - the two must produce identical bytes, and <c>NodaTimeSurrogateTests</c> asserts it.
     /// They are deliberately not named as <c>.google.type.*</c>: schema generation from a
-    /// compile-time model is not implemented, so a name here would describe nothing.
+    /// compile-time model is not implemented, so a name here would describe nothing. They are
+    /// structs for the same reason <see cref="WellKnownTypes.Timestamp"/> is - a surrogate is
+    /// created for every value converted, and the types being surrogated are themselves structs.
     /// </para>
     /// </remarks>
     public static class NodaTimeSurrogates
@@ -30,7 +32,7 @@ namespace ProtoBuf.Meta
         /// The wire shape of <see cref="LocalDate"/>, matching <c>google.type.Date</c>.
         /// </summary>
         [ProtoContract]
-        public sealed class Date
+        public struct Date
         {
             /// <summary>The year.</summary>
             [ProtoMember(1)] public int Year { get; set; }
@@ -62,7 +64,6 @@ namespace ProtoBuf.Meta
             {
                 // an absent field is a zero here, where the reader in NodaTimeSerializers starts
                 // from the components of a default LocalDate - which are 1, 1, 1
-                if (value is null) return default;
                 return new LocalDate( // ISO calendar is implicit
                     value.Year == 0 ? 1 : value.Year,
                     value.Month == 0 ? 1 : value.Month,
@@ -74,7 +75,7 @@ namespace ProtoBuf.Meta
         /// The wire shape of <see cref="LocalTime"/>, matching <c>google.type.TimeOfDay</c>.
         /// </summary>
         [ProtoContract]
-        public sealed class TimeOfDay
+        public struct TimeOfDay
         {
             /// <summary>The hour, 0-23.</summary>
             [ProtoMember(1)] public int Hours { get; set; }
@@ -99,7 +100,7 @@ namespace ProtoBuf.Meta
 
             /// <summary>Convert to <see cref="LocalTime"/>.</summary>
             public static implicit operator LocalTime(TimeOfDay value)
-                => value is null ? default : new LocalTime(value.Hours, value.Minutes, value.Seconds).PlusNanoseconds(value.Nanos);
+                => new LocalTime(value.Hours, value.Minutes, value.Seconds).PlusNanoseconds(value.Nanos);
         }
     }
 }

--- a/src/protobuf-net.Test/NodaTimeSurrogateTests.cs
+++ b/src/protobuf-net.Test/NodaTimeSurrogateTests.cs
@@ -26,6 +26,18 @@ namespace ProtoBuf.Test
         }
 
         [ProtoContract]
+        public class HazNullableLocalDate
+        {
+            [ProtoMember(1)] public LocalDate? Value { get; set; }
+        }
+
+        [ProtoContract]
+        public class HazNullableLocalTime
+        {
+            [ProtoMember(1)] public LocalTime? Value { get; set; }
+        }
+
+        [ProtoContract]
         public class HazDateSurrogate
         {
             [ProtoMember(1)] public NodaTimeSurrogates.Date Value { get; set; }
@@ -115,6 +127,32 @@ namespace ProtoBuf.Test
             using var ms = new MemoryStream();
             var clone = NodaModel().Deserialize<HazLocalDate>(ms);
             Assert.Equal(default(LocalDate), clone.Value);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NullableDateRoundTrips(bool hasValue)
+        {
+            LocalDate? value = hasValue ? new LocalDate(2020, 1, 2) : null;
+            var model = NodaModel();
+            using var ms = new MemoryStream();
+            model.Serialize(ms, new HazNullableLocalDate { Value = value });
+            ms.Position = 0;
+            Assert.Equal(value, model.Deserialize<HazNullableLocalDate>(ms).Value);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NullableTimeRoundTrips(bool hasValue)
+        {
+            LocalTime? value = hasValue ? new LocalTime(3, 4, 5) : null;
+            var model = NodaModel();
+            using var ms = new MemoryStream();
+            model.Serialize(ms, new HazNullableLocalTime { Value = value });
+            ms.Position = 0;
+            Assert.Equal(value, model.Deserialize<HazNullableLocalTime>(ms).Value);
         }
 
         [Fact]


### PR DESCRIPTION
They were `sealed class`, which allocates once per value converted — on types that are themselves structs.

The precedent is right next door: `Instant` and `Duration` pair with `WellKnownTypes.Timestamp` and `WellKnownTypes.Duration`, both `readonly struct`. Those also answer the "does the generator cope with struct surrogates?" question empirically, since `AotNodaTimeSmoke` has been round-tripping through them all along.

Mutable rather than `readonly`, because deserialization sets the members. The null checks in the conversion operators go away with the change, which also removes a small asymmetry — a class surrogate could arrive null, a struct cannot.

## Nothing else moves

- **Wire format**: the smoke test emits the same 46 bytes, and the parity tests still compare byte-for-byte against `NodaTimeSerializers`.
- **Public API**: no drift at all — the analyzer flags nothing, since the tracked lines are the properties, operators and implicit constructor, which read the same either way.
- **Compatibility**: this API is `Unshipped`, so class → struct costs nobody anything. Worth doing now rather than after a release, when it would be a binary break.

## Tests

26 NodaTime tests passing. New in this PR: `LocalDate?` and `LocalTime?` round-trip both with and without a value — the case where a struct surrogate could plausibly have behaved differently from a class, and which the original PR did not cover.