### PR TITLE
Shipping hygiene: security policy, Dependabot, SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Two ecosystems, for two different reasons.
+#
+# nuget: keeps the referenced packages current, and - more to the point - surfaces a security
+# advisory against something we depend on as a PR rather than as something someone has to notice.
+# Central package management means the versions all live in src/Directory.Packages.props, which
+# Dependabot understands.
+#
+# Roslyn is deliberately excluded. Microsoft.CodeAnalysis.CSharp.Workspaces is held at 4.3.1 on
+# purpose: it is the baseline the shipped analyzer compiles against, and it is what lets
+# protobuf-net.BuildTools.Legacy serve very old SDKs. Moving it is a decision to be argued rather
+# than a routine update - see AGENTS.md, "Don't rev the central Roslyn version speculatively".
+# (BuildToolsUnitTests already overrides it to 4.11.0 for its own reasons; that is a
+# VersionOverride in the csproj, which Dependabot does not touch.)
+#
+# github-actions: the workflows pin actions by commit SHA (see the note in release.yml), and a SHA
+# does not float. Dependabot is what moves those pins, rewriting the SHA and the trailing version
+# comment together. Without this, pinning would simply mean never updating.
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: Microsoft.CodeAnalysis.CSharp.Workspaces
+    groups:
+      # one PR per family rather than one per package; these move together anyway
+      microsoft:
+        patterns: [ "Microsoft.*", "System.*" ]
+      testing:
+        patterns: [ "xunit*", "*.Testing", "Microsoft.NET.Test.Sdk" ]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
           8.0.x
@@ -31,7 +31,7 @@ jobs:
     # Restore dominates the cold-runner build time, and the package set changes rarely; the
     # same treatment measurably helped SE.Redis (StackExchange/StackExchange.Redis@74bfe78).
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('src/Directory.Packages.props', 'global.json', '**/*.csproj') }}
@@ -76,17 +76,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # versioning
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
           8.0.x
           10.0.x
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('src/Directory.Packages.props', 'global.json', '**/*.csproj') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@
 # whose computed version matches); the guard step below fails the run on any mismatch rather than
 # publishing a package that disagrees with its release.
 
+# Actions are pinned by commit SHA rather than by tag. A tag is mutable: whoever controls the
+# action repository can repoint v4 at different code, and this workflow holds id-token: write and
+# publishes to nuget.org, so that is where it genuinely matters. The trailing comment records
+# which release the SHA is, and Dependabot moves both together.
 name: Release
 
 on:
@@ -29,11 +33,11 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
           8.0.x
@@ -64,13 +68,13 @@ jobs:
       run: dotnet pack Build.csproj --no-build -c Release /p:Packing=true /p:CI=true /p:PackageOutputPath=${{ github.workspace }}\.nupkgs
     # The packages survive as a run artifact even if the push fails
     - name: Upload packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: packages
         path: .nupkgs/*.nupkg
     - name: NuGet login (OIDC to temp API key)
       if: github.event_name == 'release'
-      uses: NuGet/login@v1
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
       id: login
       with:
         user: ${{ secrets.NUGET_USER }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting instead:
+<https://github.com/protobuf-net/protobuf-net/security/advisories/new>. That opens a private thread
+visible only to the maintainers, and is the fastest route to a fix and an advisory.
+
+If that is unavailable to you for any reason, email <marc.gravell@gmail.com> with `protobuf-net
+security` in the subject.
+
+Please include enough to reproduce: the package and version, the target framework, and a minimal
+contract plus the payload bytes that show the problem. A failing test against `RuntimeTypeModel` is
+ideal.
+
+## What is in scope
+
+protobuf-net deserializes bytes that a process often did not produce itself, so **deserializing
+untrusted input is the surface that matters**. Worth reporting:
+
+- a payload that causes unbounded allocation, non-terminating work, or a crash on deserialize -
+  including via nesting depth, declared lengths, or repeated fields;
+- a payload that causes a type to be constructed, or a member to be reached, that the contract does
+  not describe;
+- anything where the compile-time serializers (the AOT generator in `protobuf-net.BuildTools`)
+  disagree with `RuntimeTypeModel` in a way that changes what a payload can do, rather than merely
+  what it decodes to.
+
+Note that a contract which is simply *permissive* - one that describes a type you would rather not
+let a caller construct - is a property of that contract, not of the library. protobuf-net will
+faithfully do what the contract says.
+
+The gRPC layer lives in a separate repository -
+<https://github.com/protobuf-net/protobuf-net.Grpc> - and service binding, endpoint metadata and
+transport concerns belong there; if you are unsure which, report it here and it will be moved.
+
+## Supported versions
+
+Fixes land on `main` and ship in the next release of the affected package. There is no long-term
+servicing branch, so "supported" means the current release line.


### PR DESCRIPTION
Three gaps that have nothing to do with the code and everything to do with being a package other people depend on. The sibling repo gets the same treatment in protobuf-net/protobuf-net.Grpc#382.

### `SECURITY.md`

There is currently no documented private channel for reporting a vulnerability — the only route on offer is a public issue, which is the wrong one. This points at GitHub's private vulnerability reporting with an email fallback, and is specific about the surface that matters: **deserializing untrusted input**, and in particular payloads causing unbounded work, or reaching a type the contract does not describe.

It also states the thing that saves an argument later — a contract that is merely *permissive* is a property of that contract, not of the library — and sends gRPC binding and metadata questions to the other repository.

> **The file is only half of it.** Private vulnerability reporting is a repository *setting* and is currently off, so the advisory link in this file 404s until it is switched on (Settings → Code security → Private vulnerability reporting).

### `.github/dependabot.yml`

Two ecosystems:

- **nuget** — so an advisory against something we depend on arrives as a PR rather than as something someone has to notice. Grouped by family so it is a few PRs rather than thirty.

  **`Microsoft.CodeAnalysis.CSharp.Workspaces` is explicitly ignored.** 4.3.1 is a deliberate floor, not a stale version — it is what lets `protobuf-net.BuildTools.Legacy` serve very old SDKs, and bumping it is precisely the speculative rev `AGENTS.md` warns against. (`BuildToolsUnitTests` already overrides it to 4.11.0 via `VersionOverride` in the csproj, which Dependabot does not touch.)
- **github-actions** — because of the third change below.

### SHA-pinned actions

A tag is mutable: whoever controls the action repository can repoint `v4` at different code. `release.yml` holds `id-token: write` and publishes to nuget.org.

| action | was | now |
| --- | --- | --- |
| actions/checkout | `v4` | `11d5960…` (v4.4.0) |
| actions/setup-dotnet | `v4` | `67a3573…` (v4.3.1) |
| actions/cache | `v4` | `0057852…` (v4.3.0) |
| actions/upload-artifact | `v4` | `ea165f8…` (v4.6.2) |
| NuGet/login | `v1` | `8d19675…` (v1.2.0) |

**This is a pin, not an upgrade** — the SHAs are what `v4`/`v1` point at today (checkout is on v7 upstream; deliberately not adopted here). Each carries a trailing comment naming the release, and Dependabot rewrites the SHA and the comment together.

Workflows and one markdown file; nothing here reaches the build.