### PR TITLE
protobuf-net.ServiceModel: multi-target net10.0 and take WCF Client v10

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,7 +10,11 @@
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageVersion Include="System.IO.Pipelines" Version="10.0.7" />
     <!-- note: some key types get removed in 10.* -->
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="[8.1.2]" />
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="[10.0.652802]" />
+    <!-- CVE-2026-50648 (DoS in XML decryption) affects 8.0.0-8.0.3 and 10.0.0-10.0.9; both WCF
+         Client majors depend on an affected version, so both legs are pulled up. net8.0 takes 8.0.4
+         via VersionOverride in the consuming project -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="10.1.400" />

--- a/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
+++ b/src/protobuf-net.ServiceModel/protobuf-net.ServiceModel.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>ProtoBuf</RootNamespace>
     <Title>protobuf-net.ServiceModel</Title>
     <Description>ServiceModel (WCF) extensions for protobuf-net</Description>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -21,8 +21,21 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
 
+  <!-- WCF Client majors track .NET LTS majors rather than semver: v8 is the net8.0 package, v10 the
+       net10.0 one. Each ships ONLY its own TFM's asset alongside a netstandard2.0 stub with no
+       usable surface, so pointing net8.0 at v10 does not fail to restore - it silently binds the
+       stub and then fails to compile against System.ServiceModel.Description/.Dispatcher. Hence a
+       version per TFM: the central one tracks the newest, and net8.0 is held back explicitly. -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.ServiceModel.Primitives" />
+    <!-- named directly only to pull it past CVE-2026-50648: both WCF Client majors depend on an
+         affected build (v8 -> 8.0.2, v10 -> 10.0.0). Nothing here calls into it. net462 gets its
+         crypto from the framework and is not in the graph at all -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Update="System.ServiceModel.Primitives" VersionOverride="[8.1.2]" />
+    <PackageReference Update="System.Security.Cryptography.Xml" VersionOverride="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `System.ServiceModel.Primitives` `[8.1.2]` → `[10.0.652802]` bump that blocks the dependabot microsoft-group PRs. It turns out **not** to need the feature dropped.

## It was never an API break

WCF Client majors track **.NET LTS majors**, not semver — v6 is the .NET 6 package, v8 the .NET 8 one, v10 the .NET 10 one. Each ships only its own TFM's asset:

| | 8.1.2 | 10.0.652802 |
|---|---|---|
| modern asset | `lib/net8.0/` (2.39 MB) | **`lib/net10.0/`** (2.39 MB) |
| fallback | `lib/netstandard2.0/` (116 KB stub) | `lib/netstandard2.0/` (116 KB stub) |

`protobuf-net.ServiceModel` was `net462;net8.0`, so v10 restores happily and then hands net8.0 the **116 KB netstandard2.0 stub** — hence ~40 `CS0246`/`CS0538` for `IOperationBehavior`, `OperationDescription`, `ClientOperation`, `BindingParameterCollection`. Nothing was removed; we were being given the wrong folder. Both packages' netstandard2.0 assets are the same size, and the nuspec still says `authors: Microsoft`, `projectUrl: github.com/dotnet/wcf`. Only *server*-side WCF left for the community, as CoreWCF.

## So: multi-target, not migrate

`net462;net8.0;net10.0`, central version tracks v10, net8.0 held at `[8.1.2]` via `VersionOverride`. Checked from `project.assets.json` rather than trusting a green build:

| TFM | resolves |
|---|---|
| net462 | *no package* (framework reference) |
| net8.0 | `System.ServiceModel.Primitives/8.1.2` |
| net10.0 | `System.ServiceModel.Primitives/10.0.652802` |

…and the produced nuspec carries the right pinned dependency in each group, so consumers get v8 on net8.0 and v10 on net10.0.

## The part worth a second look

This also pins `System.Security.Cryptography.Xml`. **CVE-2026-50648** (DoS in XML decryption) affects `8.0.0–8.0.3` and `10.0.0–10.0.9` — and WCF Client v8 depends on `8.0.2` while v10 depends on `10.0.0`, so **both** legs were affected.

The net8.0 exposure is **not introduced here** — v4 ships `8.0.2` today. But NuGet only starts *reporting* it once the net10.0 leg exists, so on this branch it first appeared as a mystery `NU1903` that looked like fallout from the bump. Verified with a clean-`obj` A/B in one worktree: baseline silent, this branch reports it. Both legs are now named directly and pulled to **8.0.4 / 10.0.11**; nothing in this project calls into that package, the reference exists only to move the floor.

If you'd rather not add a dependency to the nuspec, the alternative is `CentralPackageTransitivePinningEnabled` scoped to this project — same effect without the declared dependency. I went with the explicit reference as it is self-documenting and doesn't change restore semantics for anything else.

## Verified

- Debug build + `dotnet test Build.csproj` — all green (BuildToolsUnitTests 662, AotConformanceTests 1920, Examples 681/707, NativeGoogleTests 3)
- `AotDifferential` — 3137 compared, **0 differ**
- `AotGrpcMetadataDiff` — 2 operations, **0 failing**
- Release `build -p:Packing=true` + `pack` — package carries `lib/net462`, `lib/net8.0`, `lib/net10.0`
- **`NU1903`: 0**

Once this is in, the `System.ServiceModel.Primitives` half of #1315/#1334 is unblocked for v4.