### PR TITLE
xunit.v3 4.0: migrate to Microsoft.Testing.Platform, and move to the .NET 11 SDK

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,7 @@ jobs:
         dotnet-version: |
           8.0.x
           10.0.x
+          11.0.x
     # Restore dominates the cold-runner build time, and the package set changes rarely; the
     # same treatment measurably helped SE.Redis (StackExchange/StackExchange.Redis@74bfe78).
     - name: Cache NuGet packages
@@ -94,6 +95,7 @@ jobs:
         dotnet-version: |
           8.0.x
           10.0.x
+          11.0.x
     - name: Cache NuGet packages
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/global.json
+++ b/global.json
@@ -2,6 +2,9 @@
   "sdk": {
     "version": "10.0.201",
     "rollForward": "latestMajor",
-    "allowPrerelease": false
+    "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/AotConformanceTests/AotConformanceTests.csproj
+++ b/src/AotConformanceTests/AotConformanceTests.csproj
@@ -4,6 +4,8 @@
     <!-- the compile-time model attributes are [Experimental] while the shape settles -->
     <NoWarn>$(NoWarn);PBN9001</NoWarn>
     <TargetFramework>net8.0</TargetFramework>
+    <!-- an MTP test app is its own host, so it must be an exe; Directory.Build.props defaults to Library -->
+    <OutputType>Exe</OutputType>
     <RootNamespace>ProtoBuf.AotConformance</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
@@ -26,12 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/BuildToolsSmokeTests/BuildToolsSmokeTests.csproj
+++ b/src/BuildToolsSmokeTests/BuildToolsSmokeTests.csproj
@@ -21,8 +21,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-
         <PackageReference Include="protobuf-net.BuildTools">
             <!-- !!update and uncomment this version!! -->
             <!--<VersionOverride>3.2.4-g4c40875979</VersionOverride>-->
@@ -31,14 +29,6 @@
         </PackageReference>
 
         <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="xunit.runner.visualstudio">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <ProjectReference Include="..\protobuf-net\protobuf-net.csproj" />
     </ItemGroup>
 

--- a/src/BuildToolsUnitTests/BuildToolsUnitTests.csproj
+++ b/src/BuildToolsUnitTests/BuildToolsUnitTests.csproj
@@ -4,6 +4,8 @@
     <!-- the compile-time model attributes are [Experimental] while the shape settles -->
     <NoWarn>$(NoWarn);PBN9001</NoWarn>
     <TargetFramework>net8.0</TargetFramework>
+    <!-- an MTP test app is its own host, so it must be an exe; Directory.Build.props defaults to Library -->
+    <OutputType>Exe</OutputType>
     <RootNamespace>BuildToolsUnitTests</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -18,10 +20,6 @@
     
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <!-- The shipped analyzer still compiles against the low Roslyn baseline (4.3.1); the tests need a
          newer one for two reasons, and neither touches what ships:
            * to parse C# 12, which is the serializer generator's declared floor;
@@ -29,7 +27,6 @@
              reflectively off the host. Below it, InterceptableLocations.IsSupported is false and the
              interceptor path could not be tested in-process at all. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageVersion Include="FSharp.Core" Version="11.0.100" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.36.1" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="11.0.0.9375" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
@@ -23,7 +22,6 @@
     <PackageVersion Include="Iesi.Collections" Version="4.1.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.12" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
@@ -62,7 +60,6 @@
     <PackageVersion Include="System.Threading.ThreadPool" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="10.0.12" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -25,15 +25,10 @@
     <PackageReference Include="Google.Protobuf">
       <Aliases>gpb</Aliases>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net472' and $(RuntimeIdentifier.StartsWith('win'))">

--- a/src/Examples/Issues/Issue713.cs
+++ b/src/Examples/Issues/Issue713.cs
@@ -63,7 +63,7 @@ namespace ProtoBuf.Issues
             Test(model);
 
             var dll = model.Compile(nameof(CanSerializeNullableSomeEnumArray_NoNulls), nameof(CanSerializeNullableSomeEnumArray_NoNulls) + ".dll");
-            PEVerify.AssertValid(nameof(CanSerializeNullableInt32Array_NoNulls) + ".dll");
+            PEVerify.AssertValid(nameof(CanSerializeNullableSomeEnumArray_NoNulls) + ".dll");
             Test(dll);
 
             //Test(model.Compile());

--- a/src/LongDataTests/LongDataTests.csproj
+++ b/src/LongDataTests/LongDataTests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <!-- an MTP test app is its own host, so it must be an exe; Directory.Build.props defaults to Library -->
+    <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release;VS</Configurations>
   </PropertyGroup>
@@ -19,12 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NativeGoogleTests/NativeGoogleTests.csproj
+++ b/src/NativeGoogleTests/NativeGoogleTests.csproj
@@ -25,13 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NodaTime" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/protobuf-net.FSharp.Test/protobuf-net.FSharp.Test.fsproj
+++ b/src/protobuf-net.FSharp.Test/protobuf-net.FSharp.Test.fsproj
@@ -15,16 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit.v3" />
-        <PackageReference Include="xunit.runner.visualstudio">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protobuf-net.Reflection.Test/protobuf-net.Reflection.Test.csproj
+++ b/src/protobuf-net.Reflection.Test/protobuf-net.Reflection.Test.csproj
@@ -35,11 +35,6 @@
     <ProjectReference Include="..\protobuf-net.Reflection\protobuf-net.Reflection.csproj" />
     <ProjectReference Include="..\protobuf-net\protobuf-net.csproj" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />

--- a/src/protobuf-net.Test/protobuf-net.Test.csproj
+++ b/src/protobuf-net.Test/protobuf-net.Test.csproj
@@ -21,11 +21,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />


### PR DESCRIPTION
Follows #1347. **Not one test source file changed** — xunit.v3 4.0 is a host-integration change, not
an API break.

## What forces it

xunit.v3 4.0 brings Microsoft.Testing.Platform 2.x, which **drops the VSTest bridge on the .NET 10
SDK and later**. Without this PR every `dotnet test` fails identically, before running anything:

> Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and
> later.

Under MTP a test project *is* the test host — an executable that runs its own tests — rather than an
assembly loaded by `vstest.console` through a reflection-discovered adapter.

## Three things that were not obvious

**The opt-in lives in `global.json`, not `dotnet.config`.** The error's own link points at the
latter; the condition in `Microsoft.Testing.Platform.MSBuild.targets` is what settles it.

**The SDK floor stays at `10.0.201`.** `rollForward: latestMajor` + `allowPrerelease: true` selects
the newest installed SDK — and a prerelease sorts *below* the release it precedes, so pinning
`"11.0.100"` fails to resolve against an installed `11.0.100-rc.1`.

**CI takes `11.0.x` with no `dotnet-quality`, and that is the important detail.** A bare channel
resolves to whatever is newest on it: rc today, **GA automatically in November, with no later edit**.
`dotnet-quality: preview` looks like the right knob and is the trap — measured against a channel that
has already shipped:

```
$ ./dotnet-install.sh --channel 10.0 --quality preview --dry-run
  → 10.0.100-rc.2.25502.107      # months after 10.0 went GA
$ ./dotnet-install.sh --channel 10.0 --dry-run
  → 10.0.401                      # GA
```

It pins to the last preview forever. `setup-dotnet` maps `11.0.x` to exactly `--channel 11.0` and
adds no quality flag unless asked (`createChannelArgument` in `installer.ts`).

## Why .NET 11 rather than a workaround

`dotnet test Build.csproj` needs dotnet/sdk#55297 (fixing dotnet/sdk#51316), which teaches the new
`dotnet test` to expand a traversal project into its `ProjectReference`s. That is **.NET 11 only** —
no 10.x backport. #1347 landed the `IsTraversal` property that makes it fire, so **the CI test step
here is unchanged**.

The SDK-10 alternative was `dotnet build Build.csproj -t:Test -p:SkipNonexistentTargets=True`, which
also works; it is recorded in the notes as the fallback if moving to an rc SDK is unwelcome.

## Other changes

**Three projects needed `<OutputType>Exe</OutputType>` stated explicitly** — `AotConformanceTests`,
`BuildToolsUnitTests`, `LongDataTests`. An MTP test app is its own host, `Directory.Build.props`
defaults `OutputType` to `Library`, and `Microsoft.NET.Test.Sdk` had been supplying it.

**Three packages dropped as dead weight**, across nine projects and the central list, now that there
is no VSTest process: `xunit.runner.visualstudio` (the adapter), `Microsoft.NET.Test.Sdk` (the host)
and `coverlet.collector` (a VSTest *data collector*). Nothing in CI collects coverage today, so the
last is a removal rather than a replacement; MTP's equivalent is
`Microsoft.Testing.Extensions.CodeCoverage` if it is ever wanted.

## Two things to know before merging

- **Contributors will need an SDK 11 build installed.** `allowPrerelease: true` plus the raised
  runner requirement is the cost of the route chosen here. Anyone on 10.x only will get
  "No test projects were found" from `dotnet test`.
- **`protobuf-net.FSharp.Test` and `VBTest` are not in CI, and never have been** — `Build.csproj`
  globs `src\*\*.csproj`, so the `.fsproj` and `.vbproj` are invisible to it. Pre-existing and
  unrelated to this PR (the F# tests do pass: 6/6, run directly), but it surfaced while checking the
  run list here and is worth its own fix.

## Gates

On 11.0.100-rc.1, linux-x64:

| gate | |
| --- | --- |
| traversal build | 0 errors |
| `dotnet test Build.csproj --no-build --framework net8.0` | **3623 total, 3600 passed, 23 skipped, 0 failed** |
| `AotDifferential` | **3090 compared, 100% match**, exit 0 |
| `AotGrpcMetadataDiff` | 0 failing |
| `AotSmoke`, `AotNodaTimeSmoke`, `AotGrpcSmoke` | PASSED |
| `DownLevelSmoke` | 0 errors |
| `BuildTools.Legacy` | builds |
| Release packing build + `pack` | 0 errors |

`--framework net8.0` is a Linux necessity, not part of the answer: .NET 11 removed the mono launch
target, so a net472 leg is `NETSDK1243` off Windows. CI is windows-latest and unaffected — **which
means the net472 legs under MTP are genuinely first exercised by this PR's own CI run.**
