### PR TITLE
Dependency sweep and build plumbing (everything except xunit)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.10.91",
+      "version": "3.10.94",
       "commands": [
         "nbgv"
       ]

--- a/Build.csproj
+++ b/Build.csproj
@@ -1,4 +1,14 @@
 <Project Sdk="Microsoft.Build.Traversal/2.0.19">
+  <PropertyGroup>
+    <!-- The Traversal SDK sets this itself, but ONLY for a file named dirs.proj - that is the whole
+         of $(TraversalProjectNames)'s default, and this file is Build.csproj. Nothing in Traversal
+         2.0.19 reads it back, so it is inert here today; what reads it is the .NET 11 SDK, where
+         `dotnet test` expands an IsTraversal project into its ProjectReferences (dotnet/sdk#55297,
+         fixing #51316). Without it, `dotnet test Build.csproj` under Microsoft.Testing.Platform
+         reports "No test projects were found" - which is indistinguishable from not having the fix
+         at all, so the trap is concluding it never shipped. -->
+    <IsTraversal>true</IsTraversal>
+  </PropertyGroup>
   <ItemGroup>
     <!-- After moving files around, this can be src\**\*.csroj -->
     <ProjectReference Include="src\protobuf-net\*.csproj" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,11 +13,11 @@
     <PackageVersion Include="System.ServiceModel.Primitives" Version="[8.1.2]" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="FSharp.Core" Version="10.1.400" />
+    <PackageVersion Include="FSharp.Core" Version="11.0.100" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.36.1" />
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="10.1.1.8388" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="11.0.0.9375" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
     <PackageVersion Include="Iesi.Collections" Version="4.1.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
   <ItemGroup>
     <!-- actual package output dependencies -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.12" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.11" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.12" />
     <!-- note: some key types get removed in 10.* -->
     <PackageVersion Include="System.ServiceModel.Primitives" Version="[8.1.2]" />
   </ItemGroup>
@@ -16,27 +16,27 @@
     <PackageVersion Include="FSharp.Core" Version="10.1.400" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.36.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.36.1" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="10.1.1.8388" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.80.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
     <PackageVersion Include="Iesi.Collections" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.12" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.4" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" PrivateAssets="All" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.94" PrivateAssets="All" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NHibernate" Version="5.6.0" />
-    <PackageVersion Include="NodaTime" Version="3.3.2" />
+    <PackageVersion Include="NHibernate" Version="5.7.0" />
+    <PackageVersion Include="NodaTime" Version="3.3.3" />
     <PackageVersion Include="NodaTime.Serialization.Protobuf" Version="2.0.2" />
-    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.3.1" />
     <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.46" />
     <!-- 1.3.0 is the floor for the gRPC generator: it ships [ProtoGrpc]/[ProtoService], and the
          ClientFactory shape the generated proxies derive from (1.0.21 predates that entirely - its
@@ -44,23 +44,23 @@
          it also stops rooting RuntimeTypeModel, which is what takes that publish from 100 IL
          warnings to 5 -->
     <PackageVersion Include="protobuf-net.Grpc" Version="1.3.14" />
-    <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
+    <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.3.14" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
-    <PackageVersion Include="System.CodeDom" Version="10.0.11" />
+    <PackageVersion Include="System.CodeDom" Version="10.0.12" />
     <PackageVersion Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.3" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="10.0.7" />
+    <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="10.0.12" />
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageVersion Include="System.Threading" Version="4.3.0" />
-    <PackageVersion Include="System.Threading.Channels" Version="10.0.11" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.12" />
     <PackageVersion Include="System.Threading.Thread" Version="4.3.0" />
     <PackageVersion Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.11" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.12" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Dependencies and build plumbing, **except xunit** — that is a migration rather than a bump and
follows in its own PR.

Supersedes the open dependabot PRs #1315, #1342, #1343, #1344, #1345.

## The sweep

All 55 declared `PackageVersion`s checked against nuget.org rather than merging PRs one at a time;
26 were behind. **21 taken** — the 10.0.11 → 10.0.12 servicing band, Google.Protobuf 3.36.1,
Data.SqlClient 7.0.3, SourceLink 10.0.401, nbgv 3.10.94 (props and `dotnet-tools.json` together),
NodaTime 3.3.3, NET.Test.Sdk 18.10.0, NHibernate 5.7.0, Pipelines.Sockets.Unofficial 2.3.1.

**Three of those are alignments rather than bumps, and are the argument for sweeping:**

- `Grpc.AspNetCore.Server` was still on 2.80.0 while `Grpc.Net.Client` moved to 2.83.0 in #1325.
  Client and server halves of one repo drifting apart is exactly what per-package PRs produce;
- `protobuf-net.Grpc.Reflection` was on 1.2.2 against protobuf-net.Grpc's 1.3.14 — untouched since
  #1018;
- `System.Runtime.Serialization.Formatters` was left on 10.0.7 when the rest of its group went to
  10.0.11.

## Two majors, neither quite mechanical

- **FSharp.Core 10.1.400 → 11.0.100.** `protobuf-net.FSharp.Test` passes and package validation is
  happy — but validation compares API surface, not dependency floors, so the interesting half is
  what it does *not* say. Read from the built nupkg: `protobuf-net.FSharp` now declares
  `FSharp.Core >= 11.0.100` on all three TFMs, so F# consumers are pulled up with us. Normal for a
  major and consistent with how this package has been tracked (#1319 moved it last), but it is a
  shipping decision, so it is its own commit and one line to revert.
- **ICSharpCode.Decompiler 10.1.1.8388 → 11.0.0.9375.** Dev-tool only (`AotRefGen`), which is net472
  and cannot *run* on Linux where this was prepared — so a compile is the whole of the evidence
  available, mitigated by the API surface being two lines. **Expect a possibly-large
  `*.reference.cs` diff on the next Windows `AotRefGen` run**: that is *decompiler* drift, not
  ref-emit drift, which is precisely the confusion `AGENTS.md` warns about.

## Four left behind, deliberately

- **`Microsoft.CodeAnalysis.CSharp.Workspaces` 4.3.1 → 5.9.0** — `AGENTS.md` forbids revving the
  central Roslyn version speculatively; the old baseline is what lets `protobuf-net.BuildTools.Legacy`
  serve very old SDKs;
- **`System.ServiceModel.Primitives` `[8.1.2]` → 10.x** — WCF Client majors track .NET LTS majors
  rather than semver, so this is a TFM question, not an API one. v4 answers it by multi-targeting
  (#1341), which is more than a bump;
- **`protobuf-net.BuildTools` 3.2.46 → 3.3.8** — that pin belongs to `BuildToolsSmokeTests`, whose
  readme documents hand-editing it against a locally packed nupkg;
- **xunit** — next PR.

## `Build.csproj` declares `IsTraversal`

One line, inert today, and it removes a problem the xunit PR would otherwise walk into.

The Traversal SDK sets that property itself but **only for a file named `dirs.proj`** — that is the
whole of `$(TraversalProjectNames)`'s default — and ours is `Build.csproj`. Nothing in Traversal
2.0.19 reads it back, so on the .NET 10 SDK it changes nothing. What reads it is the **.NET 11 SDK**:
dotnet/sdk#55297 (fixing dotnet/sdk#51316) teaches `dotnet test` to expand an `IsTraversal` project
into its `ProjectReference`s, because Microsoft.Testing.Platform test apps are launched as child
processes with no MSBuild target driving them — so a traversal project, which works only by
forwarding targets, is otherwise invisible to it.

Verified against 11.0.100-rc.1 in a throwaway worktree, and the first result is why this is its own
commit: SDK 11 reported *"No test projects were found"*, **exactly as SDK 10 does**, which reads as
the fix never having shipped. It had — the property was simply empty. *Not arranged for* and *not
fixed* produce the same message, and this is the line that tells them apart.

## Gates

linux-x64:

| gate | |
| --- | --- |
| traversal build | 0 errors |
| `AotConformanceTests` | 680 |
| `BuildToolsUnitTests` | 539 |
| `protobuf-net.Test` / `Reflection.Test` / `Examples` | 1076 / 621 / 681 |
| `NativeGoogleTests` | 3 |
| `AotDifferential` | **3090 compared, 100% match**, exit 0 |
| `AotGrpcMetadataDiff` | 0 failing |
| `AotSmoke`, `AotNodaTimeSmoke` | PASSED |
| `AotGrpcSmoke` | all checks passed — the gate that exercises the Grpc alignment |
| `DownLevelSmoke` | 3 `PBN3xxx`, 0 errors — the documented shape |
| `BuildTools.Legacy` | builds |
| Release packing build + `pack` | 0 errors, package validation clean |

**Not run here:** the three net472 legs (they want mono, so `dotnet test` on the traversal exits
non-zero on this machine for that reason alone — every net8.0 leg passed), a native publish, and
`AotRefGen`. CI covers the first two.
