### PR TITLE
PBN2001: don't report constants, static members or nested types on a service interface

### DIFF
--- a/src/BuildToolsUnitTests/ServiceContractAnalyzerTests.cs
+++ b/src/BuildToolsUnitTests/ServiceContractAnalyzerTests.cs
@@ -74,6 +74,80 @@ namespace SomeNamespace.Whatever
             Assert.Equal("This member is not a method; only methods are supported for gRPC services.", err.GetMessage(CultureInfo.InvariantCulture));
         }
 
+        /// <summary>
+        /// A constant on a service interface is not an operation candidate, so it should be passed
+        /// over rather than reported (#1314).
+        /// </summary>
+        [Fact]
+        public async Task ConstantIsIgnored()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+using ProtoBuf.Grpc.Configuration;
+using System.Threading.Tasks;
+
+[Service]
+public interface IDoServiceGrpc
+{
+    public const string CONST_TEXT = ""hello-world"";
+
+    ValueTask DoAsync();
+}");
+            Assert.Empty(diagnostics);
+        }
+
+        /// <summary>
+        /// The same reasoning covers everything else an interface can declare that the runtime
+        /// binder never enumerates: static members of any shape, and nested types.
+        /// </summary>
+        [Fact]
+        public async Task StaticMembersAndNestedTypesAreIgnored()
+        {
+            var diagnostics = await AnalyzeAsync(@"
+using ProtoBuf.Grpc.Configuration;
+using System.Threading.Tasks;
+
+[Service]
+public interface IMyService
+{
+    const int Answer = 42;
+    static int Counter;
+    static int Twice(int value) => value * 2;
+
+    public enum Mode { A, B }
+
+    ValueTask DoAsync();
+}");
+            Assert.Empty(diagnostics);
+        }
+
+        /// <summary>
+        /// ...but an INSTANCE property is exactly what this rule is for, and must still report -
+        /// otherwise the #1314 fix would have quietly disabled it.
+        /// </summary>
+        [Fact]
+        public async Task InstancePropertyStillReportsAlongsideAConstant()
+        {
+            // the property type is a contract so its ACCESSOR is valid and only the property itself
+            // reports - the same shape DetectInvalidMethodKind uses, for the same reason
+            var diagnostics = await AnalyzeAsync(@"
+using ProtoBuf.Grpc.Configuration;
+using ProtoBuf;
+using System.Threading.Tasks;
+
+[Service]
+public interface IMyService
+{
+    const int Answer = 42;
+    Foo Instance { get; }
+
+    ValueTask DoAsync();
+}
+[ProtoContract]
+public class Foo {}");
+            var err = Assert.Single(diagnostics);
+            Assert.Equal(ServiceContractAnalyzer.InvalidMemberKind, err.Descriptor);
+        }
+
         [Fact]
         public async Task ValidMethodKindIsClean()
         {

--- a/src/protobuf-net.BuildTools/Analyzers/ServiceContractAnalyzer.cs
+++ b/src/protobuf-net.BuildTools/Analyzers/ServiceContractAnalyzer.cs
@@ -145,6 +145,15 @@ namespace ProtoBuf.BuildTools.Analyzers
 
             foreach (var member in type.GetMembers())
             {
+                // Constants, static members and nested types are not candidate operations at all,
+                // so reporting them is noise rather than a warning about anything (#1314). Since
+                // C# 8 an interface can declare all three, and the runtime binder enumerates
+                // instance methods - it never looks at these, so neither should this.
+                //
+                // Note an INSTANCE property or event still reports, which is the case this rule
+                // exists for: someone declaring one and expecting it to be an operation.
+                if (member.IsStatic || member is INamedTypeSymbol) continue;
+
                 if (member is not IMethodSymbol method)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(InvalidMemberKind, Utils.PickLocation(ref context, member)));


### PR DESCRIPTION
Fixes #1314.

Since C# 8 an interface can declare constants, static fields, static methods and nested types. None of them is a candidate operation — the runtime binder enumerates instance methods and never looks at them — so `PBN2001` reporting *"this member is not a method"* is noise about something nobody asked to be an operation. The reported case:

```cs
[Service]
public interface IDoServiceGrpc
{
    public const string CONST_TEXT = "hello-world"; // no longer reports

    [Operation]
    ValueTask DoAsync(CallContext context);
}
```

A constant is an implicitly-static field, so skipping static members covers it; nested types need their own test because they aren't `IsStatic`.

An **instance** property or event still reports, which is the case the rule exists for — someone declaring one and expecting it to work as an operation. There's a test pinning that alongside a constant, so this can't quietly disable the rule it's narrowing.

Three tests added, all confirmed to fail without the change: the issue's exact repro; a mixed interface with a constant, a static field, a static method and a nested enum; and the instance-property case that must still report.
