### PR TITLE
Bump the microsoft group, minus the one major that cannot move

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
   <ItemGroup>
     <!-- actual package output dependencies -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.11" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.7" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.11" />
     <!-- note: some key types get removed in 10.* -->
     <PackageVersion Include="System.ServiceModel.Primitives" Version="[8.1.2]" />
   </ItemGroup>
@@ -21,16 +21,16 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.80.0" />
     <PackageVersion Include="Iesi.Collections" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.4" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" PrivateAssets="All" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NHibernate" Version="5.6.0" />
@@ -46,10 +46,10 @@
     <PackageVersion Include="protobuf-net.Grpc" Version="1.3.14" />
     <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
-    <PackageVersion Include="System.CodeDom" Version="10.0.7" />
+    <PackageVersion Include="System.CodeDom" Version="10.0.11" />
     <PackageVersion Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
@@ -57,10 +57,10 @@
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
-    <PackageVersion Include="System.Threading.Channels" Version="10.0.7" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.11" />
     <PackageVersion Include="System.Threading.Thread" Version="4.3.0" />
     <PackageVersion Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.7" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.11" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Supersedes the blocked halves of #1315 and #1334. Both of those fail, and both fail for **one** reason.

## Why they fail

`System.ServiceModel.Primitives` `[8.1.2]` → `[10.0.652802]`. The v10 line drops the service-description surface `protobuf-net.ServiceModel` compiles against — `IOperationBehavior`, `OperationDescription`, `ClientOperation`, `BindingParameterCollection` — so net8.0 fails with ~40 `CS0246`/`CS0538` in `ProtoBehaviorAttribute.cs` and friends. That is a migration, not a version bump, and the pin is deliberate (square brackets).

**There is no non-major move available either**: `8.1.2` is already the newest 8.x on nuget.org (the next version published is `10.0.0-rc.2.final`). So this one is simply held.

## What this takes instead

Everything else in the group, all patch or minor:

| package | from | to |
| --- | --- | --- |
| `Microsoft.Extensions.Caching.Abstractions` | 10.0.7 | 10.0.11 |
| `Microsoft.Extensions.DependencyInjection` | 10.0.7 | 10.0.11 |
| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.7 | 10.0.11 |
| `Microsoft.Bcl.AsyncInterfaces` | 10.0.7 | 10.0.11 |
| `System.IO.Pipelines` | 10.0.7 | 10.0.11 |
| `System.CodeDom` | 10.0.7 | 10.0.11 |
| `System.Configuration.ConfigurationManager` | 10.0.7 | 10.0.11 |
| `System.Threading.Channels` | 10.0.7 | 10.0.11 |
| `System.Reflection.Metadata` | 10.0.7 | 10.0.11 |
| `Microsoft.NET.Test.Sdk` | 18.5.1 | 18.9.0 |
| `Microsoft.Data.SqlClient` | 7.0.1 | 7.0.2 |
| `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` | 1.1.3 | 1.1.4 |
| `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing` | 1.1.3 | 1.1.4 |
| `Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing` | 1.1.3 | 1.1.4 |

Three more of the group are **already on main** and needed nothing: `System.Collections.Immutable` 10.0.11, `Microsoft.SourceLink.GitHub` 10.0.400, and `Microsoft.CodeAnalysis.Analyzers` 5.9.0 — so the group's *other* major is in already and is not at issue. The dependabot PRs are stale on those three.

## One deliberate omission beyond the major

This touches **`Directory.Packages.props` only**. Both dependabot PRs additionally add new *direct* `PackageReference`s — `System.Collections.Immutable`, `System.IO.Pipelines`, `System.Reflection.Metadata`, `Microsoft.Bcl.AsyncInterfaces`, several with `VersionOverride` — into `protobuf-net.BuildTools` and `protobuf-net`. BuildTools is an analyzer package with deliberate packaging rules and a Roslyn baseline it does not rev, so quietly acquiring direct references to Roslyn's own dependencies is not something to take on autopilot. Nothing needs them to build, so they are left out.

## Verified, as CI runs it

- `dotnet restore` + Debug `dotnet build Build.csproj` — clean
- `dotnet test Build.csproj --no-build` — all legs green (`BuildToolsUnitTests` 539, `AotConformanceTests` 680, `Examples` net8.0 681 / net472 707, `NativeGoogleTests` 3)
- `AotDifferential` — 3090 compared, **0 differ**
- `AotGrpcMetadataDiff` — 2 operations, **0 failing**
- Release build of `Build.csproj` — clean

Once this is in, #1315 and #1334 should either close or rebase down to just the `System.ServiceModel.Primitives` major, which can then be judged on its own.