### PR TITLE
The extension APIs read packed data (#1328)

### DIFF
--- a/src/protobuf-net.Core/ExtensibleUtil.cs
+++ b/src/protobuf-net.Core/ExtensibleUtil.cs
@@ -127,12 +127,36 @@ namespace ProtoBuf
                     TValue current = default;
                     var any = false;
                     int field;
+                    List<TValue> packed = null;
                     while ((field = state.ReadFieldHeader()) > 0)
                     {
                         if (field != tag)
                         {
                             state.SkipField();
                             continue;
+                        }
+                        // a packed run. Every conformant implementation writes repeated packable
+                        // scalars and enums this way and accepts either form on the way back in;
+                        // protoc has always done so for repeated custom options, so refusing it
+                        // here rejected data the rest of the world considers ordinary. The
+                        // repeated serializers handle this via the list they are reading into -
+                        // which the extension APIs, seeing one field at a time, do not have.
+                        if (TypeHelper<TValue>.CanBePacked && state.WireType == WireType.String)
+                        {
+                            packed ??= new List<TValue>();
+                            packed.Clear();
+                            if (state.TryReadPackedScalar<TValue>(serializer, packed))
+                            {
+                                if (packed.Count != 0)
+                                {
+                                    any = true;
+                                    // last-one-wins for the singleton merge, matching what successive
+                                    // unpacked occurrences of a scalar already do below
+                                    if (singleton) current = packed[packed.Count - 1];
+                                    else results.AddRange(packed);
+                                }
+                                continue;
+                            }
                         }
                         // singleton merges successive occurrences into one value, exactly as the
                         // reflective path does by passing the previous value back in
@@ -175,6 +199,24 @@ namespace ProtoBuf
                 var state = ProtoReader.State.Create(stream, model, ctx, ProtoReader.TO_EOF).Solidify();
                 try
                 {
+                    // packable scalars are drained in one pass: a packed run carries several values behind
+                    // a single field header, and the one-value-per-call loop below cannot straddle one
+                    if (TypeHelper.CanBePacked(type))
+                    {
+                        var all = new List<object>();
+                        model.ReadAuxValues(ref state, format, tag, type, all);
+                        if (singleton)
+                        {
+                            // last-one-wins, matching the merge the aux loop performs for repeats
+                            if (all.Count != 0) yield return all[all.Count - 1];
+                        }
+                        else
+                        {
+                            foreach (var item in all) yield return item;
+                        }
+                        yield break;
+                    }
+
                     while (model.TryDeserializeAuxiliaryType(ref state, format, tag, type, ref value, true, true, false, false, null, isRoot: false) && value is not null)
                     {
                         if (!singleton)

--- a/src/protobuf-net.Core/Meta/TypeModel.cs
+++ b/src/protobuf-net.Core/Meta/TypeModel.cs
@@ -1188,6 +1188,59 @@ namespace ProtoBuf.Meta
             return Activator.CreateInstance(concreteListType, nonPublic: true);
         }
 
+        /// <summary>
+        /// Reads every occurrence of <paramref name="tag"/> from the current position into
+        /// <paramref name="results"/>, accepting both the packed and the expanded encoding.
+        /// </summary>
+        /// <remarks>
+        /// The one-value-per-call shape of <see cref="TryDeserializeAuxiliaryType"/> cannot straddle a
+        /// packed run: it would return with the reader parked mid-run, and the next call would read the
+        /// remaining element bytes as a field header. Packable scalars are therefore drained in one pass.
+        /// </remarks>
+        internal void ReadAuxValues(ref ProtoReader.State state, DataFormat format, int tag,
+            [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, List<object> results)
+        {
+            if (type is null) ThrowHelper.ThrowArgumentNullException(nameof(type));
+            WireType wiretype = GetWireType(this, format, type);
+            if (!DynamicStub.CanSerialize(type, this, out var features))
+                ThrowHelper.ThrowInvalidOperationException("Unable to deserialize aux type: " + type.NormalizeName());
+
+            var scope = NormalizeAuxScope(features, false, type, false);
+            int fieldNumber;
+            while ((fieldNumber = state.ReadFieldHeader()) > 0)
+            {
+                if (fieldNumber != tag)
+                {
+                    state.SkipField();
+                    continue;
+                }
+
+                // a length-delimited payload for a type whose own wire type is not length-delimited is
+                // packed data - the same inference the repeated serializers make
+                if (state.WireType == WireType.String && wiretype != WireType.String)
+                {
+                    var end = state.StartPackedScalar(wiretype, type);
+                    while (state.ContinuePackedScalar(end, wiretype))
+                    {
+                        results.Add(Deserialize(scope, ref state, type, null));
+                    }
+                }
+                else
+                {
+                    state.Hint(wiretype); // handle signed data etc
+                    results.Add(Deserialize(scope, ref state, type, null));
+                }
+            }
+        }
+
+        internal void ReadAuxValues(ref ProtoReader.SolidState state, DataFormat format, int tag,
+            [DynamicallyAccessedMembers(DynamicAccess.ContractType)] Type type, List<object> results)
+        {
+            var liquid = state.Liquify();
+            ReadAuxValues(ref liquid, format, tag, type, results);
+            state = liquid.Solidify();
+        }
+
         internal bool TryDeserializeAuxiliaryType(ref ProtoReader.SolidState state, DataFormat format, int tag, Type type, ref object value, bool skipOtherFields, bool asListItem, bool autoCreate, bool insideList, object parentListOrType, bool isRoot)
         {
             var liquid = state.Liquify();

--- a/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
+++ b/src/protobuf-net.Core/ProtoReader.State.ReadMethods.cs
@@ -396,6 +396,76 @@ namespace ProtoBuf
                 }
             }
 
+            /// <summary>
+            /// Begins a packed run of scalar values, returning the absolute position at which it ends.
+            /// </summary>
+            /// <remarks>
+            /// The serializer-driven equivalent is <c>ReadPackedScalar</c>; this pair exists for the
+            /// reflective aux path, which holds a <see cref="Type"/> rather than an <c>ISerializer{T}</c>
+            /// and so has to drive the element loop itself.
+            /// </remarks>
+            internal long StartPackedScalar(WireType elementWireType, Type type)
+            {
+                var bytes = (int)ReadUInt32Varint(Read32VarintMode.Unsigned);
+                if (bytes < 0) ThrowInvalidLength(bytes);
+                AssertPlausibleLength(bytes);
+                switch (elementWireType)
+                {
+                    case WireType.Fixed32:
+                        if ((bytes % 4) != 0) ThrowHelper.ThrowInvalidOperationException("packed length should be multiple of 4");
+                        break;
+                    case WireType.Fixed64:
+                        if ((bytes % 8) != 0) ThrowHelper.ThrowInvalidOperationException("packed length should be multiple of 8");
+                        break;
+                    case WireType.Varint:
+                    case WireType.SignedVarint:
+                        break;
+                    default:
+                        ThrowHelper.ThrowInvalidPackedOperationException(elementWireType, type);
+                        break;
+                }
+                return GetPosition() + bytes;
+            }
+
+            /// <summary>
+            /// Advances to the next element of a packed run started by <see cref="StartPackedScalar"/>,
+            /// re-arming the wire type; returns <c>false</c> once the run is exhausted.
+            /// </summary>
+            internal bool ContinuePackedScalar(long end, WireType elementWireType)
+            {
+                var position = GetPosition();
+                if (position >= end)
+                {
+                    if (position != end) ThrowHelper.ThrowInvalidOperationException("over-read packed data");
+                    return false;
+                }
+                _reader.WireType = elementWireType;
+                return true;
+            }
+
+            /// <summary>
+            /// Reads a packed run of scalar values into <paramref name="values"/>, reporting whether
+            /// the current field was in fact a packed run of a packable scalar.
+            /// </summary>
+            /// <remarks>
+            /// The repeated serializers reach packed data through <see cref="FillBuffer"/>, which owns
+            /// the whole field sequence; the extension APIs cannot, since they see one field at a time
+            /// and have no list to read into. This is the narrow entry point for that case.
+            /// </remarks>
+            internal bool TryReadPackedScalar<T>(ISerializer<T> serializer, ICollection<T> values)
+            {
+                // the wire type is never "string" for a type that *can* be packed, so a length-delimited
+                // payload here is packed data - the same inference PrepareToReadRepeated makes
+                if (!TypeHelper<T>.CanBePacked || WireType != WireType.String) return false;
+
+                SerializerFeatures features = default;
+                features.InheritFrom(serializer.Features);
+                if (features.GetCategory() != SerializerFeatures.CategoryScalar) return false;
+
+                ReadPackedScalar<ISerializer<T>, ICollection<T>, T>(ref values, features.GetWireType(), serializer);
+                return true;
+            }
+
             internal ReadBuffer<T> FillBuffer<TSerializer, T>(SerializerFeatures features, in TSerializer serializer, T initialValue)
                 where TSerializer : ISerializer<T>
             {

--- a/src/protobuf-net.Reflection.Test/PackedCustomOptions.cs
+++ b/src/protobuf-net.Reflection.Test/PackedCustomOptions.cs
@@ -1,0 +1,92 @@
+using Google.Protobuf.Reflection;
+using System;
+using ProtoBuf;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ProtoBuf
+{
+    /// <summary>
+    /// Custom option values that the extension field declares as packed are written packed, matching
+    /// protoc; #1328 is that reading them back through the extension APIs then threw
+    /// "Invalid wire-type (String)", so the parser was producing descriptors it could not itself
+    /// consume. The encoding is pinned here alongside the read, since the two have to agree.
+    /// </summary>
+    public class PackedCustomOptions
+    {
+        private const string Schema = @"
+syntax = ""proto3"";
+package test;
+import ""google/protobuf/descriptor.proto"";
+enum MyEnum { UNKNOWN = 0; ALPHA = 1; BETA = 2; }
+extend google.protobuf.MessageOptions {
+    repeated MyEnum packed_enum = 50000;
+    repeated MyEnum expanded_enum = 50002 [packed = false];
+}
+message Foo {
+    option (packed_enum) = ALPHA;
+    option (packed_enum) = BETA;
+    option (expanded_enum) = ALPHA;
+    option (expanded_enum) = BETA;
+    string bar = 1;
+}
+message Unary {
+    option (packed_enum) = ALPHA;
+    string bar = 1;
+}
+";
+
+        private static FileDescriptorSet Parse()
+        {
+            var set = new FileDescriptorSet();
+            set.Add("test.proto", true, new StringReader(Schema));
+            set.Process();
+            Assert.Empty(set.GetErrors());
+            return set;
+        }
+
+        private static MessageOptions OptionsFor(string message)
+            => Parse().Files.Single(x => x.Name == "test.proto").MessageTypes.Single(x => x.Name == message).Options;
+
+        [Fact]
+        public void PackedOptionValuesAreReadable()
+        {
+            var options = OptionsFor("Foo");
+            Assert.Equal(new[] { 1, 2 }, Extensible.GetValues<int>(options, 50000));
+        }
+
+        [Fact]
+        public void UnaryPackedOptionValueIsReadable()
+        {
+            var options = OptionsFor("Unary");
+            Assert.Equal(new[] { 1 }, Extensible.GetValues<int>(options, 50000));
+        }
+
+        /// <summary>
+        /// google.api.field_behavior declares [packed = false] precisely because the packed
+        /// switch-over broke older parsers, so declared packedness has to be honoured on write.
+        /// </summary>
+        [Fact]
+        public void UnpackedOptionValuesAreReadable()
+        {
+            var options = OptionsFor("Foo");
+            Assert.Equal(new[] { 1, 2 }, Extensible.GetValues<int>(options, 50002));
+        }
+
+        [Fact]
+        public void EncodingMatchesTheDeclaredPackedness()
+        {
+            var data = DescriptorProto.GetExtensionData(OptionsFor("Foo"));
+
+            // 50000 packed:   tag 82-B5-18 (wire type 2), then one length-delimited run per value;
+            // 50002 expanded: tag 90-B5-18 (wire type 0), one varint per value.
+            //
+            // Note the packed field emits a run per value where protoc emits a single merged run
+            // (82-B5-18-02-01-02). Both decode to the same values, and every conformant reader
+            // accepts either, but it is a known byte-level divergence rather than a deliberate
+            // choice - pinned here so that closing it is a visible change.
+            Assert.Equal("82-B5-18-01-01-82-B5-18-01-02-90-B5-18-01-90-B5-18-02", BitConverter.ToString(data));
+        }
+    }
+}

--- a/src/protobuf-net.Test/Issues/Issue1328.cs
+++ b/src/protobuf-net.Test/Issues/Issue1328.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ProtoBuf.Test.Issues
+{
+    /// <summary>
+    /// The extension APIs see one field at a time, so they used to read a repeated scalar
+    /// one value per field header - which rejects the packed encoding outright. protoc has
+    /// always written repeated packable custom options packed, so this refused data that
+    /// every other implementation treats as ordinary; #1328 hit it via our own schema parser,
+    /// which started emitting packed enum options to match protoc.
+    /// </summary>
+    public class Issue1328
+    {
+        [ProtoContract]
+        public class Extended : Extensible { }
+
+        // exactly what protoc 35.1 emits for
+        //   `option (my_opt) = ALPHA; option (my_opt) = BETA;`  (repeated enum @50000)
+        //   `option (my_ints) = 3;    option (my_ints) = 4;`    (repeated int32 @50001)
+        private static readonly byte[] Packed = { 0x82, 0xB5, 0x18, 0x02, 0x01, 0x02, 0x8A, 0xB5, 0x18, 0x02, 0x03, 0x04 };
+
+        // the same values in the expanded encoding, which must keep working unchanged
+        private static readonly byte[] Expanded = { 0x80, 0xB5, 0x18, 0x01, 0x80, 0xB5, 0x18, 0x02, 0x88, 0xB5, 0x18, 0x03, 0x88, 0xB5, 0x18, 0x04 };
+
+        // a single value, packed; protoc packs even a unary run
+        private static readonly byte[] PackedUnary = { 0x82, 0xB5, 0x18, 0x01, 0x01 };
+
+        // both encodings for the same field, interleaved - legal, and the merged result is 1,2,3,4
+        private static readonly byte[] Mixed = { 0x80, 0xB5, 0x18, 0x01, 0x82, 0xB5, 0x18, 0x02, 0x02, 0x03, 0x80, 0xB5, 0x18, 0x04 };
+
+        private static Extended For(byte[] payload)
+        {
+            var obj = new Extended();
+            Extensible.AppendValue(obj, 1, 0); // force an extension object into being
+            var extn = ((IExtensible)obj).GetExtensionObject(true);
+            (extn as IExtensionResettable)?.Reset();
+            var stream = extn.BeginAppend();
+            try
+            {
+                stream.Write(payload, 0, payload.Length);
+                extn.EndAppend(stream, true);
+            }
+            catch
+            {
+                extn.EndAppend(stream, false);
+                throw;
+            }
+            return obj;
+        }
+
+        [Theory]
+        [InlineData(nameof(Packed), 50000, "1,2")]
+        [InlineData(nameof(Packed), 50001, "3,4")]
+        [InlineData(nameof(Expanded), 50000, "1,2")]
+        [InlineData(nameof(Expanded), 50001, "3,4")]
+        [InlineData(nameof(PackedUnary), 50000, "1")]
+        [InlineData(nameof(Mixed), 50000, "1,2,3,4")]
+        [InlineData(nameof(Packed), 50002, "")] // absent tag yields nothing rather than throwing
+        public void GetValuesReadsEitherEncoding(string payload, int tag, string expected)
+        {
+            var obj = For(Payload(payload));
+            Assert.Equal(expected, string.Join(",", Extensible.GetValues<int>(obj, tag)));
+        }
+
+        [Theory]
+        [InlineData(nameof(Packed), 50000, 2)]
+        [InlineData(nameof(Packed), 50001, 4)]
+        [InlineData(nameof(Expanded), 50000, 2)]
+        [InlineData(nameof(PackedUnary), 50000, 1)]
+        [InlineData(nameof(Mixed), 50000, 4)]
+        public void GetValueMergesEitherEncodingLastWins(string payload, int tag, int expected)
+        {
+            var obj = For(Payload(payload));
+            Assert.Equal(expected, Extensible.GetValue<int>(obj, tag));
+        }
+
+        /// <summary>
+        /// Generated extension accessors pass a <see cref="DataFormat"/> whenever the field
+        /// declares one, which routes through the reflective reader rather than the typed one;
+        /// both need the same tolerance.
+        /// </summary>
+        [Theory]
+        [InlineData(nameof(Packed), "1,2")]
+        [InlineData(nameof(Expanded), "1,2")]
+        public void ReflectiveReaderReadsEitherEncoding(string payload, string expected)
+        {
+            var obj = For(Payload(payload));
+            Assert.Equal(expected, string.Join(",", Extensible.GetValues<int>(obj, 50000, DataFormat.TwosComplement)));
+        }
+
+        [Theory]
+        [InlineData(nameof(Packed), "1,2")]
+        [InlineData(nameof(Expanded), "1,2")]
+        public void NonGenericReaderReadsEitherEncoding(string payload, string expected)
+        {
+            var obj = For(Payload(payload));
+            var values = Extensible.GetValues(null, typeof(int), obj, 50000).Cast<object>();
+            Assert.Equal(expected, string.Join(",", values));
+        }
+
+        /// <summary>
+        /// A length-delimited payload only means "packed" for a type whose own wire type is not
+        /// length-delimited; strings, byte arrays and messages must be untouched by the inference.
+        /// </summary>
+        [Fact]
+        public void LengthDelimitedTypesAreNotMistakenForPackedRuns()
+        {
+            var obj = new Extended();
+            Extensible.AppendValue(obj, 50010, "hello");
+            Assert.Equal("hello", Extensible.GetValue<string>(obj, 50010));
+
+            var bytes = new Extended();
+            Extensible.AppendValue(bytes, 50011, new byte[] { 1, 2, 3 });
+            Assert.Equal(new byte[] { 1, 2, 3 }, Extensible.GetValue<byte[]>(bytes, 50011));
+        }
+
+        /// <summary>
+        /// Round-tripping our own <c>AppendValue</c> output is unaffected: it writes the expanded
+        /// form, one value per call, and that is not changing here.
+        /// </summary>
+        [Fact]
+        public void AppendValueRoundTripIsUnchanged()
+        {
+            var obj = new Extended();
+            Extensible.AppendValue(obj, 50000, 1);
+            Extensible.AppendValue(obj, 50000, 2);
+            Assert.Equal("1,2", string.Join(",", Extensible.GetValues<int>(obj, 50000)));
+        }
+
+        private static byte[] Payload(string name) => name switch
+        {
+            nameof(Packed) => Packed,
+            nameof(Expanded) => Expanded,
+            nameof(PackedUnary) => PackedUnary,
+            nameof(Mixed) => Mixed,
+            _ => throw new ArgumentOutOfRangeException(nameof(name)),
+        };
+    }
+}


### PR DESCRIPTION
`Extensible.GetValue`/`GetValues` see one field at a time, so they read a repeated scalar one value per field header — which rejects the packed encoding outright, throwing `Invalid wire-type (String)`. protoc has always written repeated packable custom options packed, so this refused data every other implementation treats as ordinary. It surfaced now because the schema parser started emitting packed enum options to match protoc, leaving it unable to read back descriptors it had just produced.

Fixes #1328.

### The hole

Declared repeated fields have always accepted both encodings, as the spec requires:

```
declared-unpacked reading EXPANDED -> [3,4]     declared-packed reading EXPANDED -> [3,4]
declared-unpacked reading PACKED   -> [3,4]     declared-packed reading PACKED   -> [3,4]
```

The gap is only in the extension APIs, which have no list to read into — and therefore in protogen-generated extension accessors, which emit `GetValues<T>` for repeated fields.

### The change

Both read paths learn the inference the repeated serializers already make — a length-delimited payload for a type whose own wire type is not length-delimited is packed data:

- the typed path via a new `State.TryReadPackedScalar`, which is `ReadPackedScalar` reached without a list;
- the reflective path — which generated accessors take whenever the field declares a `DataFormat` — via `TypeModel.ReadAuxValues`. That one drains the tag in a single pass, since `TryDeserializeAuxiliaryType` returns one value per call and would otherwise leave the reader parked mid-run.

Reading is widened, not changed. The expanded encoding, both encodings mixed under one tag, and string/bytes/message extensions all behave exactly as before; `AppendValue` still writes expanded. Declared packedness is deliberately not consulted — the spec requires accepting either form regardless, which is why `PrepareToReadRepeated` does not consult it either.

Purely additive: +165 lines, no deletions, no public API change.

### Oracles

protoc 35.1 and Google.Protobuf agree, including on unary runs:

```
                          enum@50000          int32@50001
protoc 35.1     multi  :  82 B5 18 02 01 02 | 8A B5 18 02 03 04
Google.Protobuf multi  :  82 B5 18 02 01 02 | 8A B5 18 02 03 04
protoc 35.1     unary  :  82 B5 18 01 01    | 8A B5 18 01 03
Google.Protobuf unary  :  82 B5 18 01 01    | 8A B5 18 01 03
```

### Tests

`Issue1328` (Core read paths) and `PackedCustomOptions` (end-to-end through the parser). 10 of the 18 new Core cases fail without the fix. Full suites green on net8.0 and net472: 2395 and 2409 tests.

### Left alone, deliberately

Two write-side divergences measured while here, neither addressed:

- the parser emits one packed run per value where protoc emits a single merged run, and packs only enums where protoc packs every packable scalar. Pinned in `PackedCustomOptions` so closing it is a visible change.
- `RepeatedSerializer` writes a unary `IsPacked` list expanded, where protoc and Google.Protobuf pack it. Changing that would move bytes on the wire for existing contracts.

Both are valid protobuf that every conformant reader accepts. Holding them back until tolerant readers have shipped means we accept the new form before we start emitting more of it.
