### PR TITLE
release.yml: install the .NET 11 SDK too, or the release test step cannot run

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,12 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
+    # 11.0.x is required by the test step: global.json selects the Microsoft.Testing.Platform
+    # runner, and `dotnet test` can only see a traversal project on the .NET 11 SDK
+    # (dotnet/sdk#55297). The bare channel is deliberate - it resolves to whatever is newest there,
+    # so this becomes GA with no edit. Do NOT add `dotnet-quality: preview`, which pins to the last
+    # preview forever: measured, `--channel 10.0 --quality preview` still resolves to 10.0.100-rc.2
+    # months after 10.0 shipped.
     - name: Setup .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
@@ -89,6 +95,12 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # versioning
+    # 11.0.x is required by the test step: global.json selects the Microsoft.Testing.Platform
+    # runner, and `dotnet test` can only see a traversal project on the .NET 11 SDK
+    # (dotnet/sdk#55297). The bare channel is deliberate - it resolves to whatever is newest there,
+    # so this becomes GA with no edit. Do NOT add `dotnet-quality: preview`, which pins to the last
+    # preview forever: measured, `--channel 10.0 --quality preview` still resolves to 10.0.100-rc.2
+    # months after 10.0 shipped.
     - name: Setup .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,19 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # Fetch the full history (for versioning)
+    # 11.0.x is required by the test step: global.json selects the Microsoft.Testing.Platform
+    # runner, and `dotnet test` can only see a traversal project on the .NET 11 SDK
+    # (dotnet/sdk#55297). The bare channel is deliberate - it resolves to whatever is newest there,
+    # so this becomes GA with no edit. Do NOT add `dotnet-quality: preview`, which pins to the last
+    # preview forever: measured, `--channel 10.0 --quality preview` still resolves to 10.0.100-rc.2
+    # months after 10.0 shipped.
     - name: Setup .NET
       uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
           8.0.x
           10.0.x
+          11.0.x
     - name: Verify tag matches computed version
       if: github.event_name == 'release'
       shell: pwsh


### PR DESCRIPTION
Follow-up to #1348, which I missed there: `release.yml` has its **own** `setup-dotnet` step and was
left on `8.0.x` / `10.0.x`.

It runs `dotnet test Build.csproj --no-build`, and on the .NET 10 SDK that now reports
**"No test projects were found"** and exits non-zero — `global.json` selects the Microsoft.Testing.
Platform runner, and `dotnet test` can only expand a traversal project on the .NET 11 SDK
(dotnet/sdk#55297, no 10.x backport).

So the release pipeline would have failed at its Test step, and **only when someone published a
release** — release.yml runs on `release: published` (or manual dispatch) and is not exercised by
ordinary CI, so nothing has caught it. Nothing has fired since #1348 merged.

## Also: the reasoning, as a comment in both workflows

The version list is not self-explanatory and the obvious "fix" is the wrong one. A **bare channel**
resolves to whatever is newest on it, so `11.0.x` is rc today and **GA in November with no edit
here**. `dotnet-quality: preview` looks like the right knob and pins to the last preview *forever* —
measured against a channel that has already shipped:

```
$ ./dotnet-install.sh --channel 10.0 --quality preview --dry-run
  → 10.0.100-rc.2.25502.107      # months after 10.0 went GA
```

**The comment goes above the step, not inside the `dotnet-version: |` block** — that is a literal
block scalar, so a `#` line there is *content* and would be handed to setup-dotnet as a version. I
wrote it the wrong way first. Both files now parse to exactly `'8.0.x\n10.0.x\n11.0.x\n'`, checked
by parsing the YAML rather than by eye.

## Verified

On 11.0.100-rc.1, the full command both workflows use — including the `--verbosity normal` that the
new `dotnet test` might plausibly have rejected — is accepted and green: **3623 total, 3600 passed,
23 skipped, 0 failed**.
