### PR TITLE
Point the package project URL at the site

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,10 @@
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ProtoBuf.snk</AssemblyOriginatorKeyFile>
         <Copyright>See https://github.com/protobuf-net/protobuf-net</Copyright>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/protobuf-net/protobuf-net</PackageProjectUrl>
+        <!-- the project's home, not its source: RepositoryUrl below already carries the repo,
+             and nuget.org renders the two as separate links - pointing both at GitHub spends
+             the "Project website" slot on a duplicate -->
+        <PackageProjectUrl>https://protobuf-net.dev</PackageProjectUrl>
         <RepositoryUrl>https://github.com/protobuf-net/protobuf-net</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageIcon>protobuf-net.png</PackageIcon>


### PR DESCRIPTION
`PackageProjectUrl` and `RepositoryUrl` were both `https://github.com/protobuf-net/protobuf-net`, so nuget.org rendered **"Project website" and "Source repository" as the same link** — the project website slot was spent on a duplicate of something already there, and nothing in the package metadata pointed at the site.

protobuf-net.dev goes in the first; the repo stays in the second.

Confirmed in a real packed nuspec rather than assumed:

```xml
<projectUrl>https://protobuf-net.dev/</projectUrl>
<repository type="git" url="https://github.com/protobuf-net/protobuf-net" commit="e379f9b7..." />
```

Two things worth knowing:

- It is a shared property in `src/Directory.Build.props`, so this moves `protobuf-net.Core`, `.Reflection` and the rest of the packed set along with it. That is the intent — they are all the same project — but it is wider than the one package.
- Published packages are immutable, so this shows up from the next release onward and does nothing for 3.4.19 and earlier.

The readme already links protobuf-net.dev and docs.protobuf-net.dev, so the site was reachable from the page body; this just stops the metadata link being a duplicate.
