### PR TITLE
Expose the descriptor TypeModel

### DIFF
--- a/src/protobuf-net.Reflection.Test/DescriptorSerializerTests.cs
+++ b/src/protobuf-net.Reflection.Test/DescriptorSerializerTests.cs
@@ -1,0 +1,89 @@
+using Google.Protobuf.Reflection;
+using ProtoBuf.Meta;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ProtoBuf.Reflection.Test
+{
+    /// <summary>
+    /// Covers <see cref="FileDescriptorSet.Serializer"/>: the model that makes the existing
+    /// <see cref="FileDescriptorSet.Serialize(TypeModel, Stream, bool)"/> reachable from a project
+    /// that references only this package, which brings protobuf-net.Core and so has no concrete
+    /// <see cref="TypeModel"/> of its own.
+    /// </summary>
+    public class DescriptorSerializerTests
+    {
+        /// <summary>descriptor.proto, resolved from this package's own embedded copy.</summary>
+        private static FileDescriptorSet ParseDescriptorProto()
+        {
+            var set = new FileDescriptorSet();
+            Assert.True(set.Add("google/protobuf/descriptor.proto", includeInOutput: true));
+            set.Process();
+            Assert.DoesNotContain(set.GetErrors(), error => error.IsError);
+            return set;
+        }
+
+        private static byte[] Serialize(FileDescriptorSet set, TypeModel model, bool includeImports)
+        {
+            using var ms = new MemoryStream();
+            set.Serialize(model, ms, includeImports);
+            return ms.ToArray();
+        }
+
+        [Fact]
+        public void TheExposedModelRoundTripsADescriptorSet()
+        {
+            var bytes = Serialize(ParseDescriptorProto(), FileDescriptorSet.Serializer, includeImports: true);
+            Assert.NotEmpty(bytes);
+
+            var back = FileDescriptorSet.Serializer.Deserialize<FileDescriptorSet>(new MemoryStream(bytes));
+
+            var file = Assert.Single(back.Files);
+            Assert.Equal("google/protobuf/descriptor.proto", file.Name);
+            Assert.Equal("google.protobuf", file.Package);
+            Assert.Contains(file.MessageTypes, message => message.Name == "FileDescriptorSet");
+
+            // and the bytes are stable across the round trip
+            Assert.Equal(bytes, Serialize(back, FileDescriptorSet.Serializer, includeImports: true));
+        }
+
+        [Fact]
+        public void TheExposedModelAgreesWithTheRuntimeModel()
+        {
+            var set = ParseDescriptorProto();
+
+            Assert.Equal(
+                Serialize(set, RuntimeTypeModel.Default, includeImports: true),
+                Serialize(set, FileDescriptorSet.Serializer, includeImports: true));
+        }
+
+        [Fact]
+        public void IncludeImportsComposesWithTheExposedModel()
+        {
+            // the filtering is the one thing a bare TypeModel cannot do: it works by narrowing
+            // Files to those flagged for output, which is a property of the set, not the model
+            var set = new FileDescriptorSet();
+            Assert.True(set.Add("my.proto", includeInOutput: true, new StringReader(@"
+syntax = ""proto3"";
+import ""google/protobuf/descriptor.proto"";
+message Holder { google.protobuf.FileDescriptorSet fds = 1; }")));
+            set.Process();
+            Assert.DoesNotContain(set.GetErrors(), error => error.IsError);
+            Assert.Equal(2, set.Files.Count);
+
+            var excluded = FileDescriptorSet.Serializer.Deserialize<FileDescriptorSet>(
+                new MemoryStream(Serialize(set, FileDescriptorSet.Serializer, includeImports: false)));
+            Assert.Equal("my.proto", Assert.Single(excluded.Files).Name);
+
+            var included = FileDescriptorSet.Serializer.Deserialize<FileDescriptorSet>(
+                new MemoryStream(Serialize(set, FileDescriptorSet.Serializer, includeImports: true)));
+            Assert.Equal(
+                new[] { "google/protobuf/descriptor.proto", "my.proto" },
+                included.Files.Select(file => file.Name).OrderBy(name => name).ToArray());
+
+            // the set itself is left as it was found
+            Assert.Equal(2, set.Files.Count);
+        }
+    }
+}

--- a/src/protobuf-net.Reflection/Parsers.cs
+++ b/src/protobuf-net.Reflection/Parsers.cs
@@ -415,6 +415,20 @@ namespace Google.Protobuf.Reflection
         }
 
         /// <summary>
+        /// The <see cref="TypeModel"/> this library uses for descriptors; pass it to
+        /// <see cref="Serialize(TypeModel, Stream, bool)"/>, or use it directly to read a
+        /// serialized descriptor set back via <see cref="TypeModel.Deserialize{T}(Stream, T, object)"/>
+        /// and friends.
+        /// </summary>
+        /// <remarks>
+        /// This package references protobuf-net.Core, which has no concrete <see cref="TypeModel"/>,
+        /// so without this there is no way to serialize a descriptor set without also taking a
+        /// dependency on protobuf-net itself. A <c>TypeModel</c> is a cache and is intended to be
+        /// shared, so this is a single instance rather than something to construct per use.
+        /// </remarks>
+        public static TypeModel Serializer => CustomProtogenSerializer.Instance;
+
+        /// <summary>
         /// Serializes this instance using the provided serializer (which does not need to be protobuf)
         /// </summary>
         public T Serialize<T>(Func<FileDescriptorSet,object,T> customSerializer, bool includeImports, object state = null)

--- a/src/protobuf-net.Reflection/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/protobuf-net.Reflection/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Google.Protobuf.Reflection.FileDescriptorSet.Serializer.get -> ProtoBuf.Meta.TypeModel


### PR DESCRIPTION
`FileDescriptorSet.Serialize(TypeModel, Stream, bool)` has been public for years, but nothing in this package could supply the `TypeModel`: we reference protobuf-net.Core, which has no concrete model. So the only way to serialize a descriptor set was to take a dependency on protobuf-net itself, purely to reach `RuntimeTypeModel.Default` — for a type this package already has a generated serializer for.

One static fixes that:

```csharp
public static TypeModel Serializer => CustomProtogenSerializer.Instance;
```

It returns `TypeModel`, not the generated class, so `CustomProtogenSerializer` and its member surface stay internal and out of ApiCompat's remit. Everything `TypeModel` offers comes with it — `Deserialize` over `Stream`, `ReadOnlyMemory` and `ReadOnlySequence`, `Serialize` to `IBufferWriter`, `DeepClone` — so this covers the buffer and pipeline cases without a member each.

```csharp
set.Serialize(FileDescriptorSet.Serializer, stream, includeImports: false);
FileDescriptorSet.Serializer.Serialize(stream, set);
var back = FileDescriptorSet.Serializer.Deserialize<FileDescriptorSet>(stream);
```

Deliberately not adding a `Serialize(Stream, bool)` overload. The parameter order on the existing one is awkward — the model comes first, so it cannot be given a default — but it works, and a second spelling of the same call is not worth the surface. If it grates in practice, an overload stays additive.

Three tests in `protobuf-net.Reflection.Test`, over descriptor.proto's own descriptor set:

- it round-trips, and re-serializing what came back gives the same bytes
- `includeImports` still filters through it — that is the one thing a bare `TypeModel` cannot do, since it narrows `Files` rather than changing how they are written, and the set is left as it was found
- output is byte-identical to `RuntimeTypeModel.Default`

One line in `PublicAPI.Unshipped.txt`. Full `protobuf-net.Reflection.Test` suite passes, 619 tests.
